### PR TITLE
fix: 隐藏无推荐时的相邻导航旁空白占位

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -116,7 +116,7 @@
                    and not #lists.isEmpty(post.categories) 
                    and (#lists.size(postFinder.list({
                     size: n,
-                    categoryName: firstCategoryName,
+                    categoryName: post.categories[0].metadata.name,
                     sort: {'spec.publishTime,desc', 'metadata.creationTimestamp,asc'}
                    }).items) > 1)},
                  postCursor=${postFinder.cursor(post.metadata?.name)},


### PR DESCRIPTION
修复在同时显示推荐文章和相邻文章导航时，无推荐文章但显示空白占位