### PR TITLE
chore: update browserslist coverage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepare": "husky"
   },
   "browserslist": [
-    "defaults"
+    "cover 99.5%"
   ],
   "keywords": [
     "halo",


### PR DESCRIPTION
Changed the browserslist configuration from 'defaults' to 'cover 99.5%' to target a broader range of browsers and ensure compatibility for a larger user base.