### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.48.2.json
+++ b/.github/page_size_audit_results/v1.48.2.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.21.10",
+    "javaVersion": "21.0.9",
+    "themeVersion": "v1.48.2",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2025-11-24T17:05:36.888Z"
+  },
+  "timestamp": "2025-11-24T17:05:36.888Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 3069,
+          "resourceSize": 8668
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 22409,
+          "resourceSize": 72544
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 768,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 260446,
+          "resourceSize": 762432
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 19787,
+          "resourceSize": 70254
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69706,
+          "resourceSize": 136206
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 3084,
+          "resourceSize": 8898
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 22655,
+          "resourceSize": 72626
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 766,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 260705,
+          "resourceSize": 762744
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 20033,
+          "resourceSize": 70336
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69952,
+          "resourceSize": 136288
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 5857,
+          "resourceSize": 26025
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 595653,
+          "resourceSize": 1796245
+        },
+        "stylesheet": {
+          "transferSize": 22902,
+          "resourceSize": 78116
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 13037,
+          "resourceSize": 14202
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 661733,
+          "resourceSize": 1938132
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 14063,
+          "resourceSize": 33521
+        },
+        "stylesheet": {
+          "transferSize": 20280,
+          "resourceSize": 75826
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 58009,
+          "resourceSize": 132675
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 2847,
+          "resourceSize": 7984
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 21513,
+          "resourceSize": 71813
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 770,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 259330,
+          "resourceSize": 761017
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 18891,
+          "resourceSize": 69523
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 68810,
+          "resourceSize": 135475
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 3106,
+          "resourceSize": 8922
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 22892,
+          "resourceSize": 72699
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 771,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 260970,
+          "resourceSize": 762842
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 20270,
+          "resourceSize": 70409
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 70189,
+          "resourceSize": 136361
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 2835,
+          "resourceSize": 7813
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 21234,
+          "resourceSize": 71699
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 770,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 259040,
+          "resourceSize": 760733
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 18612,
+          "resourceSize": 69409
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 68531,
+          "resourceSize": 135361
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 3192,
+          "resourceSize": 8968
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 22655,
+          "resourceSize": 72626
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 768,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 260816,
+          "resourceSize": 762815
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 20033,
+          "resourceSize": 70336
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69952,
+          "resourceSize": 136288
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3437,
+          "resourceSize": 10373
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196043,
+          "resourceSize": 643777
+        },
+        "stylesheet": {
+          "transferSize": 24263,
+          "resourceSize": 75544
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 772,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 262673,
+          "resourceSize": 767138
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 21641,
+          "resourceSize": 73254
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 71560,
+          "resourceSize": 139206
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3355,
+          "resourceSize": 9303
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 593970,
+          "resourceSize": 1791644
+        },
+        "stylesheet": {
+          "transferSize": 22243,
+          "resourceSize": 74019
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 3947,
+          "resourceSize": 1443
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 661673,
+          "resourceSize": 1913658
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12380,
+          "resourceSize": 28920
+        },
+        "stylesheet": {
+          "transferSize": 19621,
+          "resourceSize": 71729
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69540,
+          "resourceSize": 137681
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.48.2
- **End Version:** v1.48.2

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Size Audit workflow*