### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.48.3.json
+++ b/.github/page_size_audit_results/v1.48.3.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.21.10",
+    "javaVersion": "21.0.9",
+    "themeVersion": "v1.48.3",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2025-11-26T08:37:10.330Z"
+  },
+  "timestamp": "2025-11-26T08:37:10.330Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 3022,
+          "resourceSize": 8661
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196583,
+          "resourceSize": 643752
+        },
+        "stylesheet": {
+          "transferSize": 22364,
+          "resourceSize": 72483
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 768,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 260894,
+          "resourceSize": 762339
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12920,
+          "resourceSize": 28895
+        },
+        "stylesheet": {
+          "transferSize": 19742,
+          "resourceSize": 70193
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 70201,
+          "resourceSize": 136120
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 3040,
+          "resourceSize": 8759
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196583,
+          "resourceSize": 643752
+        },
+        "stylesheet": {
+          "transferSize": 22610,
+          "resourceSize": 72565
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 769,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 261159,
+          "resourceSize": 762519
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12920,
+          "resourceSize": 28895
+        },
+        "stylesheet": {
+          "transferSize": 19988,
+          "resourceSize": 70275
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 70447,
+          "resourceSize": 136202
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 5856,
+          "resourceSize": 26155
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 596203,
+          "resourceSize": 1796230
+        },
+        "stylesheet": {
+          "transferSize": 23290,
+          "resourceSize": 78066
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 12998,
+          "resourceSize": 14202
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 662631,
+          "resourceSize": 1938197
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 14613,
+          "resourceSize": 33506
+        },
+        "stylesheet": {
+          "transferSize": 20668,
+          "resourceSize": 75776
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 58947,
+          "resourceSize": 132610
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 2828,
+          "resourceSize": 8004
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196583,
+          "resourceSize": 643752
+        },
+        "stylesheet": {
+          "transferSize": 21478,
+          "resourceSize": 71762
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 769,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 618,
+          "resourceSize": 216
+        },
+        "total": {
+          "transferSize": 259815,
+          "resourceSize": 760961
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12920,
+          "resourceSize": 28895
+        },
+        "stylesheet": {
+          "transferSize": 18856,
+          "resourceSize": 69472
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69315,
+          "resourceSize": 135399
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 3056,
+          "resourceSize": 8902
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196583,
+          "resourceSize": 643752
+        },
+        "stylesheet": {
+          "transferSize": 22847,
+          "resourceSize": 72638
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 773,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 261417,
+          "resourceSize": 762736
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12920,
+          "resourceSize": 28895
+        },
+        "stylesheet": {
+          "transferSize": 20225,
+          "resourceSize": 70348
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 70684,
+          "resourceSize": 136275
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 2816,
+          "resourceSize": 7827
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196583,
+          "resourceSize": 643752
+        },
+        "stylesheet": {
+          "transferSize": 21199,
+          "resourceSize": 71648
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 775,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 259531,
+          "resourceSize": 760671
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12920,
+          "resourceSize": 28895
+        },
+        "stylesheet": {
+          "transferSize": 18577,
+          "resourceSize": 69358
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 69036,
+          "resourceSize": 135285
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 3148,
+          "resourceSize": 8943
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196583,
+          "resourceSize": 643752
+        },
+        "stylesheet": {
+          "transferSize": 22610,
+          "resourceSize": 72565
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 768,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 261267,
+          "resourceSize": 762704
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12920,
+          "resourceSize": 28895
+        },
+        "stylesheet": {
+          "transferSize": 19988,
+          "resourceSize": 70275
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 70447,
+          "resourceSize": 136202
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3390,
+          "resourceSize": 10347
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 196583,
+          "resourceSize": 643752
+        },
+        "stylesheet": {
+          "transferSize": 24218,
+          "resourceSize": 75483
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 770,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 263119,
+          "resourceSize": 767026
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12920,
+          "resourceSize": 28895
+        },
+        "stylesheet": {
+          "transferSize": 21596,
+          "resourceSize": 73193
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 72055,
+          "resourceSize": 139120
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3331,
+          "resourceSize": 9320
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 594510,
+          "resourceSize": 1791619
+        },
+        "stylesheet": {
+          "transferSize": 22208,
+          "resourceSize": 73968
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 3946,
+          "resourceSize": 1443
+        },
+        "other": {
+          "transferSize": 619,
+          "resourceSize": 217
+        },
+        "total": {
+          "transferSize": 662153,
+          "resourceSize": 1913599
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 12920,
+          "resourceSize": 28895
+        },
+        "stylesheet": {
+          "transferSize": 19586,
+          "resourceSize": 71678
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "total": {
+          "transferSize": 70045,
+          "resourceSize": 137605
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.48.3
- **End Version:** v1.48.3

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Size Audit workflow*