### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.48.1.json
+++ b/.github/page_size_audit_results/v1.48.1.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.21.10",
+    "javaVersion": "21.0.9",
+    "themeVersion": "v1.48.1",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2025-11-23T14:54:59.080Z"
+  },
+  "timestamp": "2025-11-23T14:54:59.080Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 3044,
+          "resourceSize": 8635
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196082,
+          "resourceSize": 643816
+        },
+        "stylesheet": {
+          "transferSize": 23081,
+          "resourceSize": 76252
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 763,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 261127,
+          "resourceSize": 766146
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12419,
+          "resourceSize": 28959
+        },
+        "stylesheet": {
+          "transferSize": 20459,
+          "resourceSize": 73962
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 70417,
+          "resourceSize": 139953
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 3030,
+          "resourceSize": 8563
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196082,
+          "resourceSize": 643816
+        },
+        "stylesheet": {
+          "transferSize": 22654,
+          "resourceSize": 75990
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 771,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 260694,
+          "resourceSize": 765812
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12419,
+          "resourceSize": 28959
+        },
+        "stylesheet": {
+          "transferSize": 20032,
+          "resourceSize": 73700
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69990,
+          "resourceSize": 139691
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 5843,
+          "resourceSize": 25923
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 595653,
+          "resourceSize": 1796245
+        },
+        "stylesheet": {
+          "transferSize": 22640,
+          "resourceSize": 79322
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 12999,
+          "resourceSize": 14202
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 661419,
+          "resourceSize": 1939236
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 14063,
+          "resourceSize": 33521
+        },
+        "stylesheet": {
+          "transferSize": 20018,
+          "resourceSize": 77032
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 57747,
+          "resourceSize": 133881
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 2846,
+          "resourceSize": 7984
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 22346,
+          "resourceSize": 75682
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 769,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 260161,
+          "resourceSize": 764886
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 19724,
+          "resourceSize": 73392
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69643,
+          "resourceSize": 139344
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 3035,
+          "resourceSize": 8589
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 22304,
+          "resourceSize": 75641
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 773,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 260313,
+          "resourceSize": 765451
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 19682,
+          "resourceSize": 73351
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69601,
+          "resourceSize": 139303
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 2828,
+          "resourceSize": 7813
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 22067,
+          "resourceSize": 75568
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 769,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 259865,
+          "resourceSize": 764602
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 19445,
+          "resourceSize": 73278
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69364,
+          "resourceSize": 139230
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 3119,
+          "resourceSize": 8635
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 22067,
+          "resourceSize": 75568
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 765,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 260152,
+          "resourceSize": 765424
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 19445,
+          "resourceSize": 73278
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69364,
+          "resourceSize": 139230
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3364,
+          "resourceSize": 10049
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 22912,
+          "resourceSize": 76248
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 772,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 261249,
+          "resourceSize": 767518
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 20290,
+          "resourceSize": 73958
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 70209,
+          "resourceSize": 139910
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3331,
+          "resourceSize": 9201
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 593970,
+          "resourceSize": 1791644
+        },
+        "stylesheet": {
+          "transferSize": 22067,
+          "resourceSize": 75568
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 3952,
+          "resourceSize": 1443
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 661478,
+          "resourceSize": 1915105
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 19445,
+          "resourceSize": 73278
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69364,
+          "resourceSize": 139230
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.48.1
- **End Version:** v1.48.1

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Size Audit workflow*