### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.0.0.json
+++ b/.github/page_size_audit_results/v1.0.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.0.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:25.855Z"
+    "generatedAt": "2025-11-27T16:01:08.225Z"
   },
-  "timestamp": "2025-11-22T11:49:25.856Z",
+  "timestamp": "2025-11-27T16:01:08.225Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2672,
-          "resourceSize": 6248
+          "transferSize": 2500,
+          "resourceSize": 5593
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333428,
-          "resourceSize": 1052301
+          "transferSize": 149765,
+          "resourceSize": 437444
         },
         "stylesheet": {
-          "transferSize": 318662,
-          "resourceSize": 705129
+          "transferSize": 316040,
+          "resourceSize": 702839
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880324,
-          "resourceSize": 1988095
+          "transferSize": 693868,
+          "resourceSize": 1370293
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2518,
-          "resourceSize": 5790
+          "transferSize": 2342,
+          "resourceSize": 5135
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333428,
-          "resourceSize": 1052301
+          "transferSize": 149765,
+          "resourceSize": 437444
         },
         "stylesheet": {
-          "transferSize": 318662,
-          "resourceSize": 705129
+          "transferSize": 316040,
+          "resourceSize": 702839
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880167,
-          "resourceSize": 1987637
+          "transferSize": 693714,
+          "resourceSize": 1369835
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5321,
-          "resourceSize": 17381
+          "transferSize": 5029,
+          "resourceSize": 16192
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 735415,
-          "resourceSize": 2210726
+          "transferSize": 155836,
+          "resourceSize": 449840
         },
         "stylesheet": {
-          "transferSize": 318662,
-          "resourceSize": 705129
+          "transferSize": 316040,
+          "resourceSize": 702839
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 6238,
-          "resourceSize": 4994
+          "transferSize": 3420,
+          "resourceSize": 3746
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066254,
-          "resourceSize": 2938446
+          "transferSize": 480943,
+          "resourceSize": 1172833
         }
       },
       "themeResources": {
@@ -225,20 +225,20 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2355,
-          "resourceSize": 5263
+          "transferSize": 2179,
+          "resourceSize": 4608
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333428,
-          "resourceSize": 1052301
+          "transferSize": 149765,
+          "resourceSize": 437444
         },
         "stylesheet": {
-          "transferSize": 318662,
-          "resourceSize": 705129
+          "transferSize": 316040,
+          "resourceSize": 702839
         },
         "image": {
           "transferSize": 224175,
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880004,
-          "resourceSize": 1987110
+          "transferSize": 693543,
+          "resourceSize": 1369308
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2511,
-          "resourceSize": 5689
+          "transferSize": 2338,
+          "resourceSize": 5034
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333428,
-          "resourceSize": 1052301
+          "transferSize": 149765,
+          "resourceSize": 437444
         },
         "stylesheet": {
-          "transferSize": 318662,
-          "resourceSize": 705129
+          "transferSize": 316040,
+          "resourceSize": 702839
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880164,
-          "resourceSize": 1987536
+          "transferSize": 693704,
+          "resourceSize": 1369734
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2378,
-          "resourceSize": 5280
+          "transferSize": 2203,
+          "resourceSize": 4625
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333428,
-          "resourceSize": 1052301
+          "transferSize": 149765,
+          "resourceSize": 437444
         },
         "stylesheet": {
-          "transferSize": 318662,
-          "resourceSize": 705129
+          "transferSize": 316040,
+          "resourceSize": 702839
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880033,
-          "resourceSize": 1987127
+          "transferSize": 693572,
+          "resourceSize": 1369325
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2580,
-          "resourceSize": 5799
+          "transferSize": 2401,
+          "resourceSize": 5144
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333428,
-          "resourceSize": 1052301
+          "transferSize": 149765,
+          "resourceSize": 437444
         },
         "stylesheet": {
-          "transferSize": 318662,
-          "resourceSize": 705129
+          "transferSize": 316040,
+          "resourceSize": 702839
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880234,
-          "resourceSize": 1987647
+          "transferSize": 693767,
+          "resourceSize": 1369844
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3169,
-          "resourceSize": 7891
+          "transferSize": 2999,
+          "resourceSize": 7236
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333428,
-          "resourceSize": 1052301
+          "transferSize": 149765,
+          "resourceSize": 437444
         },
         "stylesheet": {
-          "transferSize": 318662,
-          "resourceSize": 705129
+          "transferSize": 316040,
+          "resourceSize": 702839
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880824,
-          "resourceSize": 1989739
+          "transferSize": 694364,
+          "resourceSize": 1371936
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3292,
-          "resourceSize": 7576
+          "transferSize": 3009,
+          "resourceSize": 6470
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 735415,
-          "resourceSize": 2210726
+          "transferSize": 155836,
+          "resourceSize": 449840
         },
         "stylesheet": {
-          "transferSize": 318662,
-          "resourceSize": 705129
+          "transferSize": 316040,
+          "resourceSize": 702839
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1124,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1286110,
-          "resourceSize": 3149097
+          "transferSize": 700802,
+          "resourceSize": 1383566
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.0.1.json
+++ b/.github/page_size_audit_results/v1.0.1.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.0.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:46.031Z"
+    "generatedAt": "2025-11-27T16:03:34.920Z"
   },
-  "timestamp": "2025-11-22T11:49:46.031Z",
+  "timestamp": "2025-11-27T16:03:34.920Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2374,
-          "resourceSize": 5292
+          "transferSize": 2195,
+          "resourceSize": 4637
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880139,
-          "resourceSize": 1988977
+          "transferSize": 693675,
+          "resourceSize": 1371175
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2221,
-          "resourceSize": 4834
+          "transferSize": 2039,
+          "resourceSize": 4179
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879991,
-          "resourceSize": 1988519
+          "transferSize": 693520,
+          "resourceSize": 1370717
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5046,
-          "resourceSize": 16425
+          "transferSize": 4738,
+          "resourceSize": 15236
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 735399,
-          "resourceSize": 2210732
+          "transferSize": 155820,
+          "resourceSize": 449846
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 6234,
-          "resourceSize": 4994
+          "transferSize": 3409,
+          "resourceSize": 3746
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066090,
-          "resourceSize": 2939328
+          "transferSize": 480756,
+          "resourceSize": 1173715
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2063,
-          "resourceSize": 4307
+          "transferSize": 1878,
+          "resourceSize": 3652
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879828,
-          "resourceSize": 1987992
+          "transferSize": 693357,
+          "resourceSize": 1370190
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2216,
-          "resourceSize": 4730
+          "transferSize": 2038,
+          "resourceSize": 4078
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879987,
-          "resourceSize": 1988415
+          "transferSize": 693518,
+          "resourceSize": 1370616
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2087,
-          "resourceSize": 4324
+          "transferSize": 1901,
+          "resourceSize": 3669
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879856,
-          "resourceSize": 1988009
+          "transferSize": 693384,
+          "resourceSize": 1370207
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2290,
-          "resourceSize": 4840
+          "transferSize": 2109,
+          "resourceSize": 4188
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880059,
-          "resourceSize": 1988526
+          "transferSize": 693589,
+          "resourceSize": 1370726
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2886,
-          "resourceSize": 6935
+          "transferSize": 2708,
+          "resourceSize": 6280
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880648,
-          "resourceSize": 1990621
+          "transferSize": 694197,
+          "resourceSize": 1372818
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3007,
-          "resourceSize": 6620
+          "transferSize": 2722,
+          "resourceSize": 5514
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 735399,
-          "resourceSize": 2210732
+          "transferSize": 155820,
+          "resourceSize": 449846
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1124,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1285939,
-          "resourceSize": 3149979
+          "transferSize": 700630,
+          "resourceSize": 1384448
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.1.0.json
+++ b/.github/page_size_audit_results/v1.1.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:19.289Z"
+    "generatedAt": "2025-11-27T16:03:31.941Z"
   },
-  "timestamp": "2025-11-22T11:49:19.290Z",
+  "timestamp": "2025-11-27T16:03:31.941Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2339,
-          "resourceSize": 5209
+          "transferSize": 2164,
+          "resourceSize": 4554
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880105,
-          "resourceSize": 1988894
+          "transferSize": 693641,
+          "resourceSize": 1371092
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2211,
-          "resourceSize": 4818
+          "transferSize": 2033,
+          "resourceSize": 4163
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879980,
-          "resourceSize": 1988503
+          "transferSize": 693513,
+          "resourceSize": 1370701
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5038,
-          "resourceSize": 16409
+          "transferSize": 4731,
+          "resourceSize": 15220
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 735399,
-          "resourceSize": 2210732
+          "transferSize": 155820,
+          "resourceSize": 449846
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 6237,
-          "resourceSize": 4994
+          "transferSize": 3423,
+          "resourceSize": 3746
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066085,
-          "resourceSize": 2939312
+          "transferSize": 480763,
+          "resourceSize": 1173699
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2053,
-          "resourceSize": 4291
+          "transferSize": 1871,
+          "resourceSize": 3636
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879825,
-          "resourceSize": 1987976
+          "transferSize": 693353,
+          "resourceSize": 1370174
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2210,
-          "resourceSize": 4717
+          "transferSize": 2031,
+          "resourceSize": 4062
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879978,
-          "resourceSize": 1988402
+          "transferSize": 693512,
+          "resourceSize": 1370600
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2076,
-          "resourceSize": 4308
+          "transferSize": 1895,
+          "resourceSize": 3653
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879842,
-          "resourceSize": 1987993
+          "transferSize": 693376,
+          "resourceSize": 1370191
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2285,
-          "resourceSize": 4827
+          "transferSize": 2102,
+          "resourceSize": 4172
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880047,
-          "resourceSize": 1988513
+          "transferSize": 693588,
+          "resourceSize": 1370710
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2877,
-          "resourceSize": 6919
+          "transferSize": 2702,
+          "resourceSize": 6264
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333412,
-          "resourceSize": 1052307
+          "transferSize": 149749,
+          "resourceSize": 437450
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880643,
-          "resourceSize": 1990605
+          "transferSize": 694187,
+          "resourceSize": 1372802
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3001,
-          "resourceSize": 6604
+          "transferSize": 2720,
+          "resourceSize": 5498
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 735399,
-          "resourceSize": 2210732
+          "transferSize": 155820,
+          "resourceSize": 449846
         },
         "stylesheet": {
-          "transferSize": 318793,
-          "resourceSize": 706961
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3953,
-          "resourceSize": 1443
+          "transferSize": 1124,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1285940,
-          "resourceSize": 3149963
+          "transferSize": 700628,
+          "resourceSize": 1384432
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.1.1.json
+++ b/.github/page_size_audit_results/v1.1.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:21.077Z"
+    "generatedAt": "2025-11-27T16:01:03.816Z"
   },
-  "timestamp": "2025-11-22T11:49:21.077Z",
+  "timestamp": "2025-11-27T16:01:03.816Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2337,
-          "resourceSize": 5209
+          "transferSize": 2162,
+          "resourceSize": 4554
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333416,
-          "resourceSize": 1052322
+          "transferSize": 149753,
+          "resourceSize": 437465
         },
         "stylesheet": {
-          "transferSize": 318778,
-          "resourceSize": 706913
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880100,
-          "resourceSize": 1988861
+          "transferSize": 693631,
+          "resourceSize": 1371059
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2207,
-          "resourceSize": 4818
+          "transferSize": 2031,
+          "resourceSize": 4163
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333416,
-          "resourceSize": 1052322
+          "transferSize": 149753,
+          "resourceSize": 437465
         },
         "stylesheet": {
-          "transferSize": 318778,
-          "resourceSize": 706913
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879964,
-          "resourceSize": 1988470
+          "transferSize": 693502,
+          "resourceSize": 1370668
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5087,
-          "resourceSize": 16937
+          "transferSize": 4793,
+          "resourceSize": 15748
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 735403,
-          "resourceSize": 2210747
+          "transferSize": 155824,
+          "resourceSize": 449861
         },
         "stylesheet": {
-          "transferSize": 318778,
-          "resourceSize": 706913
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7261,
-          "resourceSize": 6361
+          "transferSize": 4399,
+          "resourceSize": 5113
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1067147,
-          "resourceSize": 2941174
+          "transferSize": 481790,
+          "resourceSize": 1175561
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2049,
-          "resourceSize": 4291
+          "transferSize": 1868,
+          "resourceSize": 3636
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333416,
-          "resourceSize": 1052322
+          "transferSize": 149753,
+          "resourceSize": 437465
         },
         "stylesheet": {
-          "transferSize": 318778,
-          "resourceSize": 706913
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 780,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879816,
-          "resourceSize": 1987943
+          "transferSize": 693342,
+          "resourceSize": 1370141
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2206,
-          "resourceSize": 4717
+          "transferSize": 2028,
+          "resourceSize": 4062
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333416,
-          "resourceSize": 1052322
+          "transferSize": 149753,
+          "resourceSize": 437465
         },
         "stylesheet": {
-          "transferSize": 318778,
-          "resourceSize": 706913
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879960,
-          "resourceSize": 1988369
+          "transferSize": 693500,
+          "resourceSize": 1370567
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2072,
-          "resourceSize": 4308
+          "transferSize": 1893,
+          "resourceSize": 3653
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333416,
-          "resourceSize": 1052322
+          "transferSize": 149753,
+          "resourceSize": 437465
         },
         "stylesheet": {
-          "transferSize": 318778,
-          "resourceSize": 706913
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879833,
-          "resourceSize": 1987960
+          "transferSize": 693364,
+          "resourceSize": 1370158
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2279,
-          "resourceSize": 4827
+          "transferSize": 2099,
+          "resourceSize": 4172
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333416,
-          "resourceSize": 1052322
+          "transferSize": 149753,
+          "resourceSize": 437465
         },
         "stylesheet": {
-          "transferSize": 318778,
-          "resourceSize": 706913
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880044,
-          "resourceSize": 1988480
+          "transferSize": 693569,
+          "resourceSize": 1370677
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2866,
-          "resourceSize": 6919
+          "transferSize": 2699,
+          "resourceSize": 6264
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 333416,
-          "resourceSize": 1052322
+          "transferSize": 149753,
+          "resourceSize": 437465
         },
         "stylesheet": {
-          "transferSize": 318778,
-          "resourceSize": 706913
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880624,
-          "resourceSize": 1990572
+          "transferSize": 694168,
+          "resourceSize": 1372769
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2996,
-          "resourceSize": 6604
+          "transferSize": 2717,
+          "resourceSize": 5498
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 735403,
-          "resourceSize": 2210747
+          "transferSize": 155824,
+          "resourceSize": 449861
         },
         "stylesheet": {
-          "transferSize": 318778,
-          "resourceSize": 706913
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1124,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1285917,
-          "resourceSize": 3149930
+          "transferSize": 700614,
+          "resourceSize": 1384399
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.1.2.json
+++ b/.github/page_size_audit_results/v1.1.2.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:21.624Z"
+    "generatedAt": "2025-11-27T16:01:17.617Z"
   },
-  "timestamp": "2025-11-22T11:49:21.624Z",
+  "timestamp": "2025-11-27T16:01:17.618Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3009,
-          "resourceSize": 6585
+          "transferSize": 2826,
+          "resourceSize": 5930
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878455,
-          "resourceSize": 1986764
+          "transferSize": 691982,
+          "resourceSize": 1368962
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2890,
-          "resourceSize": 6342
+          "transferSize": 2704,
+          "resourceSize": 5687
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878334,
-          "resourceSize": 1986521
+          "transferSize": 691868,
+          "resourceSize": 1368719
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5754,
-          "resourceSize": 18482
+          "transferSize": 5456,
+          "resourceSize": 17293
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 732673,
-          "resourceSize": 2205080
+          "transferSize": 153094,
+          "resourceSize": 444194
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7838,
-          "resourceSize": 6933
+          "transferSize": 4974,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066077,
-          "resourceSize": 2939818
+          "transferSize": 480714,
+          "resourceSize": 1174205
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2718,
-          "resourceSize": 5726
+          "transferSize": 2525,
+          "resourceSize": 5071
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878164,
-          "resourceSize": 1985905
+          "transferSize": 691681,
+          "resourceSize": 1368103
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2879,
-          "resourceSize": 6152
+          "transferSize": 2692,
+          "resourceSize": 5497
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878319,
-          "resourceSize": 1986331
+          "transferSize": 691857,
+          "resourceSize": 1368529
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2736,
-          "resourceSize": 5743
+          "transferSize": 2551,
+          "resourceSize": 5088
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878180,
-          "resourceSize": 1985922
+          "transferSize": 691713,
+          "resourceSize": 1368120
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2935,
-          "resourceSize": 6262
+          "transferSize": 2750,
+          "resourceSize": 5607
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878374,
-          "resourceSize": 1986442
+          "transferSize": 691906,
+          "resourceSize": 1368639
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3523,
-          "resourceSize": 8357
+          "transferSize": 3332,
+          "resourceSize": 7702
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878968,
-          "resourceSize": 1988537
+          "transferSize": 692499,
+          "resourceSize": 1370734
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3654,
-          "resourceSize": 8039
+          "transferSize": 3369,
+          "resourceSize": 6933
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 732673,
-          "resourceSize": 2205080
+          "transferSize": 153094,
+          "resourceSize": 444194
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3944,
-          "resourceSize": 1443
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1284259,
-          "resourceSize": 3147892
+          "transferSize": 698954,
+          "resourceSize": 1382361
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.1.3.json
+++ b/.github/page_size_audit_results/v1.1.3.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:56.087Z"
+    "generatedAt": "2025-11-27T16:01:00.688Z"
   },
-  "timestamp": "2025-11-22T11:51:56.088Z",
+  "timestamp": "2025-11-27T16:01:00.688Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2976,
-          "resourceSize": 6538
+          "transferSize": 2800,
+          "resourceSize": 5883
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878422,
-          "resourceSize": 1986717
+          "transferSize": 691952,
+          "resourceSize": 1368915
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2855,
-          "resourceSize": 6282
+          "transferSize": 2680,
+          "resourceSize": 5627
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878300,
-          "resourceSize": 1986461
+          "transferSize": 691834,
+          "resourceSize": 1368659
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5722,
-          "resourceSize": 18422
+          "transferSize": 5427,
+          "resourceSize": 17233
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 732673,
-          "resourceSize": 2205080
+          "transferSize": 153094,
+          "resourceSize": 444194
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7818,
-          "resourceSize": 6933
+          "transferSize": 4962,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066025,
-          "resourceSize": 2939758
+          "transferSize": 480673,
+          "resourceSize": 1174145
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2685,
-          "resourceSize": 5666
+          "transferSize": 2500,
+          "resourceSize": 5011
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878129,
-          "resourceSize": 1985845
+          "transferSize": 691652,
+          "resourceSize": 1368043
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2842,
-          "resourceSize": 6092
+          "transferSize": 2668,
+          "resourceSize": 5437
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878281,
-          "resourceSize": 1986271
+          "transferSize": 691819,
+          "resourceSize": 1368469
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2704,
-          "resourceSize": 5683
+          "transferSize": 2523,
+          "resourceSize": 5028
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878147,
-          "resourceSize": 1985862
+          "transferSize": 691680,
+          "resourceSize": 1368060
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2901,
-          "resourceSize": 6202
+          "transferSize": 2725,
+          "resourceSize": 5547
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878349,
-          "resourceSize": 1986382
+          "transferSize": 691882,
+          "resourceSize": 1368579
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3489,
-          "resourceSize": 8312
+          "transferSize": 3308,
+          "resourceSize": 7657
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878929,
-          "resourceSize": 1988492
+          "transferSize": 692460,
+          "resourceSize": 1370689
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3624,
-          "resourceSize": 7979
+          "transferSize": 3346,
+          "resourceSize": 6873
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 732673,
-          "resourceSize": 2205080
+          "transferSize": 153094,
+          "resourceSize": 444194
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1284231,
-          "resourceSize": 3147832
+          "transferSize": 698925,
+          "resourceSize": 1382301
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.1.4.json
+++ b/.github/page_size_audit_results/v1.1.4.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:21.330Z"
+    "generatedAt": "2025-11-27T16:01:10.009Z"
   },
-  "timestamp": "2025-11-22T11:49:21.330Z",
+  "timestamp": "2025-11-27T16:01:10.009Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2977,
-          "resourceSize": 6544
+          "transferSize": 2801,
+          "resourceSize": 5889
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878421,
-          "resourceSize": 1986723
+          "transferSize": 691968,
+          "resourceSize": 1368921
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2856,
-          "resourceSize": 6288
+          "transferSize": 2681,
+          "resourceSize": 5633
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878302,
-          "resourceSize": 1986467
+          "transferSize": 691845,
+          "resourceSize": 1368665
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5721,
-          "resourceSize": 18428
+          "transferSize": 5431,
+          "resourceSize": 17239
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 732673,
-          "resourceSize": 2205080
+          "transferSize": 153094,
+          "resourceSize": 444194
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7836,
-          "resourceSize": 6933
+          "transferSize": 4988,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066042,
-          "resourceSize": 2939764
+          "transferSize": 480703,
+          "resourceSize": 1174151
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2686,
-          "resourceSize": 5672
+          "transferSize": 2503,
+          "resourceSize": 5017
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878127,
-          "resourceSize": 1985851
+          "transferSize": 691664,
+          "resourceSize": 1368049
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2843,
-          "resourceSize": 6098
+          "transferSize": 2670,
+          "resourceSize": 5443
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878285,
-          "resourceSize": 1986277
+          "transferSize": 691830,
+          "resourceSize": 1368475
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2706,
-          "resourceSize": 5689
+          "transferSize": 2524,
+          "resourceSize": 5034
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878150,
-          "resourceSize": 1985868
+          "transferSize": 691683,
+          "resourceSize": 1368066
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2902,
-          "resourceSize": 6208
+          "transferSize": 2727,
+          "resourceSize": 5553
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878345,
-          "resourceSize": 1986388
+          "transferSize": 691885,
+          "resourceSize": 1368585
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3490,
-          "resourceSize": 8318
+          "transferSize": 3310,
+          "resourceSize": 7663
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 330686,
-          "resourceSize": 1046655
+          "transferSize": 147023,
+          "resourceSize": 431798
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878933,
-          "resourceSize": 1988498
+          "transferSize": 692464,
+          "resourceSize": 1370695
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3627,
-          "resourceSize": 7985
+          "transferSize": 3348,
+          "resourceSize": 6879
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 732673,
-          "resourceSize": 2205080
+          "transferSize": 153094,
+          "resourceSize": 444194
         },
         "stylesheet": {
-          "transferSize": 319194,
-          "resourceSize": 709107
+          "transferSize": 316572,
+          "resourceSize": 706817
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3948,
-          "resourceSize": 1443
+          "transferSize": 1121,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1284236,
-          "resourceSize": 3147838
+          "transferSize": 698928,
+          "resourceSize": 1382307
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.10.0.json
+++ b/.github/page_size_audit_results/v1.10.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:31.051Z"
+    "generatedAt": "2025-11-27T16:01:09.521Z"
   },
-  "timestamp": "2025-11-22T11:49:31.051Z",
+  "timestamp": "2025-11-27T16:01:09.521Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2869,
-          "resourceSize": 6533
+          "transferSize": 2682,
+          "resourceSize": 5857
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877531,
-          "resourceSize": 1985321
+          "transferSize": 691053,
+          "resourceSize": 1367498
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2776,
-          "resourceSize": 6333
+          "transferSize": 2593,
+          "resourceSize": 5657
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877437,
-          "resourceSize": 1985121
+          "transferSize": 690971,
+          "resourceSize": 1367298
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5611,
-          "resourceSize": 18685
+          "transferSize": 5294,
+          "resourceSize": 17438
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7815,
-          "resourceSize": 6933
+          "transferSize": 4969,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064703,
-          "resourceSize": 2938630
+          "transferSize": 479339,
+          "resourceSize": 1172959
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2599,
-          "resourceSize": 5707
+          "transferSize": 2407,
+          "resourceSize": 5031
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877258,
-          "resourceSize": 1984495
+          "transferSize": 690785,
+          "resourceSize": 1366672
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2763,
-          "resourceSize": 6143
+          "transferSize": 2583,
+          "resourceSize": 5467
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877421,
-          "resourceSize": 1984931
+          "transferSize": 690956,
+          "resourceSize": 1367108
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2612,
-          "resourceSize": 5689
+          "transferSize": 2421,
+          "resourceSize": 5013
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
@@ -391,12 +391,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877276,
-          "resourceSize": 1984478
+          "transferSize": 690799,
+          "resourceSize": 1366654
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2824,
-          "resourceSize": 6253
+          "transferSize": 2640,
+          "resourceSize": 5577
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877487,
-          "resourceSize": 1985042
+          "transferSize": 691011,
+          "resourceSize": 1367218
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3449,
-          "resourceSize": 8406
+          "transferSize": 3250,
+          "resourceSize": 7730
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878106,
-          "resourceSize": 2211201
+          "transferSize": 691626,
+          "resourceSize": 1593377
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3589,
-          "resourceSize": 8108
+          "transferSize": 3289,
+          "resourceSize": 6929
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3949,
-          "resourceSize": 1443
+          "transferSize": 1118,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1283416,
-          "resourceSize": 3146570
+          "transferSize": 698084,
+          "resourceSize": 1380967
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.10.1.json
+++ b/.github/page_size_audit_results/v1.10.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:23.404Z"
+    "generatedAt": "2025-11-27T16:00:58.099Z"
   },
-  "timestamp": "2025-11-22T11:49:23.404Z",
+  "timestamp": "2025-11-27T16:00:58.100Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2896,
-          "resourceSize": 6601
+          "transferSize": 2712,
+          "resourceSize": 5925
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 781,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877567,
-          "resourceSize": 1985389
+          "transferSize": 691084,
+          "resourceSize": 1367566
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2770,
-          "resourceSize": 6333
+          "transferSize": 2592,
+          "resourceSize": 5657
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877429,
-          "resourceSize": 1985121
+          "transferSize": 690967,
+          "resourceSize": 1367298
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5609,
-          "resourceSize": 18685
+          "transferSize": 5292,
+          "resourceSize": 17438
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7814,
-          "resourceSize": 6933
+          "transferSize": 4972,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064700,
-          "resourceSize": 2938630
+          "transferSize": 479340,
+          "resourceSize": 1172959
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2594,
-          "resourceSize": 5707
+          "transferSize": 2405,
+          "resourceSize": 5031
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877259,
-          "resourceSize": 1984495
+          "transferSize": 690784,
+          "resourceSize": 1366672
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2758,
-          "resourceSize": 6143
+          "transferSize": 2580,
+          "resourceSize": 5467
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877415,
-          "resourceSize": 1984931
+          "transferSize": 690952,
+          "resourceSize": 1367108
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2606,
-          "resourceSize": 5689
+          "transferSize": 2419,
+          "resourceSize": 5013
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877270,
-          "resourceSize": 1984478
+          "transferSize": 690793,
+          "resourceSize": 1366654
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2820,
-          "resourceSize": 6253
+          "transferSize": 2637,
+          "resourceSize": 5577
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877481,
-          "resourceSize": 1985042
+          "transferSize": 691010,
+          "resourceSize": 1367218
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3475,
-          "resourceSize": 8569
+          "transferSize": 3283,
+          "resourceSize": 7893
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878133,
-          "resourceSize": 2211364
+          "transferSize": 691657,
+          "resourceSize": 1593540
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3584,
-          "resourceSize": 8108
+          "transferSize": 3287,
+          "resourceSize": 6929
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3951,
-          "resourceSize": 1443
+          "transferSize": 1121,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1283413,
-          "resourceSize": 3146570
+          "transferSize": 698085,
+          "resourceSize": 1380967
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.10.2.json
+++ b/.github/page_size_audit_results/v1.10.2.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:20.295Z"
+    "generatedAt": "2025-11-27T16:01:01.200Z"
   },
-  "timestamp": "2025-11-22T11:49:20.296Z",
+  "timestamp": "2025-11-27T16:01:01.200Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2898,
-          "resourceSize": 6601
+          "transferSize": 2712,
+          "resourceSize": 5925
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877563,
-          "resourceSize": 1985389
+          "transferSize": 691086,
+          "resourceSize": 1367566
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2772,
-          "resourceSize": 6333
+          "transferSize": 2592,
+          "resourceSize": 5657
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877430,
-          "resourceSize": 1985121
+          "transferSize": 690964,
+          "resourceSize": 1367298
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5610,
-          "resourceSize": 18697
+          "transferSize": 5292,
+          "resourceSize": 17450
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7848,
-          "resourceSize": 6933
+          "transferSize": 4962,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064735,
-          "resourceSize": 2938642
+          "transferSize": 479330,
+          "resourceSize": 1172971
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2597,
-          "resourceSize": 5707
+          "transferSize": 2405,
+          "resourceSize": 5031
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877254,
-          "resourceSize": 1984495
+          "transferSize": 690780,
+          "resourceSize": 1366672
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2760,
-          "resourceSize": 6143
+          "transferSize": 2581,
+          "resourceSize": 5467
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877417,
-          "resourceSize": 1984931
+          "transferSize": 690955,
+          "resourceSize": 1367108
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2609,
-          "resourceSize": 5689
+          "transferSize": 2420,
+          "resourceSize": 5013
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
@@ -391,12 +391,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877271,
-          "resourceSize": 1984478
+          "transferSize": 690796,
+          "resourceSize": 1366654
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2821,
-          "resourceSize": 6253
+          "transferSize": 2637,
+          "resourceSize": 5577
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877481,
-          "resourceSize": 1985042
+          "transferSize": 691008,
+          "resourceSize": 1367218
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3478,
-          "resourceSize": 8569
+          "transferSize": 3283,
+          "resourceSize": 7893
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878135,
-          "resourceSize": 2211364
+          "transferSize": 691656,
+          "resourceSize": 1593540
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3589,
-          "resourceSize": 8108
+          "transferSize": 3287,
+          "resourceSize": 6929
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1127,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1283413,
-          "resourceSize": 3146570
+          "transferSize": 698091,
+          "resourceSize": 1380967
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.11.0.json
+++ b/.github/page_size_audit_results/v1.11.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.11.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:58.872Z"
+    "generatedAt": "2025-11-27T16:01:03.051Z"
   },
-  "timestamp": "2025-11-22T11:51:58.872Z",
+  "timestamp": "2025-11-27T16:01:03.052Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2805,
-          "resourceSize": 6304
+          "transferSize": 2617,
+          "resourceSize": 5628
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877371,
-          "resourceSize": 1984799
+          "transferSize": 690900,
+          "resourceSize": 1366976
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2778,
-          "resourceSize": 6333
+          "transferSize": 2592,
+          "resourceSize": 5657
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877349,
-          "resourceSize": 1984828
+          "transferSize": 690875,
+          "resourceSize": 1367005
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5614,
-          "resourceSize": 18697
+          "transferSize": 5292,
+          "resourceSize": 17450
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730924,
-          "resourceSize": 2200418
+          "transferSize": 151345,
+          "resourceSize": 439532
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7807,
-          "resourceSize": 6933
+          "transferSize": 4964,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064606,
-          "resourceSize": 2938349
+          "transferSize": 479240,
+          "resourceSize": 1172678
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2600,
-          "resourceSize": 5707
+          "transferSize": 2405,
+          "resourceSize": 5031
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877169,
-          "resourceSize": 1984202
+          "transferSize": 690687,
+          "resourceSize": 1366379
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2764,
-          "resourceSize": 6143
+          "transferSize": 2581,
+          "resourceSize": 5467
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877334,
-          "resourceSize": 1984638
+          "transferSize": 690860,
+          "resourceSize": 1366815
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2613,
-          "resourceSize": 5689
+          "transferSize": 2419,
+          "resourceSize": 5013
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877183,
-          "resourceSize": 1984185
+          "transferSize": 690701,
+          "resourceSize": 1366361
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2825,
-          "resourceSize": 6253
+          "transferSize": 2638,
+          "resourceSize": 5577
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877393,
-          "resourceSize": 1984749
+          "transferSize": 690917,
+          "resourceSize": 1366925
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3482,
-          "resourceSize": 8569
+          "transferSize": 3283,
+          "resourceSize": 7893
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878057,
-          "resourceSize": 2211071
+          "transferSize": 691566,
+          "resourceSize": 1593247
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3591,
-          "resourceSize": 8108
+          "transferSize": 3287,
+          "resourceSize": 6929
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730924,
-          "resourceSize": 2200418
+          "transferSize": 151345,
+          "resourceSize": 439532
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3950,
-          "resourceSize": 1443
+          "transferSize": 1121,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1283327,
-          "resourceSize": 3146277
+          "transferSize": 697993,
+          "resourceSize": 1380674
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.12.0.json
+++ b/.github/page_size_audit_results/v1.12.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:14.699Z"
+    "generatedAt": "2025-11-27T16:01:07.868Z"
   },
-  "timestamp": "2025-11-22T11:49:14.699Z",
+  "timestamp": "2025-11-27T16:01:07.868Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2821,
-          "resourceSize": 6345
+          "transferSize": 2631,
+          "resourceSize": 5669
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319687,
-          "resourceSize": 712226
+          "transferSize": 317065,
+          "resourceSize": 709936
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877440,
-          "resourceSize": 1984981
+          "transferSize": 690963,
+          "resourceSize": 1367158
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2789,
-          "resourceSize": 6374
+          "transferSize": 2601,
+          "resourceSize": 5698
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319687,
-          "resourceSize": 712226
+          "transferSize": 317065,
+          "resourceSize": 709936
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877400,
-          "resourceSize": 1985010
+          "transferSize": 690924,
+          "resourceSize": 1367187
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5622,
-          "resourceSize": 18738
+          "transferSize": 5299,
+          "resourceSize": 17491
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730924,
-          "resourceSize": 2200418
+          "transferSize": 151345,
+          "resourceSize": 439532
         },
         "stylesheet": {
-          "transferSize": 319687,
-          "resourceSize": 712226
+          "transferSize": 317065,
+          "resourceSize": 709936
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7804,
-          "resourceSize": 6933
+          "transferSize": 4960,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064655,
-          "resourceSize": 2938531
+          "transferSize": 479287,
+          "resourceSize": 1172860
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2615,
-          "resourceSize": 5760
+          "transferSize": 2417,
+          "resourceSize": 5084
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319687,
-          "resourceSize": 712226
+          "transferSize": 317065,
+          "resourceSize": 709936
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877227,
-          "resourceSize": 1984396
+          "transferSize": 690746,
+          "resourceSize": 1366573
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2774,
-          "resourceSize": 6184
+          "transferSize": 2591,
+          "resourceSize": 5508
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319687,
-          "resourceSize": 712226
+          "transferSize": 317065,
+          "resourceSize": 709936
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877382,
-          "resourceSize": 1984820
+          "transferSize": 690921,
+          "resourceSize": 1366997
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2627,
-          "resourceSize": 5742
+          "transferSize": 2433,
+          "resourceSize": 5066
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319687,
-          "resourceSize": 712226
+          "transferSize": 317065,
+          "resourceSize": 709936
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877242,
-          "resourceSize": 1984379
+          "transferSize": 690756,
+          "resourceSize": 1366555
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2835,
-          "resourceSize": 6294
+          "transferSize": 2649,
+          "resourceSize": 5618
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319687,
-          "resourceSize": 712226
+          "transferSize": 317065,
+          "resourceSize": 709936
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877451,
-          "resourceSize": 1984931
+          "transferSize": 690971,
+          "resourceSize": 1367107
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3500,
-          "resourceSize": 8610
+          "transferSize": 3296,
+          "resourceSize": 7934
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 328937,
-          "resourceSize": 1041993
+          "transferSize": 145274,
+          "resourceSize": 427136
         },
         "stylesheet": {
-          "transferSize": 319687,
-          "resourceSize": 712226
+          "transferSize": 317065,
+          "resourceSize": 709936
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878113,
-          "resourceSize": 2211253
+          "transferSize": 691622,
+          "resourceSize": 1593429
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3606,
-          "resourceSize": 8165
+          "transferSize": 3302,
+          "resourceSize": 6986
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730924,
-          "resourceSize": 2200418
+          "transferSize": 151345,
+          "resourceSize": 439532
         },
         "stylesheet": {
-          "transferSize": 319687,
-          "resourceSize": 712226
+          "transferSize": 317065,
+          "resourceSize": 709936
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1283382,
-          "resourceSize": 3146475
+          "transferSize": 698053,
+          "resourceSize": 1380872
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.12.1.json
+++ b/.github/page_size_audit_results/v1.12.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:28.276Z"
+    "generatedAt": "2025-11-27T16:03:41.249Z"
   },
-  "timestamp": "2025-11-22T11:49:28.277Z",
+  "timestamp": "2025-11-27T16:03:41.250Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2831,
-          "resourceSize": 6529
+          "transferSize": 2636,
+          "resourceSize": 5853
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329870,
-          "resourceSize": 1044368
+          "transferSize": 146207,
+          "resourceSize": 429511
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878418,
-          "resourceSize": 1987615
+          "transferSize": 691932,
+          "resourceSize": 1369792
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2800,
-          "resourceSize": 6558
+          "transferSize": 2608,
+          "resourceSize": 5882
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329870,
-          "resourceSize": 1044368
+          "transferSize": 146207,
+          "resourceSize": 429511
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878388,
-          "resourceSize": 1987644
+          "transferSize": 691906,
+          "resourceSize": 1369821
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5645,
-          "resourceSize": 19014
+          "transferSize": 5307,
+          "resourceSize": 17767
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731583,
-          "resourceSize": 2201395
+          "transferSize": 152004,
+          "resourceSize": 440509
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7794,
-          "resourceSize": 6933
+          "transferSize": 4966,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1065368,
-          "resourceSize": 2939859
+          "transferSize": 480001,
+          "resourceSize": 1174188
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2627,
-          "resourceSize": 5944
+          "transferSize": 2426,
+          "resourceSize": 5268
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329870,
-          "resourceSize": 1044368
+          "transferSize": 146207,
+          "resourceSize": 429511
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878212,
-          "resourceSize": 1987030
+          "transferSize": 691723,
+          "resourceSize": 1369207
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2789,
-          "resourceSize": 6368
+          "transferSize": 2596,
+          "resourceSize": 5692
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329870,
-          "resourceSize": 1044368
+          "transferSize": 146207,
+          "resourceSize": 429511
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878371,
-          "resourceSize": 1987454
+          "transferSize": 691896,
+          "resourceSize": 1369631
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2635,
-          "resourceSize": 5926
+          "transferSize": 2442,
+          "resourceSize": 5250
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329870,
-          "resourceSize": 1044368
+          "transferSize": 146207,
+          "resourceSize": 429511
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
@@ -391,12 +391,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878221,
-          "resourceSize": 1987013
+          "transferSize": 691742,
+          "resourceSize": 1369189
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2850,
-          "resourceSize": 6478
+          "transferSize": 2654,
+          "resourceSize": 5802
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329870,
-          "resourceSize": 1044368
+          "transferSize": 146207,
+          "resourceSize": 429511
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878439,
-          "resourceSize": 1987565
+          "transferSize": 691950,
+          "resourceSize": 1369741
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3518,
-          "resourceSize": 8794
+          "transferSize": 3300,
+          "resourceSize": 8118
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329870,
-          "resourceSize": 1044368
+          "transferSize": 146207,
+          "resourceSize": 429511
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879104,
-          "resourceSize": 2213887
+          "transferSize": 692604,
+          "resourceSize": 1596063
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3635,
-          "resourceSize": 8349
+          "transferSize": 3305,
+          "resourceSize": 7170
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731583,
-          "resourceSize": 2201395
+          "transferSize": 152004,
+          "resourceSize": 440509
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1284111,
-          "resourceSize": 3147711
+          "transferSize": 698756,
+          "resourceSize": 1382108
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.12.2.json
+++ b/.github/page_size_audit_results/v1.12.2.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:14.241Z"
+    "generatedAt": "2025-11-27T16:12:03.937Z"
   },
-  "timestamp": "2025-11-22T11:49:14.242Z",
+  "timestamp": "2025-11-27T16:12:03.938Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2880,
-          "resourceSize": 6719
+          "transferSize": 2691,
+          "resourceSize": 6043
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880076,
-          "resourceSize": 1990856
+          "transferSize": 693604,
+          "resourceSize": 1373033
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2852,
-          "resourceSize": 6748
+          "transferSize": 2663,
+          "resourceSize": 6072
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880051,
-          "resourceSize": 1990885
+          "transferSize": 693572,
+          "resourceSize": 1373062
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5685,
-          "resourceSize": 19204
+          "transferSize": 5372,
+          "resourceSize": 17957
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733191,
-          "resourceSize": 2204446
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7866,
-          "resourceSize": 6933
+          "transferSize": 4971,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1067088,
-          "resourceSize": 2943100
+          "transferSize": 481679,
+          "resourceSize": 1177429
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2678,
-          "resourceSize": 6134
+          "transferSize": 2482,
+          "resourceSize": 5458
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879873,
-          "resourceSize": 1990271
+          "transferSize": 693390,
+          "resourceSize": 1372448
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2840,
-          "resourceSize": 6558
+          "transferSize": 2650,
+          "resourceSize": 5882
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880036,
-          "resourceSize": 1990696
+          "transferSize": 693558,
+          "resourceSize": 1372872
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2686,
-          "resourceSize": 6116
+          "transferSize": 2491,
+          "resourceSize": 5440
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879885,
-          "resourceSize": 1990254
+          "transferSize": 693399,
+          "resourceSize": 1372430
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2899,
-          "resourceSize": 6668
+          "transferSize": 2708,
+          "resourceSize": 5992
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880096,
-          "resourceSize": 1990806
+          "transferSize": 693617,
+          "resourceSize": 1372982
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3558,
-          "resourceSize": 8984
+          "transferSize": 3370,
+          "resourceSize": 8308
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 880757,
-          "resourceSize": 2217128
+          "transferSize": 694279,
+          "resourceSize": 1599305
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3677,
-          "resourceSize": 8539
+          "transferSize": 3356,
+          "resourceSize": 7360
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733191,
-          "resourceSize": 2204446
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 319728,
-          "resourceSize": 712301
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3948,
-          "resourceSize": 1443
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1285763,
-          "resourceSize": 3150952
+          "transferSize": 700415,
+          "resourceSize": 1385349
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.12.3.json
+++ b/.github/page_size_audit_results/v1.12.3.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:32.184Z"
+    "generatedAt": "2025-11-27T16:03:40.782Z"
   },
-  "timestamp": "2025-11-22T11:49:32.185Z",
+  "timestamp": "2025-11-27T16:03:40.782Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2885,
-          "resourceSize": 6725
+          "transferSize": 2789,
+          "resourceSize": 6330
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 294920,
+          "resourceSize": 939867
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 318557,
+          "resourceSize": 711314
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880077,
-          "resourceSize": 1990879
+          "transferSize": 842253,
+          "resourceSize": 1881928
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2858,
-          "resourceSize": 6754
+          "transferSize": 2760,
+          "resourceSize": 6359
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 294920,
+          "resourceSize": 939867
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 318557,
+          "resourceSize": 711314
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880054,
-          "resourceSize": 1990908
+          "transferSize": 842220,
+          "resourceSize": 1881957
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5689,
-          "resourceSize": 19210
+          "transferSize": 5591,
+          "resourceSize": 18693
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733191,
-          "resourceSize": 2204446
+          "transferSize": 696633,
+          "resourceSize": 2096894
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 318557,
+          "resourceSize": 711314
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7845,
+          "transferSize": 7792,
           "resourceSize": 6933
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1067070,
-          "resourceSize": 2943123
+          "transferSize": 1029191,
+          "resourceSize": 2834050
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2683,
-          "resourceSize": 6140
+          "transferSize": 2586,
+          "resourceSize": 5745
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 294920,
+          "resourceSize": 939867
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 318557,
+          "resourceSize": 711314
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879875,
-          "resourceSize": 1990294
+          "transferSize": 842053,
+          "resourceSize": 1881343
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2845,
-          "resourceSize": 6564
+          "transferSize": 2749,
+          "resourceSize": 6169
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 294920,
+          "resourceSize": 939867
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 318557,
+          "resourceSize": 711314
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880036,
-          "resourceSize": 1990719
+          "transferSize": 842214,
+          "resourceSize": 1881767
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2692,
-          "resourceSize": 6122
+          "transferSize": 2597,
+          "resourceSize": 5727
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 294920,
+          "resourceSize": 939867
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 318557,
+          "resourceSize": 711314
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 879884,
-          "resourceSize": 1990277
+          "transferSize": 842060,
+          "resourceSize": 1881326
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2904,
-          "resourceSize": 6674
+          "transferSize": 2809,
+          "resourceSize": 6279
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 294920,
+          "resourceSize": 939867
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 318557,
+          "resourceSize": 711314
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 880097,
-          "resourceSize": 1990829
+          "transferSize": 842276,
+          "resourceSize": 1881878
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3562,
-          "resourceSize": 8990
+          "transferSize": 3464,
+          "resourceSize": 8595
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 294920,
+          "resourceSize": 939867
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 318557,
+          "resourceSize": 711314
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 880754,
-          "resourceSize": 2217151
+          "transferSize": 842930,
+          "resourceSize": 2108200
         }
       },
       "themeResources": {
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3685,
-          "resourceSize": 8545
+          "transferSize": 3578,
+          "resourceSize": 8150
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733191,
-          "resourceSize": 2204446
+          "transferSize": 696633,
+          "resourceSize": 2096894
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 318557,
+          "resourceSize": 711314
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
+          "transferSize": 3945,
           "resourceSize": 1443
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1285769,
-          "resourceSize": 3150975
+          "transferSize": 1247932,
+          "resourceSize": 3042024
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.13.0.json
+++ b/.github/page_size_audit_results/v1.13.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:19.552Z"
+    "generatedAt": "2025-11-27T16:01:27.274Z"
   },
-  "timestamp": "2025-11-22T11:49:19.552Z",
+  "timestamp": "2025-11-27T16:01:27.274Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2887,
-          "resourceSize": 6725
+          "transferSize": 2700,
+          "resourceSize": 6049
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880082,
-          "resourceSize": 1990879
+          "transferSize": 693609,
+          "resourceSize": 1373056
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2861,
-          "resourceSize": 6754
+          "transferSize": 2672,
+          "resourceSize": 6078
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880053,
-          "resourceSize": 1990908
+          "transferSize": 693582,
+          "resourceSize": 1373085
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5692,
-          "resourceSize": 19210
+          "transferSize": 5381,
+          "resourceSize": 17963
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733191,
-          "resourceSize": 2204446
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7855,
-          "resourceSize": 6933
+          "transferSize": 4970,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1067083,
-          "resourceSize": 2943123
+          "transferSize": 481686,
+          "resourceSize": 1177452
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2685,
-          "resourceSize": 6140
+          "transferSize": 2498,
+          "resourceSize": 5464
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879877,
-          "resourceSize": 1990294
+          "transferSize": 693410,
+          "resourceSize": 1372471
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2847,
-          "resourceSize": 6564
+          "transferSize": 2661,
+          "resourceSize": 5888
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880043,
-          "resourceSize": 1990719
+          "transferSize": 693566,
+          "resourceSize": 1372895
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2694,
-          "resourceSize": 6122
+          "transferSize": 2508,
+          "resourceSize": 5446
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879890,
-          "resourceSize": 1990277
+          "transferSize": 693413,
+          "resourceSize": 1372453
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2906,
-          "resourceSize": 6674
+          "transferSize": 2719,
+          "resourceSize": 5998
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880099,
-          "resourceSize": 1990829
+          "transferSize": 693625,
+          "resourceSize": 1373005
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3565,
-          "resourceSize": 8990
+          "transferSize": 3381,
+          "resourceSize": 8314
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 880754,
-          "resourceSize": 2217151
+          "transferSize": 694288,
+          "resourceSize": 1599328
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3691,
-          "resourceSize": 8545
+          "transferSize": 3368,
+          "resourceSize": 7366
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733191,
-          "resourceSize": 2204446
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 319727,
-          "resourceSize": 712318
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3943,
-          "resourceSize": 1443
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1285771,
-          "resourceSize": 3150975
+          "transferSize": 700430,
+          "resourceSize": 1385372
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.13.1.json
+++ b/.github/page_size_audit_results/v1.13.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:20.968Z"
+    "generatedAt": "2025-11-27T16:01:00.050Z"
   },
-  "timestamp": "2025-11-22T11:49:20.968Z",
+  "timestamp": "2025-11-27T16:01:00.050Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2893,
-          "resourceSize": 6743
+          "transferSize": 2708,
+          "resourceSize": 6067
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880148,
-          "resourceSize": 1991550
+          "transferSize": 693673,
+          "resourceSize": 1373727
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2866,
-          "resourceSize": 6772
+          "transferSize": 2680,
+          "resourceSize": 6096
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880120,
-          "resourceSize": 1991579
+          "transferSize": 693643,
+          "resourceSize": 1373756
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5697,
-          "resourceSize": 19228
+          "transferSize": 5387,
+          "resourceSize": 17981
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733191,
-          "resourceSize": 2204446
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7835,
-          "resourceSize": 6933
+          "transferSize": 4975,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1067129,
-          "resourceSize": 2943794
+          "transferSize": 481758,
+          "resourceSize": 1178123
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2691,
-          "resourceSize": 6158
+          "transferSize": 2505,
+          "resourceSize": 5482
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879951,
-          "resourceSize": 1990965
+          "transferSize": 693471,
+          "resourceSize": 1373142
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2854,
-          "resourceSize": 6582
+          "transferSize": 2669,
+          "resourceSize": 5906
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880112,
-          "resourceSize": 1991390
+          "transferSize": 693637,
+          "resourceSize": 1373566
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2700,
-          "resourceSize": 6140
+          "transferSize": 2517,
+          "resourceSize": 5464
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879962,
-          "resourceSize": 1990948
+          "transferSize": 693482,
+          "resourceSize": 1373124
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2914,
-          "resourceSize": 6692
+          "transferSize": 2727,
+          "resourceSize": 6016
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880172,
-          "resourceSize": 1991500
+          "transferSize": 693695,
+          "resourceSize": 1373676
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3571,
-          "resourceSize": 9008
+          "transferSize": 3386,
+          "resourceSize": 8332
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 880827,
-          "resourceSize": 2217822
+          "transferSize": 694354,
+          "resourceSize": 1599999
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3694,
-          "resourceSize": 8563
+          "transferSize": 3374,
+          "resourceSize": 7384
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733191,
-          "resourceSize": 2204446
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3951,
-          "resourceSize": 1443
+          "transferSize": 1119,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1285843,
-          "resourceSize": 3151646
+          "transferSize": 700490,
+          "resourceSize": 1386043
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.14.0.json
+++ b/.github/page_size_audit_results/v1.14.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.14.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:24.790Z"
+    "generatedAt": "2025-11-27T16:03:42.885Z"
   },
-  "timestamp": "2025-11-22T11:49:24.790Z",
+  "timestamp": "2025-11-27T16:03:42.885Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2863,
-          "resourceSize": 6671
+          "transferSize": 2679,
+          "resourceSize": 5995
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880116,
-          "resourceSize": 1991478
+          "transferSize": 693646,
+          "resourceSize": 1373655
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2835,
-          "resourceSize": 6700
+          "transferSize": 2650,
+          "resourceSize": 6024
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880085,
-          "resourceSize": 1991507
+          "transferSize": 693622,
+          "resourceSize": 1373684
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5699,
-          "resourceSize": 19228
+          "transferSize": 5387,
+          "resourceSize": 17981
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733191,
-          "resourceSize": 2204446
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7826,
-          "resourceSize": 6933
+          "transferSize": 4971,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1067122,
-          "resourceSize": 2943794
+          "transferSize": 481754,
+          "resourceSize": 1178123
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2692,
-          "resourceSize": 6158
+          "transferSize": 2505,
+          "resourceSize": 5482
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879943,
-          "resourceSize": 1990965
+          "transferSize": 693470,
+          "resourceSize": 1373142
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2825,
-          "resourceSize": 6510
+          "transferSize": 2639,
+          "resourceSize": 5834
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880083,
-          "resourceSize": 1991318
+          "transferSize": 693609,
+          "resourceSize": 1373494
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2701,
-          "resourceSize": 6140
+          "transferSize": 2516,
+          "resourceSize": 5464
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879960,
-          "resourceSize": 1990948
+          "transferSize": 693480,
+          "resourceSize": 1373124
         }
       },
       "themeResources": {
@@ -438,20 +438,20 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2880,
-          "resourceSize": 6620
+          "transferSize": 2694,
+          "resourceSize": 5944
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
@@ -462,12 +462,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880141,
-          "resourceSize": 1991428
+          "transferSize": 693669,
+          "resourceSize": 1373604
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3539,
-          "resourceSize": 8936
+          "transferSize": 3354,
+          "resourceSize": 8260
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331478,
-          "resourceSize": 1047419
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 880790,
-          "resourceSize": 2217750
+          "transferSize": 694323,
+          "resourceSize": 1599927
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3693,
-          "resourceSize": 8563
+          "transferSize": 3374,
+          "resourceSize": 7384
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733191,
-          "resourceSize": 2204446
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712971
+          "transferSize": 317166,
+          "resourceSize": 710681
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3943,
-          "resourceSize": 1443
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1285834,
-          "resourceSize": 3151646
+          "transferSize": 700497,
+          "resourceSize": 1386043
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.15.0.json
+++ b/.github/page_size_audit_results/v1.15.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:23.411Z"
+    "generatedAt": "2025-11-27T16:01:00.398Z"
   },
-  "timestamp": "2025-11-22T11:49:23.411Z",
+  "timestamp": "2025-11-27T16:01:00.399Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2870,
-          "resourceSize": 6689
+          "transferSize": 2695,
+          "resourceSize": 6013
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331610,
-          "resourceSize": 1048047
+          "transferSize": 147947,
+          "resourceSize": 433190
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712979
+          "transferSize": 317166,
+          "resourceSize": 710689
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880257,
-          "resourceSize": 1992132
+          "transferSize": 693796,
+          "resourceSize": 1374309
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2842,
-          "resourceSize": 6718
+          "transferSize": 2667,
+          "resourceSize": 6042
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331610,
-          "resourceSize": 1048047
+          "transferSize": 147947,
+          "resourceSize": 433190
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712979
+          "transferSize": 317166,
+          "resourceSize": 710689
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880231,
-          "resourceSize": 1992161
+          "transferSize": 693773,
+          "resourceSize": 1374338
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5895,
-          "resourceSize": 19532
+          "transferSize": 5574,
+          "resourceSize": 18285
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733323,
-          "resourceSize": 2205074
+          "transferSize": 153744,
+          "resourceSize": 444188
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712979
+          "transferSize": 317166,
+          "resourceSize": 710689
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7809,
-          "resourceSize": 6933
+          "transferSize": 4970,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1067433,
-          "resourceSize": 2944734
+          "transferSize": 482072,
+          "resourceSize": 1179063
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2699,
-          "resourceSize": 6176
+          "transferSize": 2522,
+          "resourceSize": 5500
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331610,
-          "resourceSize": 1048047
+          "transferSize": 147947,
+          "resourceSize": 433190
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712979
+          "transferSize": 317166,
+          "resourceSize": 710689
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880087,
-          "resourceSize": 1991619
+          "transferSize": 693629,
+          "resourceSize": 1373796
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2833,
-          "resourceSize": 6528
+          "transferSize": 2655,
+          "resourceSize": 5852
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331610,
-          "resourceSize": 1048047
+          "transferSize": 147947,
+          "resourceSize": 433190
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712979
+          "transferSize": 317166,
+          "resourceSize": 710689
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880222,
-          "resourceSize": 1991972
+          "transferSize": 693756,
+          "resourceSize": 1374148
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2708,
-          "resourceSize": 6158
+          "transferSize": 2531,
+          "resourceSize": 5482
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331610,
-          "resourceSize": 1048047
+          "transferSize": 147947,
+          "resourceSize": 433190
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712979
+          "transferSize": 317166,
+          "resourceSize": 710689
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880092,
-          "resourceSize": 1991602
+          "transferSize": 693630,
+          "resourceSize": 1373778
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2887,
-          "resourceSize": 6638
+          "transferSize": 2710,
+          "resourceSize": 5962
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331610,
-          "resourceSize": 1048047
+          "transferSize": 147947,
+          "resourceSize": 433190
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712979
+          "transferSize": 317166,
+          "resourceSize": 710689
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880274,
-          "resourceSize": 1992082
+          "transferSize": 693808,
+          "resourceSize": 1374258
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3542,
-          "resourceSize": 8954
+          "transferSize": 3369,
+          "resourceSize": 8278
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331610,
-          "resourceSize": 1048047
+          "transferSize": 147947,
+          "resourceSize": 433190
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712979
+          "transferSize": 317166,
+          "resourceSize": 710689
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 880922,
-          "resourceSize": 2218404
+          "transferSize": 694473,
+          "resourceSize": 1600581
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3698,
-          "resourceSize": 8581
+          "transferSize": 3386,
+          "resourceSize": 7402
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733323,
-          "resourceSize": 2205074
+          "transferSize": 153744,
+          "resourceSize": 444188
         },
         "stylesheet": {
-          "transferSize": 319788,
-          "resourceSize": 712979
+          "transferSize": 317166,
+          "resourceSize": 710689
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3941,
-          "resourceSize": 1443
+          "transferSize": 1127,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1285969,
-          "resourceSize": 3152300
+          "transferSize": 700642,
+          "resourceSize": 1386697
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.15.1.json
+++ b/.github/page_size_audit_results/v1.15.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:08.790Z"
+    "generatedAt": "2025-11-27T16:00:58.869Z"
   },
-  "timestamp": "2025-11-22T11:52:08.791Z",
+  "timestamp": "2025-11-27T16:00:58.869Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2231,
-          "resourceSize": 5547
+          "transferSize": 2044,
+          "resourceSize": 4871
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319339,
-          "resourceSize": 711994
+          "transferSize": 316717,
+          "resourceSize": 709704
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879147,
-          "resourceSize": 1990016
+          "transferSize": 692673,
+          "resourceSize": 1372193
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2207,
-          "resourceSize": 5576
+          "transferSize": 2018,
+          "resourceSize": 4900
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319339,
-          "resourceSize": 711994
+          "transferSize": 316717,
+          "resourceSize": 709704
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879123,
-          "resourceSize": 1990045
+          "transferSize": 692644,
+          "resourceSize": 1372222
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5331,
-          "resourceSize": 18428
+          "transferSize": 5022,
+          "resourceSize": 17181
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319339,
-          "resourceSize": 711994
+          "transferSize": 316717,
+          "resourceSize": 709704
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7832,
-          "resourceSize": 6933
+          "transferSize": 4966,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066422,
-          "resourceSize": 2942656
+          "transferSize": 481046,
+          "resourceSize": 1176985
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2074,
-          "resourceSize": 5034
+          "transferSize": 1890,
+          "resourceSize": 4358
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319339,
-          "resourceSize": 711994
+          "transferSize": 316717,
+          "resourceSize": 709704
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878985,
-          "resourceSize": 1989503
+          "transferSize": 692520,
+          "resourceSize": 1371680
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2206,
-          "resourceSize": 5386
+          "transferSize": 2021,
+          "resourceSize": 4710
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319339,
-          "resourceSize": 711994
+          "transferSize": 316717,
+          "resourceSize": 709704
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879126,
-          "resourceSize": 1989856
+          "transferSize": 692646,
+          "resourceSize": 1372032
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2088,
-          "resourceSize": 5016
+          "transferSize": 1901,
+          "resourceSize": 4340
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319339,
-          "resourceSize": 711994
+          "transferSize": 316717,
+          "resourceSize": 709704
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879011,
-          "resourceSize": 1989486
+          "transferSize": 692532,
+          "resourceSize": 1371662
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2280,
-          "resourceSize": 5496
+          "transferSize": 2094,
+          "resourceSize": 4820
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319339,
-          "resourceSize": 711994
+          "transferSize": 316717,
+          "resourceSize": 709704
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879199,
-          "resourceSize": 1989966
+          "transferSize": 692725,
+          "resourceSize": 1372142
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2924,
-          "resourceSize": 7812
+          "transferSize": 2743,
+          "resourceSize": 7136
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319339,
-          "resourceSize": 711994
+          "transferSize": 316717,
+          "resourceSize": 709704
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 879841,
-          "resourceSize": 2216288
+          "transferSize": 693377,
+          "resourceSize": 1598465
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3085,
-          "resourceSize": 7421
+          "transferSize": 2784,
+          "resourceSize": 6242
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319339,
-          "resourceSize": 711994
+          "transferSize": 316717,
+          "resourceSize": 709704
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3954,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1284899,
-          "resourceSize": 3150166
+          "transferSize": 699563,
+          "resourceSize": 1384563
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.16.0.json
+++ b/.github/page_size_audit_results/v1.16.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:24.250Z"
+    "generatedAt": "2025-11-27T16:01:03.504Z"
   },
-  "timestamp": "2025-11-22T11:49:24.250Z",
+  "timestamp": "2025-11-27T16:01:03.505Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2233,
-          "resourceSize": 5557
+          "transferSize": 2045,
+          "resourceSize": 4881
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879246,
-          "resourceSize": 1990562
+          "transferSize": 692776,
+          "resourceSize": 1372739
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2209,
-          "resourceSize": 5586
+          "transferSize": 2019,
+          "resourceSize": 4910
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879221,
-          "resourceSize": 1990591
+          "transferSize": 692756,
+          "resourceSize": 1372768
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5329,
-          "resourceSize": 18438
+          "transferSize": 5022,
+          "resourceSize": 17191
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7805,
-          "resourceSize": 6933
+          "transferSize": 4983,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066491,
-          "resourceSize": 2943202
+          "transferSize": 481161,
+          "resourceSize": 1177531
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2074,
-          "resourceSize": 5044
+          "transferSize": 1891,
+          "resourceSize": 4368
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879094,
-          "resourceSize": 1990049
+          "transferSize": 692627,
+          "resourceSize": 1372226
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2208,
-          "resourceSize": 5396
+          "transferSize": 2023,
+          "resourceSize": 4720
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879221,
-          "resourceSize": 1990402
+          "transferSize": 692752,
+          "resourceSize": 1372578
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2088,
-          "resourceSize": 5026
+          "transferSize": 1903,
+          "resourceSize": 4350
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
@@ -391,12 +391,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879102,
-          "resourceSize": 1990032
+          "transferSize": 692631,
+          "resourceSize": 1372208
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2282,
-          "resourceSize": 5506
+          "transferSize": 2096,
+          "resourceSize": 4830
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879300,
-          "resourceSize": 1990512
+          "transferSize": 692825,
+          "resourceSize": 1372688
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2924,
-          "resourceSize": 7822
+          "transferSize": 2745,
+          "resourceSize": 7146
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 879943,
-          "resourceSize": 2216834
+          "transferSize": 693475,
+          "resourceSize": 1599011
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3085,
-          "resourceSize": 7431
+          "transferSize": 2787,
+          "resourceSize": 6252
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1124,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1284989,
-          "resourceSize": 3150712
+          "transferSize": 699668,
+          "resourceSize": 1385109
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.16.1.json
+++ b/.github/page_size_audit_results/v1.16.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:58.076Z"
+    "generatedAt": "2025-11-27T16:03:34.695Z"
   },
-  "timestamp": "2025-11-22T11:51:58.077Z",
+  "timestamp": "2025-11-27T16:03:34.696Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2234,
-          "resourceSize": 5557
+          "transferSize": 2045,
+          "resourceSize": 4881
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879245,
-          "resourceSize": 1990562
+          "transferSize": 692776,
+          "resourceSize": 1372739
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2209,
-          "resourceSize": 5586
+          "transferSize": 2019,
+          "resourceSize": 4910
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879224,
-          "resourceSize": 1990591
+          "transferSize": 692747,
+          "resourceSize": 1372768
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5330,
-          "resourceSize": 18438
+          "transferSize": 5021,
+          "resourceSize": 17191
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7785,
-          "resourceSize": 6933
+          "transferSize": 4960,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066472,
-          "resourceSize": 2943202
+          "transferSize": 481137,
+          "resourceSize": 1177531
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2074,
-          "resourceSize": 5044
+          "transferSize": 1891,
+          "resourceSize": 4368
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879091,
-          "resourceSize": 1990049
+          "transferSize": 692619,
+          "resourceSize": 1372226
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2208,
-          "resourceSize": 5396
+          "transferSize": 2022,
+          "resourceSize": 4720
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879224,
-          "resourceSize": 1990402
+          "transferSize": 692750,
+          "resourceSize": 1372578
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2089,
-          "resourceSize": 5026
+          "transferSize": 1903,
+          "resourceSize": 4350
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879104,
-          "resourceSize": 1990032
+          "transferSize": 692631,
+          "resourceSize": 1372208
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2282,
-          "resourceSize": 5506
+          "transferSize": 2094,
+          "resourceSize": 4830
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879296,
-          "resourceSize": 1990512
+          "transferSize": 692821,
+          "resourceSize": 1372688
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2926,
-          "resourceSize": 7822
+          "transferSize": 2745,
+          "resourceSize": 7146
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 879941,
-          "resourceSize": 2216834
+          "transferSize": 693473,
+          "resourceSize": 1599011
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3087,
-          "resourceSize": 7431
+          "transferSize": 2787,
+          "resourceSize": 6252
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319437,
-          "resourceSize": 712530
+          "transferSize": 316815,
+          "resourceSize": 710240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3949,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1284994,
-          "resourceSize": 3150712
+          "transferSize": 699664,
+          "resourceSize": 1385109
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.17.0.json
+++ b/.github/page_size_audit_results/v1.17.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.17.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:02.019Z"
+    "generatedAt": "2025-11-27T16:03:38.145Z"
   },
-  "timestamp": "2025-11-22T11:52:02.020Z",
+  "timestamp": "2025-11-27T16:03:38.146Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2319,
-          "resourceSize": 6033
+          "transferSize": 2139,
+          "resourceSize": 5357
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319402,
-          "resourceSize": 712383
+          "transferSize": 316780,
+          "resourceSize": 710093
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878874,
-          "resourceSize": 1990891
+          "transferSize": 692405,
+          "resourceSize": 1373068
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2292,
-          "resourceSize": 6062
+          "transferSize": 2112,
+          "resourceSize": 5386
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319402,
-          "resourceSize": 712383
+          "transferSize": 316780,
+          "resourceSize": 710093
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878846,
-          "resourceSize": 1990920
+          "transferSize": 692376,
+          "resourceSize": 1373097
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5457,
-          "resourceSize": 18986
+          "transferSize": 5157,
+          "resourceSize": 17739
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319402,
-          "resourceSize": 712383
+          "transferSize": 316780,
+          "resourceSize": 710093
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7851,
-          "resourceSize": 6933
+          "transferSize": 4989,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066630,
-          "resourceSize": 2943603
+          "transferSize": 481267,
+          "resourceSize": 1177932
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2159,
-          "resourceSize": 5520
+          "transferSize": 1983,
+          "resourceSize": 4844
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319402,
-          "resourceSize": 712383
+          "transferSize": 316780,
+          "resourceSize": 710093
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878716,
-          "resourceSize": 1990378
+          "transferSize": 692246,
+          "resourceSize": 1372555
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2295,
-          "resourceSize": 5872
+          "transferSize": 2118,
+          "resourceSize": 5196
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319402,
-          "resourceSize": 712383
+          "transferSize": 316780,
+          "resourceSize": 710093
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878855,
-          "resourceSize": 1990730
+          "transferSize": 692385,
+          "resourceSize": 1372907
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2173,
-          "resourceSize": 5502
+          "transferSize": 1996,
+          "resourceSize": 4826
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319402,
-          "resourceSize": 712383
+          "transferSize": 316780,
+          "resourceSize": 710093
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878731,
-          "resourceSize": 1990361
+          "transferSize": 692266,
+          "resourceSize": 1372537
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2367,
-          "resourceSize": 5982
+          "transferSize": 2190,
+          "resourceSize": 5306
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319402,
-          "resourceSize": 712383
+          "transferSize": 316780,
+          "resourceSize": 710093
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878924,
-          "resourceSize": 1990841
+          "transferSize": 692455,
+          "resourceSize": 1373017
         }
       },
       "themeResources": {
@@ -509,20 +509,20 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3015,
-          "resourceSize": 8298
+          "transferSize": 2833,
+          "resourceSize": 7622
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319402,
-          "resourceSize": 712383
+          "transferSize": 316780,
+          "resourceSize": 710093
         },
         "image": {
           "transferSize": 224175,
@@ -533,12 +533,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879569,
-          "resourceSize": 1993157
+          "transferSize": 693101,
+          "resourceSize": 1375333
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3164,
-          "resourceSize": 7907
+          "transferSize": 2873,
+          "resourceSize": 6728
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319402,
-          "resourceSize": 712383
+          "transferSize": 316780,
+          "resourceSize": 710093
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3948,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1284610,
-          "resourceSize": 3151041
+          "transferSize": 699292,
+          "resourceSize": 1385437
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.18.0.json
+++ b/.github/page_size_audit_results/v1.18.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.18.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:25.452Z"
+    "generatedAt": "2025-11-27T16:01:00.543Z"
   },
-  "timestamp": "2025-11-22T11:52:25.452Z",
+  "timestamp": "2025-11-27T16:01:00.544Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2288,
-          "resourceSize": 5741
+          "transferSize": 2103,
+          "resourceSize": 5065
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879039,
-          "resourceSize": 1994248
+          "transferSize": 692574,
+          "resourceSize": 1376425
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2263,
-          "resourceSize": 5770
+          "transferSize": 2077,
+          "resourceSize": 5094
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879010,
-          "resourceSize": 1994277
+          "transferSize": 692546,
+          "resourceSize": 1376454
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5432,
-          "resourceSize": 18694
+          "transferSize": 5119,
+          "resourceSize": 17447
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7851,
-          "resourceSize": 6933
+          "transferSize": 4965,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066802,
-          "resourceSize": 2946960
+          "transferSize": 481402,
+          "resourceSize": 1181289
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2132,
-          "resourceSize": 5228
+          "transferSize": 1948,
+          "resourceSize": 4552
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878885,
-          "resourceSize": 1993735
+          "transferSize": 692413,
+          "resourceSize": 1375912
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2265,
-          "resourceSize": 5580
+          "transferSize": 2082,
+          "resourceSize": 4904
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879015,
-          "resourceSize": 1994087
+          "transferSize": 692546,
+          "resourceSize": 1376264
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2146,
-          "resourceSize": 5210
+          "transferSize": 1960,
+          "resourceSize": 4534
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878898,
-          "resourceSize": 1993718
+          "transferSize": 692424,
+          "resourceSize": 1375894
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2338,
-          "resourceSize": 5690
+          "transferSize": 2154,
+          "resourceSize": 5014
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879091,
-          "resourceSize": 1994198
+          "transferSize": 692614,
+          "resourceSize": 1376374
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2974,
-          "resourceSize": 8006
+          "transferSize": 2795,
+          "resourceSize": 7330
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879728,
-          "resourceSize": 1996514
+          "transferSize": 693264,
+          "resourceSize": 1378690
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3137,
-          "resourceSize": 7615
+          "transferSize": 2837,
+          "resourceSize": 6436
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1121,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1284778,
-          "resourceSize": 3154398
+          "transferSize": 699451,
+          "resourceSize": 1388794
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.19.0.json
+++ b/.github/page_size_audit_results/v1.19.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.19.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:07.858Z"
+    "generatedAt": "2025-11-27T16:01:06.504Z"
   },
-  "timestamp": "2025-11-22T11:52:07.859Z",
+  "timestamp": "2025-11-27T16:01:06.504Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2289,
-          "resourceSize": 5741
+          "transferSize": 2098,
+          "resourceSize": 5065
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879041,
-          "resourceSize": 1994248
+          "transferSize": 692563,
+          "resourceSize": 1376425
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2264,
-          "resourceSize": 5770
+          "transferSize": 2073,
+          "resourceSize": 5094
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879014,
-          "resourceSize": 1994277
+          "transferSize": 692545,
+          "resourceSize": 1376454
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5665,
-          "resourceSize": 21799
+          "transferSize": 5370,
+          "resourceSize": 20552
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10723,
-          "resourceSize": 10089
+          "transferSize": 7783,
+          "resourceSize": 8841
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069907,
-          "resourceSize": 2953221
+          "transferSize": 484471,
+          "resourceSize": 1187550
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2132,
-          "resourceSize": 5228
+          "transferSize": 1947,
+          "resourceSize": 4552
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878883,
-          "resourceSize": 1993735
+          "transferSize": 692414,
+          "resourceSize": 1375912
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2264,
-          "resourceSize": 5580
+          "transferSize": 2078,
+          "resourceSize": 4904
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879013,
-          "resourceSize": 1994087
+          "transferSize": 692542,
+          "resourceSize": 1376264
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2147,
-          "resourceSize": 5210
+          "transferSize": 1957,
+          "resourceSize": 4534
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878895,
-          "resourceSize": 1993717
+          "transferSize": 692422,
+          "resourceSize": 1375894
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2337,
-          "resourceSize": 5690
+          "transferSize": 2150,
+          "resourceSize": 5014
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879092,
-          "resourceSize": 1994198
+          "transferSize": 692616,
+          "resourceSize": 1376374
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2974,
-          "resourceSize": 8006
+          "transferSize": 2792,
+          "resourceSize": 7330
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879726,
-          "resourceSize": 1996514
+          "transferSize": 693263,
+          "resourceSize": 1378690
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3137,
-          "resourceSize": 7615
+          "transferSize": 2834,
+          "resourceSize": 6436
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319599,
-          "resourceSize": 716032
+          "transferSize": 316977,
+          "resourceSize": 713742
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3951,
-          "resourceSize": 1443
+          "transferSize": 1129,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1284783,
-          "resourceSize": 3154398
+          "transferSize": 699456,
+          "resourceSize": 1388794
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.2.0.json
+++ b/.github/page_size_audit_results/v1.2.0.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.2.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:19.692Z"
+    "generatedAt": "2025-11-27T16:00:53.599Z"
   },
-  "timestamp": "2025-11-22T11:49:19.693Z",
+  "timestamp": "2025-11-27T16:00:53.599Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2756,
-          "resourceSize": 6019
+          "transferSize": 2577,
+          "resourceSize": 5364
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329012,
-          "resourceSize": 1042284
+          "transferSize": 145349,
+          "resourceSize": 427427
         },
         "stylesheet": {
-          "transferSize": 319247,
-          "resourceSize": 709255
+          "transferSize": 316625,
+          "resourceSize": 706965
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876577,
-          "resourceSize": 1981975
+          "transferSize": 690113,
+          "resourceSize": 1364173
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2631,
-          "resourceSize": 5735
+          "transferSize": 2449,
+          "resourceSize": 5080
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329012,
-          "resourceSize": 1042284
+          "transferSize": 145349,
+          "resourceSize": 427427
         },
         "stylesheet": {
-          "transferSize": 319247,
-          "resourceSize": 709255
+          "transferSize": 316625,
+          "resourceSize": 706965
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876449,
-          "resourceSize": 1981691
+          "transferSize": 689989,
+          "resourceSize": 1363889
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5508,
-          "resourceSize": 17875
+          "transferSize": 5207,
+          "resourceSize": 16686
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730999,
-          "resourceSize": 2200709
+          "transferSize": 151420,
+          "resourceSize": 439823
         },
         "stylesheet": {
-          "transferSize": 319247,
-          "resourceSize": 709255
+          "transferSize": 316625,
+          "resourceSize": 706965
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7785,
-          "resourceSize": 6933
+          "transferSize": 4967,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064157,
-          "resourceSize": 2934988
+          "transferSize": 478837,
+          "resourceSize": 1169375
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2454,
-          "resourceSize": 5119
+          "transferSize": 2271,
+          "resourceSize": 4464
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329012,
-          "resourceSize": 1042284
+          "transferSize": 145349,
+          "resourceSize": 427427
         },
         "stylesheet": {
-          "transferSize": 319247,
-          "resourceSize": 709255
+          "transferSize": 316625,
+          "resourceSize": 706965
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876275,
-          "resourceSize": 1981075
+          "transferSize": 689812,
+          "resourceSize": 1363273
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2619,
-          "resourceSize": 5545
+          "transferSize": 2436,
+          "resourceSize": 4890
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329012,
-          "resourceSize": 1042284
+          "transferSize": 145349,
+          "resourceSize": 427427
         },
         "stylesheet": {
-          "transferSize": 319247,
-          "resourceSize": 709255
+          "transferSize": 316625,
+          "resourceSize": 706965
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876443,
-          "resourceSize": 1981501
+          "transferSize": 689973,
+          "resourceSize": 1363699
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2476,
-          "resourceSize": 5136
+          "transferSize": 2293,
+          "resourceSize": 4481
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329012,
-          "resourceSize": 1042284
+          "transferSize": 145349,
+          "resourceSize": 427427
         },
         "stylesheet": {
-          "transferSize": 319247,
-          "resourceSize": 709255
+          "transferSize": 316625,
+          "resourceSize": 706965
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876297,
-          "resourceSize": 1981092
+          "transferSize": 689830,
+          "resourceSize": 1363290
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2679,
-          "resourceSize": 5655
+          "transferSize": 2497,
+          "resourceSize": 5000
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329012,
-          "resourceSize": 1042284
+          "transferSize": 145349,
+          "resourceSize": 427427
         },
         "stylesheet": {
-          "transferSize": 319247,
-          "resourceSize": 709255
+          "transferSize": 316625,
+          "resourceSize": 706965
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876500,
-          "resourceSize": 1981612
+          "transferSize": 690034,
+          "resourceSize": 1363809
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3258,
-          "resourceSize": 7778
+          "transferSize": 3079,
+          "resourceSize": 7123
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329012,
-          "resourceSize": 1042284
+          "transferSize": 145349,
+          "resourceSize": 427427
         },
         "stylesheet": {
-          "transferSize": 319247,
-          "resourceSize": 709255
+          "transferSize": 316625,
+          "resourceSize": 706965
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877082,
-          "resourceSize": 1983735
+          "transferSize": 690621,
+          "resourceSize": 1365932
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3401,
-          "resourceSize": 7432
+          "transferSize": 3118,
+          "resourceSize": 6326
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730999,
-          "resourceSize": 2200709
+          "transferSize": 151420,
+          "resourceSize": 439823
         },
         "stylesheet": {
-          "transferSize": 319247,
-          "resourceSize": 709255
+          "transferSize": 316625,
+          "resourceSize": 706965
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3944,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282385,
-          "resourceSize": 3143062
+          "transferSize": 697076,
+          "resourceSize": 1377531
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.2.1.json
+++ b/.github/page_size_audit_results/v1.2.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.2.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:46.898Z"
+    "generatedAt": "2025-11-27T16:00:59.158Z"
   },
-  "timestamp": "2025-11-22T11:49:46.899Z",
+  "timestamp": "2025-11-27T16:00:59.158Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2763,
-          "resourceSize": 6027
+          "transferSize": 2579,
+          "resourceSize": 5372
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329032,
-          "resourceSize": 1042290
+          "transferSize": 145369,
+          "resourceSize": 427433
         },
         "stylesheet": {
-          "transferSize": 319003,
-          "resourceSize": 708532
+          "transferSize": 316381,
+          "resourceSize": 706242
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876359,
-          "resourceSize": 1981266
+          "transferSize": 689894,
+          "resourceSize": 1363464
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2639,
-          "resourceSize": 5743
+          "transferSize": 2453,
+          "resourceSize": 5088
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329032,
-          "resourceSize": 1042290
+          "transferSize": 145369,
+          "resourceSize": 427433
         },
         "stylesheet": {
-          "transferSize": 319003,
-          "resourceSize": 708532
+          "transferSize": 316381,
+          "resourceSize": 706242
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876238,
-          "resourceSize": 1980982
+          "transferSize": 689767,
+          "resourceSize": 1363180
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5513,
-          "resourceSize": 17883
+          "transferSize": 5208,
+          "resourceSize": 16694
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731019,
-          "resourceSize": 2200715
+          "transferSize": 151440,
+          "resourceSize": 439829
         },
         "stylesheet": {
-          "transferSize": 319003,
-          "resourceSize": 708532
+          "transferSize": 316381,
+          "resourceSize": 706242
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7851,
-          "resourceSize": 6933
+          "transferSize": 4995,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064004,
-          "resourceSize": 2934279
+          "transferSize": 478642,
+          "resourceSize": 1168666
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2461,
-          "resourceSize": 5127
+          "transferSize": 2273,
+          "resourceSize": 4472
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329032,
-          "resourceSize": 1042290
+          "transferSize": 145369,
+          "resourceSize": 427433
         },
         "stylesheet": {
-          "transferSize": 319003,
-          "resourceSize": 708532
+          "transferSize": 316381,
+          "resourceSize": 706242
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876059,
-          "resourceSize": 1980366
+          "transferSize": 689585,
+          "resourceSize": 1362564
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2627,
-          "resourceSize": 5553
+          "transferSize": 2437,
+          "resourceSize": 4898
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329032,
-          "resourceSize": 1042290
+          "transferSize": 145369,
+          "resourceSize": 427433
         },
         "stylesheet": {
-          "transferSize": 319003,
-          "resourceSize": 708532
+          "transferSize": 316381,
+          "resourceSize": 706242
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876221,
-          "resourceSize": 1980792
+          "transferSize": 689748,
+          "resourceSize": 1362990
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2487,
-          "resourceSize": 5144
+          "transferSize": 2296,
+          "resourceSize": 4489
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329032,
-          "resourceSize": 1042290
+          "transferSize": 145369,
+          "resourceSize": 427433
         },
         "stylesheet": {
-          "transferSize": 319003,
-          "resourceSize": 708532
+          "transferSize": 316381,
+          "resourceSize": 706242
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876087,
-          "resourceSize": 1980383
+          "transferSize": 689609,
+          "resourceSize": 1362581
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2687,
-          "resourceSize": 5663
+          "transferSize": 2498,
+          "resourceSize": 5008
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329032,
-          "resourceSize": 1042290
+          "transferSize": 145369,
+          "resourceSize": 427433
         },
         "stylesheet": {
-          "transferSize": 319003,
-          "resourceSize": 708532
+          "transferSize": 316381,
+          "resourceSize": 706242
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876284,
-          "resourceSize": 1980903
+          "transferSize": 689811,
+          "resourceSize": 1363100
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3267,
-          "resourceSize": 7780
+          "transferSize": 3084,
+          "resourceSize": 7125
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329032,
-          "resourceSize": 1042290
+          "transferSize": 145369,
+          "resourceSize": 427433
         },
         "stylesheet": {
-          "transferSize": 319003,
-          "resourceSize": 708532
+          "transferSize": 316381,
+          "resourceSize": 706242
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876862,
-          "resourceSize": 1983020
+          "transferSize": 690394,
+          "resourceSize": 1365217
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3409,
-          "resourceSize": 7440
+          "transferSize": 3120,
+          "resourceSize": 6334
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731019,
-          "resourceSize": 2200715
+          "transferSize": 151440,
+          "resourceSize": 439829
         },
         "stylesheet": {
-          "transferSize": 319003,
-          "resourceSize": 708532
+          "transferSize": 316381,
+          "resourceSize": 706242
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282171,
-          "resourceSize": 3142353
+          "transferSize": 696854,
+          "resourceSize": 1376822
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.20.0.json
+++ b/.github/page_size_audit_results/v1.20.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.20.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:21.468Z"
+    "generatedAt": "2025-11-27T16:00:58.161Z"
   },
-  "timestamp": "2025-11-22T11:49:21.468Z",
+  "timestamp": "2025-11-27T16:00:58.162Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2288,
-          "resourceSize": 5741
+          "transferSize": 2104,
+          "resourceSize": 5065
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319631,
-          "resourceSize": 716598
+          "transferSize": 317009,
+          "resourceSize": 714308
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879067,
-          "resourceSize": 1994814
+          "transferSize": 692601,
+          "resourceSize": 1376991
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2263,
-          "resourceSize": 5770
+          "transferSize": 2078,
+          "resourceSize": 5094
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319631,
-          "resourceSize": 716598
+          "transferSize": 317009,
+          "resourceSize": 714308
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879046,
-          "resourceSize": 1994843
+          "transferSize": 692582,
+          "resourceSize": 1377020
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5666,
-          "resourceSize": 21799
+          "transferSize": 5377,
+          "resourceSize": 20552
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319631,
-          "resourceSize": 716598
+          "transferSize": 317009,
+          "resourceSize": 714308
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10718,
-          "resourceSize": 10089
+          "transferSize": 7781,
+          "resourceSize": 8841
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069935,
-          "resourceSize": 2953787
+          "transferSize": 484508,
+          "resourceSize": 1188116
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2132,
-          "resourceSize": 5228
+          "transferSize": 1948,
+          "resourceSize": 4552
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319631,
-          "resourceSize": 716598
+          "transferSize": 317009,
+          "resourceSize": 714308
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 878916,
-          "resourceSize": 1994301
+          "transferSize": 692444,
+          "resourceSize": 1376478
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2265,
-          "resourceSize": 5580
+          "transferSize": 2083,
+          "resourceSize": 4904
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319631,
-          "resourceSize": 716598
+          "transferSize": 317009,
+          "resourceSize": 714308
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879052,
-          "resourceSize": 1994653
+          "transferSize": 692583,
+          "resourceSize": 1376830
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2146,
-          "resourceSize": 5210
+          "transferSize": 1960,
+          "resourceSize": 4534
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319631,
-          "resourceSize": 716598
+          "transferSize": 317009,
+          "resourceSize": 714308
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878936,
-          "resourceSize": 1994284
+          "transferSize": 692456,
+          "resourceSize": 1376460
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2337,
-          "resourceSize": 5690
+          "transferSize": 2155,
+          "resourceSize": 5014
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319631,
-          "resourceSize": 716598
+          "transferSize": 317009,
+          "resourceSize": 714308
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879117,
-          "resourceSize": 1994764
+          "transferSize": 692650,
+          "resourceSize": 1376940
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2974,
-          "resourceSize": 8006
+          "transferSize": 2795,
+          "resourceSize": 7330
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319631,
-          "resourceSize": 716598
+          "transferSize": 317009,
+          "resourceSize": 714308
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879758,
-          "resourceSize": 1997080
+          "transferSize": 693294,
+          "resourceSize": 1379256
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3137,
-          "resourceSize": 7615
+          "transferSize": 2838,
+          "resourceSize": 6436
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319631,
-          "resourceSize": 716598
+          "transferSize": 317009,
+          "resourceSize": 714308
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3952,
-          "resourceSize": 1443
+          "transferSize": 1125,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1284816,
-          "resourceSize": 3154964
+          "transferSize": 699488,
+          "resourceSize": 1389360
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.21.0.json
+++ b/.github/page_size_audit_results/v1.21.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.21.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:26.746Z"
+    "generatedAt": "2025-11-27T16:01:10.148Z"
   },
-  "timestamp": "2025-11-22T11:49:26.746Z",
+  "timestamp": "2025-11-27T16:01:10.149Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2341,
-          "resourceSize": 6065
+          "transferSize": 2161,
+          "resourceSize": 5389
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319779,
-          "resourceSize": 717556
+          "transferSize": 317157,
+          "resourceSize": 715266
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879279,
-          "resourceSize": 1996096
+          "transferSize": 692804,
+          "resourceSize": 1378273
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2315,
-          "resourceSize": 6094
+          "transferSize": 2134,
+          "resourceSize": 5418
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319779,
-          "resourceSize": 717556
+          "transferSize": 317157,
+          "resourceSize": 715266
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879248,
-          "resourceSize": 1996125
+          "transferSize": 692783,
+          "resourceSize": 1378302
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6042,
-          "resourceSize": 25104
+          "transferSize": 5731,
+          "resourceSize": 23857
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319779,
-          "resourceSize": 717556
+          "transferSize": 317157,
+          "resourceSize": 715266
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 11918,
-          "resourceSize": 13177
+          "transferSize": 9072,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1071659,
-          "resourceSize": 2961138
+          "transferSize": 486301,
+          "resourceSize": 1195467
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2181,
-          "resourceSize": 5552
+          "transferSize": 2006,
+          "resourceSize": 4876
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319779,
-          "resourceSize": 717556
+          "transferSize": 317157,
+          "resourceSize": 715266
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879110,
-          "resourceSize": 1995583
+          "transferSize": 692658,
+          "resourceSize": 1377760
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2315,
-          "resourceSize": 5904
+          "transferSize": 2136,
+          "resourceSize": 5228
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319779,
-          "resourceSize": 717556
+          "transferSize": 317157,
+          "resourceSize": 715266
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879249,
-          "resourceSize": 1995935
+          "transferSize": 692776,
+          "resourceSize": 1378112
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2198,
-          "resourceSize": 5534
+          "transferSize": 2018,
+          "resourceSize": 4858
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319779,
-          "resourceSize": 717556
+          "transferSize": 317157,
+          "resourceSize": 715266
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879132,
-          "resourceSize": 1995566
+          "transferSize": 692658,
+          "resourceSize": 1377742
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2388,
-          "resourceSize": 6014
+          "transferSize": 2210,
+          "resourceSize": 5338
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319779,
-          "resourceSize": 717556
+          "transferSize": 317157,
+          "resourceSize": 715266
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879317,
-          "resourceSize": 1996046
+          "transferSize": 692852,
+          "resourceSize": 1378222
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3224,
-          "resourceSize": 9490
+          "transferSize": 3045,
+          "resourceSize": 8814
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331589,
-          "resourceSize": 1048058
+          "transferSize": 147926,
+          "resourceSize": 433201
         },
         "stylesheet": {
-          "transferSize": 319779,
-          "resourceSize": 717556
+          "transferSize": 317157,
+          "resourceSize": 715266
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1317,
+          "transferSize": 1318,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880703,
-          "resourceSize": 1999931
+          "transferSize": 694239,
+          "resourceSize": 1382107
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3189,
-          "resourceSize": 7939
+          "transferSize": 2896,
+          "resourceSize": 6760
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733302,
-          "resourceSize": 2205085
+          "transferSize": 153723,
+          "resourceSize": 444199
         },
         "stylesheet": {
-          "transferSize": 319779,
-          "resourceSize": 717556
+          "transferSize": 317157,
+          "resourceSize": 715266
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3943,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1285007,
-          "resourceSize": 3156246
+          "transferSize": 699692,
+          "resourceSize": 1390642
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.22.0.json
+++ b/.github/page_size_audit_results/v1.22.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.22.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:11.828Z"
+    "generatedAt": "2025-11-27T16:01:26.889Z"
   },
-  "timestamp": "2025-11-22T11:52:11.829Z",
+  "timestamp": "2025-11-27T16:01:26.890Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2314,
-          "resourceSize": 6036
+          "transferSize": 2128,
+          "resourceSize": 5360
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319860,
-          "resourceSize": 718051
+          "transferSize": 317238,
+          "resourceSize": 715761
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879388,
-          "resourceSize": 1996682
+          "transferSize": 692912,
+          "resourceSize": 1378859
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2286,
-          "resourceSize": 6058
+          "transferSize": 2100,
+          "resourceSize": 5382
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319860,
-          "resourceSize": 718051
+          "transferSize": 317238,
+          "resourceSize": 715761
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879363,
-          "resourceSize": 1996704
+          "transferSize": 692884,
+          "resourceSize": 1378881
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6017,
-          "resourceSize": 25083
+          "transferSize": 5697,
+          "resourceSize": 23836
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733361,
-          "resourceSize": 2205205
+          "transferSize": 153782,
+          "resourceSize": 444319
         },
         "stylesheet": {
-          "transferSize": 319860,
-          "resourceSize": 718051
+          "transferSize": 317238,
+          "resourceSize": 715761
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12375,
-          "resourceSize": 13177
+          "transferSize": 9073,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1072231,
-          "resourceSize": 2961732
+          "transferSize": 486408,
+          "resourceSize": 1196061
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2155,
-          "resourceSize": 5516
+          "transferSize": 1973,
+          "resourceSize": 4840
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319860,
-          "resourceSize": 718051
+          "transferSize": 317238,
+          "resourceSize": 715761
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879225,
-          "resourceSize": 1996162
+          "transferSize": 692759,
+          "resourceSize": 1378339
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2287,
-          "resourceSize": 5868
+          "transferSize": 2104,
+          "resourceSize": 5192
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319860,
-          "resourceSize": 718051
+          "transferSize": 317238,
+          "resourceSize": 715761
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879353,
-          "resourceSize": 1996514
+          "transferSize": 692894,
+          "resourceSize": 1378691
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2171,
-          "resourceSize": 5498
+          "transferSize": 1986,
+          "resourceSize": 4822
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319860,
-          "resourceSize": 718051
+          "transferSize": 317238,
+          "resourceSize": 715761
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879241,
-          "resourceSize": 1996144
+          "transferSize": 692768,
+          "resourceSize": 1378321
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2360,
-          "resourceSize": 5978
+          "transferSize": 2177,
+          "resourceSize": 5302
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319860,
-          "resourceSize": 718051
+          "transferSize": 317238,
+          "resourceSize": 715761
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879430,
-          "resourceSize": 1996625
+          "transferSize": 692956,
+          "resourceSize": 1378801
         }
       },
       "themeResources": {
@@ -509,20 +509,20 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3202,
-          "resourceSize": 9506
+          "transferSize": 3019,
+          "resourceSize": 8830
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319860,
-          "resourceSize": 718051
+          "transferSize": 317238,
+          "resourceSize": 715761
         },
         "image": {
           "transferSize": 224175,
@@ -533,12 +533,12 @@
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880819,
-          "resourceSize": 2000562
+          "transferSize": 694350,
+          "resourceSize": 1382738
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3161,
-          "resourceSize": 7903
+          "transferSize": 2863,
+          "resourceSize": 6724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733361,
-          "resourceSize": 2205205
+          "transferSize": 153782,
+          "resourceSize": 444319
         },
         "stylesheet": {
-          "transferSize": 319860,
-          "resourceSize": 718051
+          "transferSize": 317238,
+          "resourceSize": 715761
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1119,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1285123,
-          "resourceSize": 3156825
+          "transferSize": 699795,
+          "resourceSize": 1391221
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.23.0.json
+++ b/.github/page_size_audit_results/v1.23.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.23.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:19.881Z"
+    "generatedAt": "2025-11-27T16:03:35.278Z"
   },
-  "timestamp": "2025-11-22T11:49:19.881Z",
+  "timestamp": "2025-11-27T16:03:35.278Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2315,
-          "resourceSize": 6049
+          "transferSize": 2126,
+          "resourceSize": 5373
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879414,
-          "resourceSize": 1996779
+          "transferSize": 692943,
+          "resourceSize": 1378956
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2288,
-          "resourceSize": 6058
+          "transferSize": 2101,
+          "resourceSize": 5382
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879393,
-          "resourceSize": 1996788
+          "transferSize": 692923,
+          "resourceSize": 1378965
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6020,
-          "resourceSize": 25083
+          "transferSize": 5699,
+          "resourceSize": 23836
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733361,
-          "resourceSize": 2205205
+          "transferSize": 153782,
+          "resourceSize": 444319
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12305,
-          "resourceSize": 13177
+          "transferSize": 9056,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1072196,
-          "resourceSize": 2961816
+          "transferSize": 486425,
+          "resourceSize": 1196145
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2158,
-          "resourceSize": 5516
+          "transferSize": 1974,
+          "resourceSize": 4840
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879261,
-          "resourceSize": 1996246
+          "transferSize": 692791,
+          "resourceSize": 1378423
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2289,
-          "resourceSize": 5868
+          "transferSize": 2104,
+          "resourceSize": 5192
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879390,
-          "resourceSize": 1996598
+          "transferSize": 692918,
+          "resourceSize": 1378775
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2172,
-          "resourceSize": 5498
+          "transferSize": 1987,
+          "resourceSize": 4822
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879277,
-          "resourceSize": 1996228
+          "transferSize": 692805,
+          "resourceSize": 1378405
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2362,
-          "resourceSize": 5978
+          "transferSize": 2177,
+          "resourceSize": 5302
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879467,
-          "resourceSize": 1996709
+          "transferSize": 692994,
+          "resourceSize": 1378885
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3209,
-          "resourceSize": 9577
+          "transferSize": 3025,
+          "resourceSize": 8901
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1318,
+          "transferSize": 1315,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880861,
-          "resourceSize": 2000717
+          "transferSize": 694388,
+          "resourceSize": 1382893
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3164,
-          "resourceSize": 7903
+          "transferSize": 2864,
+          "resourceSize": 6724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733361,
-          "resourceSize": 2205205
+          "transferSize": 153782,
+          "resourceSize": 444319
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3945,
-          "resourceSize": 1443
+          "transferSize": 1129,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1285156,
-          "resourceSize": 3156909
+          "transferSize": 699838,
+          "resourceSize": 1391305
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.24.0.json
+++ b/.github/page_size_audit_results/v1.24.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.24.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:00.417Z"
+    "generatedAt": "2025-11-27T16:00:53.929Z"
   },
-  "timestamp": "2025-11-22T11:52:00.417Z",
+  "timestamp": "2025-11-27T16:00:53.929Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2314,
-          "resourceSize": 6049
+          "transferSize": 2127,
+          "resourceSize": 5373
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879420,
-          "resourceSize": 1996779
+          "transferSize": 692938,
+          "resourceSize": 1378956
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2287,
-          "resourceSize": 6058
+          "transferSize": 2101,
+          "resourceSize": 5382
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879389,
-          "resourceSize": 1996788
+          "transferSize": 692916,
+          "resourceSize": 1378965
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6018,
-          "resourceSize": 25083
+          "transferSize": 5697,
+          "resourceSize": 23836
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733361,
-          "resourceSize": 2205205
+          "transferSize": 153782,
+          "resourceSize": 444319
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12256,
-          "resourceSize": 13177
+          "transferSize": 9033,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1072145,
-          "resourceSize": 2961816
+          "transferSize": 486400,
+          "resourceSize": 1196145
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2156,
-          "resourceSize": 5516
+          "transferSize": 1974,
+          "resourceSize": 4840
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879256,
-          "resourceSize": 1996246
+          "transferSize": 692788,
+          "resourceSize": 1378423
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2292,
-          "resourceSize": 5909
+          "transferSize": 2107,
+          "resourceSize": 5233
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879392,
-          "resourceSize": 1996639
+          "transferSize": 692921,
+          "resourceSize": 1378816
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2171,
-          "resourceSize": 5498
+          "transferSize": 1987,
+          "resourceSize": 4822
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879278,
-          "resourceSize": 1996229
+          "transferSize": 692804,
+          "resourceSize": 1378405
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2364,
-          "resourceSize": 6019
+          "transferSize": 2180,
+          "resourceSize": 5343
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879462,
-          "resourceSize": 1996750
+          "transferSize": 693000,
+          "resourceSize": 1378926
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3207,
-          "resourceSize": 9577
+          "transferSize": 3026,
+          "resourceSize": 8901
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331648,
-          "resourceSize": 1048178
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1311,
+          "transferSize": 1317,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880852,
-          "resourceSize": 2000717
+          "transferSize": 694391,
+          "resourceSize": 1382893
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3161,
-          "resourceSize": 7903
+          "transferSize": 2863,
+          "resourceSize": 6724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733361,
-          "resourceSize": 2205205
+          "transferSize": 153782,
+          "resourceSize": 444319
         },
         "stylesheet": {
-          "transferSize": 319892,
-          "resourceSize": 718135
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3948,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1285156,
-          "resourceSize": 3156909
+          "transferSize": 699828,
+          "resourceSize": 1391305
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.25.0.json
+++ b/.github/page_size_audit_results/v1.25.0.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.25.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:16.515Z"
+    "generatedAt": "2025-11-27T16:03:38.689Z"
   },
-  "timestamp": "2025-11-22T11:49:16.515Z",
+  "timestamp": "2025-11-27T16:03:38.690Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2311,
-          "resourceSize": 6049
+          "transferSize": 2123,
+          "resourceSize": 5373
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879560,
-          "resourceSize": 1997142
+          "transferSize": 693087,
+          "resourceSize": 1379319
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2287,
-          "resourceSize": 6077
+          "transferSize": 2100,
+          "resourceSize": 5401
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879544,
-          "resourceSize": 1997170
+          "transferSize": 693065,
+          "resourceSize": 1379347
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6015,
-          "resourceSize": 25083
+          "transferSize": 5694,
+          "resourceSize": 23836
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733466,
-          "resourceSize": 2205431
+          "transferSize": 153887,
+          "resourceSize": 444545
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12340,
-          "resourceSize": 13177
+          "transferSize": 9053,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1072373,
-          "resourceSize": 2962179
+          "transferSize": 486564,
+          "resourceSize": 1196508
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2152,
-          "resourceSize": 5516
+          "transferSize": 1970,
+          "resourceSize": 4840
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879402,
-          "resourceSize": 1996609
+          "transferSize": 692937,
+          "resourceSize": 1378786
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2287,
-          "resourceSize": 5909
+          "transferSize": 2102,
+          "resourceSize": 5233
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879543,
-          "resourceSize": 1997002
+          "transferSize": 693063,
+          "resourceSize": 1379179
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2167,
-          "resourceSize": 5498
+          "transferSize": 1983,
+          "resourceSize": 4822
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879422,
-          "resourceSize": 1996592
+          "transferSize": 692946,
+          "resourceSize": 1378768
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2359,
-          "resourceSize": 6019
+          "transferSize": 2176,
+          "resourceSize": 5343
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879612,
-          "resourceSize": 1997113
+          "transferSize": 693141,
+          "resourceSize": 1379289
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3206,
-          "resourceSize": 9577
+          "transferSize": 3022,
+          "resourceSize": 8901
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1312,
+          "transferSize": 1322,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880999,
-          "resourceSize": 2001080
+          "transferSize": 694539,
+          "resourceSize": 1383256
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3162,
-          "resourceSize": 7903
+          "transferSize": 2859,
+          "resourceSize": 6724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733466,
-          "resourceSize": 2205431
+          "transferSize": 153887,
+          "resourceSize": 444545
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3944,
-          "resourceSize": 1443
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1285300,
-          "resourceSize": 3157272
+          "transferSize": 699973,
+          "resourceSize": 1391668
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.26.0.json
+++ b/.github/page_size_audit_results/v1.26.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.26.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:22.050Z"
+    "generatedAt": "2025-11-27T16:01:02.895Z"
   },
-  "timestamp": "2025-11-22T11:49:22.051Z",
+  "timestamp": "2025-11-27T16:01:02.895Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2313,
-          "resourceSize": 6049
+          "transferSize": 2124,
+          "resourceSize": 5373
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879566,
-          "resourceSize": 1997142
+          "transferSize": 693085,
+          "resourceSize": 1379319
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2291,
-          "resourceSize": 6077
+          "transferSize": 2101,
+          "resourceSize": 5401
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879543,
-          "resourceSize": 1997170
+          "transferSize": 693066,
+          "resourceSize": 1379347
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6019,
-          "resourceSize": 25083
+          "transferSize": 5696,
+          "resourceSize": 23836
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733466,
-          "resourceSize": 2205431
+          "transferSize": 153887,
+          "resourceSize": 444545
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 11926,
-          "resourceSize": 13177
+          "transferSize": 9088,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1071963,
-          "resourceSize": 2962179
+          "transferSize": 486601,
+          "resourceSize": 1196508
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2156,
-          "resourceSize": 5516
+          "transferSize": 1971,
+          "resourceSize": 4840
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879406,
-          "resourceSize": 1996609
+          "transferSize": 692935,
+          "resourceSize": 1378786
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2291,
-          "resourceSize": 5909
+          "transferSize": 2104,
+          "resourceSize": 5233
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879544,
-          "resourceSize": 1997002
+          "transferSize": 693075,
+          "resourceSize": 1379179
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2172,
-          "resourceSize": 5498
+          "transferSize": 1984,
+          "resourceSize": 4822
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879424,
-          "resourceSize": 1996591
+          "transferSize": 692946,
+          "resourceSize": 1378768
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2364,
-          "resourceSize": 6019
+          "transferSize": 2177,
+          "resourceSize": 5343
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879618,
-          "resourceSize": 1997113
+          "transferSize": 693141,
+          "resourceSize": 1379289
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3212,
-          "resourceSize": 9590
+          "transferSize": 3023,
+          "resourceSize": 8914
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 331753,
-          "resourceSize": 1048404
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1327,
+          "transferSize": 1320,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 881020,
-          "resourceSize": 2001093
+          "transferSize": 694538,
+          "resourceSize": 1383269
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3162,
-          "resourceSize": 7903
+          "transferSize": 2860,
+          "resourceSize": 6724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 733466,
-          "resourceSize": 2205431
+          "transferSize": 153887,
+          "resourceSize": 444545
         },
         "stylesheet": {
-          "transferSize": 319934,
-          "resourceSize": 718272
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3950,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1285306,
-          "resourceSize": 3157272
+          "transferSize": 699975,
+          "resourceSize": 1391668
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.27.0.json
+++ b/.github/page_size_audit_results/v1.27.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.27.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:22.565Z"
+    "generatedAt": "2025-11-27T16:01:10.451Z"
   },
-  "timestamp": "2025-11-22T11:49:22.565Z",
+  "timestamp": "2025-11-27T16:01:10.451Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2323,
-          "resourceSize": 6209
+          "transferSize": 2137,
+          "resourceSize": 5533
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 332294,
-          "resourceSize": 1047979
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 319918,
-          "resourceSize": 718272
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880095,
-          "resourceSize": 1996877
+          "transferSize": 693628,
+          "resourceSize": 1379054
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2296,
-          "resourceSize": 6237
+          "transferSize": 2113,
+          "resourceSize": 5561
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 332294,
-          "resourceSize": 1047979
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 319918,
-          "resourceSize": 718272
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880071,
-          "resourceSize": 1996905
+          "transferSize": 693605,
+          "resourceSize": 1379082
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6022,
-          "resourceSize": 25243
+          "transferSize": 5706,
+          "resourceSize": 23996
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 734007,
-          "resourceSize": 2205006
+          "transferSize": 154428,
+          "resourceSize": 444120
         },
         "stylesheet": {
-          "transferSize": 319918,
-          "resourceSize": 718272
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12279,
-          "resourceSize": 13177
+          "transferSize": 9094,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1072844,
-          "resourceSize": 2961914
+          "transferSize": 487142,
+          "resourceSize": 1196243
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2160,
-          "resourceSize": 5676
+          "transferSize": 1981,
+          "resourceSize": 5000
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 332294,
-          "resourceSize": 1047979
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 319918,
-          "resourceSize": 718272
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 879936,
-          "resourceSize": 1996344
+          "transferSize": 693475,
+          "resourceSize": 1378521
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2296,
-          "resourceSize": 6069
+          "transferSize": 2114,
+          "resourceSize": 5393
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 332294,
-          "resourceSize": 1047979
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 319918,
-          "resourceSize": 718272
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 880071,
-          "resourceSize": 1996737
+          "transferSize": 693606,
+          "resourceSize": 1378914
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2177,
-          "resourceSize": 5658
+          "transferSize": 1994,
+          "resourceSize": 4982
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 332294,
-          "resourceSize": 1047979
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 319918,
-          "resourceSize": 718272
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879956,
-          "resourceSize": 1996327
+          "transferSize": 693483,
+          "resourceSize": 1378503
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2369,
-          "resourceSize": 6179
+          "transferSize": 2187,
+          "resourceSize": 5503
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 332294,
-          "resourceSize": 1047979
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 319918,
-          "resourceSize": 718272
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 880146,
-          "resourceSize": 1996848
+          "transferSize": 693680,
+          "resourceSize": 1379024
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3216,
-          "resourceSize": 9750
+          "transferSize": 3031,
+          "resourceSize": 9074
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 332294,
-          "resourceSize": 1047979
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 319918,
-          "resourceSize": 718272
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1317,
+          "transferSize": 1312,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 881539,
-          "resourceSize": 2000828
+          "transferSize": 695063,
+          "resourceSize": 1383004
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3168,
-          "resourceSize": 8063
+          "transferSize": 2868,
+          "resourceSize": 6884
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 734007,
-          "resourceSize": 2205006
+          "transferSize": 154428,
+          "resourceSize": 444120
         },
         "stylesheet": {
-          "transferSize": 319918,
-          "resourceSize": 718272
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3945,
-          "resourceSize": 1443
+          "transferSize": 1124,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1285832,
-          "resourceSize": 3157007
+          "transferSize": 700509,
+          "resourceSize": 1391403
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.28.0.json
+++ b/.github/page_size_audit_results/v1.28.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.28.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:54:47.798Z"
+    "generatedAt": "2025-11-27T16:04:12.530Z"
   },
-  "timestamp": "2025-11-22T11:54:47.799Z",
+  "timestamp": "2025-11-27T16:04:12.530Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2327,
-          "resourceSize": 6216
+          "transferSize": 2135,
+          "resourceSize": 5540
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876956,
-          "resourceSize": 1966322
+          "transferSize": 690475,
+          "resourceSize": 1348499
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2299,
-          "resourceSize": 6237
+          "transferSize": 2111,
+          "resourceSize": 5561
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876925,
-          "resourceSize": 1966343
+          "transferSize": 690448,
+          "resourceSize": 1348520
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6026,
-          "resourceSize": 25245
+          "transferSize": 5703,
+          "resourceSize": 23998
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730862,
-          "resourceSize": 2174441
+          "transferSize": 151283,
+          "resourceSize": 413555
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12336,
-          "resourceSize": 13177
+          "transferSize": 9053,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069757,
-          "resourceSize": 2931354
+          "transferSize": 483950,
+          "resourceSize": 1165683
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2165,
-          "resourceSize": 5676
+          "transferSize": 1980,
+          "resourceSize": 5000
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876791,
-          "resourceSize": 1965782
+          "transferSize": 690323,
+          "resourceSize": 1347959
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2298,
-          "resourceSize": 6069
+          "transferSize": 2112,
+          "resourceSize": 5393
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 762,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876929,
-          "resourceSize": 1966175
+          "transferSize": 690446,
+          "resourceSize": 1348352
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2180,
-          "resourceSize": 5658
+          "transferSize": 1991,
+          "resourceSize": 4982
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876807,
-          "resourceSize": 1965765
+          "transferSize": 690330,
+          "resourceSize": 1347941
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2373,
-          "resourceSize": 6179
+          "transferSize": 2185,
+          "resourceSize": 5503
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877002,
-          "resourceSize": 1966286
+          "transferSize": 690522,
+          "resourceSize": 1348462
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3220,
-          "resourceSize": 9750
+          "transferSize": 3030,
+          "resourceSize": 9074
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1326,
+          "transferSize": 1314,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878404,
-          "resourceSize": 1970266
+          "transferSize": 691916,
+          "resourceSize": 1352442
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3173,
-          "resourceSize": 8065
+          "transferSize": 2867,
+          "resourceSize": 6886
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730862,
-          "resourceSize": 2174441
+          "transferSize": 151283,
+          "resourceSize": 413555
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3949,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282693,
-          "resourceSize": 3126447
+          "transferSize": 697356,
+          "resourceSize": 1360843
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.29.0.json
+++ b/.github/page_size_audit_results/v1.29.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.29.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:26.794Z"
+    "generatedAt": "2025-11-27T16:01:07.684Z"
   },
-  "timestamp": "2025-11-22T11:49:26.794Z",
+  "timestamp": "2025-11-27T16:01:07.685Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2326,
-          "resourceSize": 6221
+          "transferSize": 2134,
+          "resourceSize": 5545
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876952,
-          "resourceSize": 1966327
+          "transferSize": 690478,
+          "resourceSize": 1348504
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2299,
-          "resourceSize": 6242
+          "transferSize": 2110,
+          "resourceSize": 5566
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876927,
-          "resourceSize": 1966348
+          "transferSize": 690454,
+          "resourceSize": 1348525
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6020,
-          "resourceSize": 25250
+          "transferSize": 5705,
+          "resourceSize": 24003
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730862,
-          "resourceSize": 2174441
+          "transferSize": 151283,
+          "resourceSize": 413555
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12259,
-          "resourceSize": 13177
+          "transferSize": 9086,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069674,
-          "resourceSize": 2931359
+          "transferSize": 483985,
+          "resourceSize": 1165688
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2163,
-          "resourceSize": 5681
+          "transferSize": 1979,
+          "resourceSize": 5005
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876792,
-          "resourceSize": 1965787
+          "transferSize": 690327,
+          "resourceSize": 1347964
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2297,
-          "resourceSize": 6074
+          "transferSize": 2111,
+          "resourceSize": 5398
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876920,
-          "resourceSize": 1966180
+          "transferSize": 690453,
+          "resourceSize": 1348357
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2176,
-          "resourceSize": 5663
+          "transferSize": 1992,
+          "resourceSize": 4987
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876810,
-          "resourceSize": 1965770
+          "transferSize": 690331,
+          "resourceSize": 1347946
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2370,
-          "resourceSize": 6184
+          "transferSize": 2185,
+          "resourceSize": 5508
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877001,
-          "resourceSize": 1966291
+          "transferSize": 690529,
+          "resourceSize": 1348467
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3219,
-          "resourceSize": 9755
+          "transferSize": 3029,
+          "resourceSize": 9079
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1320,
+          "transferSize": 1319,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878397,
-          "resourceSize": 1970271
+          "transferSize": 691920,
+          "resourceSize": 1352447
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3166,
-          "resourceSize": 8070
+          "transferSize": 2867,
+          "resourceSize": 6891
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730862,
-          "resourceSize": 2174441
+          "transferSize": 151283,
+          "resourceSize": 413555
         },
         "stylesheet": {
-          "transferSize": 319915,
-          "resourceSize": 718275
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282684,
-          "resourceSize": 3126452
+          "transferSize": 697362,
+          "resourceSize": 1360848
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.29.1.json
+++ b/.github/page_size_audit_results/v1.29.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.29.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:54:29.457Z"
+    "generatedAt": "2025-11-27T16:03:42.824Z"
   },
-  "timestamp": "2025-11-22T11:54:29.457Z",
+  "timestamp": "2025-11-27T16:03:42.825Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2326,
-          "resourceSize": 6221
+          "transferSize": 2135,
+          "resourceSize": 5545
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319920,
-          "resourceSize": 718293
+          "transferSize": 317298,
+          "resourceSize": 716003
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876962,
-          "resourceSize": 1966345
+          "transferSize": 690477,
+          "resourceSize": 1348522
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2299,
-          "resourceSize": 6242
+          "transferSize": 2111,
+          "resourceSize": 5566
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319920,
-          "resourceSize": 718293
+          "transferSize": 317298,
+          "resourceSize": 716003
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876931,
-          "resourceSize": 1966366
+          "transferSize": 690457,
+          "resourceSize": 1348543
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6023,
-          "resourceSize": 25250
+          "transferSize": 5706,
+          "resourceSize": 24003
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730862,
-          "resourceSize": 2174441
+          "transferSize": 151283,
+          "resourceSize": 413555
         },
         "stylesheet": {
-          "transferSize": 319920,
-          "resourceSize": 718293
+          "transferSize": 317298,
+          "resourceSize": 716003
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12282,
-          "resourceSize": 13177
+          "transferSize": 9045,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069705,
-          "resourceSize": 2931377
+          "transferSize": 483950,
+          "resourceSize": 1165706
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2163,
-          "resourceSize": 5681
+          "transferSize": 1981,
+          "resourceSize": 5005
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319920,
-          "resourceSize": 718293
+          "transferSize": 317298,
+          "resourceSize": 716003
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876797,
-          "resourceSize": 1965805
+          "transferSize": 690325,
+          "resourceSize": 1347982
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2297,
-          "resourceSize": 6074
+          "transferSize": 2112,
+          "resourceSize": 5398
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319920,
-          "resourceSize": 718293
+          "transferSize": 317298,
+          "resourceSize": 716003
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876930,
-          "resourceSize": 1966198
+          "transferSize": 690460,
+          "resourceSize": 1348375
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2178,
-          "resourceSize": 5663
+          "transferSize": 1992,
+          "resourceSize": 4987
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319920,
-          "resourceSize": 718293
+          "transferSize": 317298,
+          "resourceSize": 716003
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876816,
-          "resourceSize": 1965787
+          "transferSize": 690338,
+          "resourceSize": 1347964
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2371,
-          "resourceSize": 6184
+          "transferSize": 2185,
+          "resourceSize": 5508
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319920,
-          "resourceSize": 718293
+          "transferSize": 317298,
+          "resourceSize": 716003
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877007,
-          "resourceSize": 1966309
+          "transferSize": 690529,
+          "resourceSize": 1348485
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3219,
-          "resourceSize": 9755
+          "transferSize": 3030,
+          "resourceSize": 9079
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329149,
-          "resourceSize": 1017414
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319920,
-          "resourceSize": 718293
+          "transferSize": 317298,
+          "resourceSize": 716003
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1326,
+          "transferSize": 1313,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878408,
-          "resourceSize": 1970289
+          "transferSize": 691920,
+          "resourceSize": 1352465
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3167,
-          "resourceSize": 8070
+          "transferSize": 2866,
+          "resourceSize": 6891
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730862,
-          "resourceSize": 2174441
+          "transferSize": 151283,
+          "resourceSize": 413555
         },
         "stylesheet": {
-          "transferSize": 319920,
-          "resourceSize": 718293
+          "transferSize": 317298,
+          "resourceSize": 716003
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282689,
-          "resourceSize": 3126470
+          "transferSize": 697363,
+          "resourceSize": 1360866
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.3.0.json
+++ b/.github/page_size_audit_results/v1.3.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.3.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:20.804Z"
+    "generatedAt": "2025-11-27T16:03:34.316Z"
   },
-  "timestamp": "2025-11-22T11:49:20.804Z",
+  "timestamp": "2025-11-27T16:03:34.317Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2761,
-          "resourceSize": 6027
+          "transferSize": 2582,
+          "resourceSize": 5372
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876981,
-          "resourceSize": 1984780
+          "transferSize": 690515,
+          "resourceSize": 1366978
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2637,
-          "resourceSize": 5743
+          "transferSize": 2450,
+          "resourceSize": 5088
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876855,
-          "resourceSize": 1984496
+          "transferSize": 690383,
+          "resourceSize": 1366694
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5519,
-          "resourceSize": 17915
+          "transferSize": 5213,
+          "resourceSize": 16726
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7851,
-          "resourceSize": 6933
+          "transferSize": 4978,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064631,
-          "resourceSize": 2937825
+          "transferSize": 479251,
+          "resourceSize": 1172212
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2460,
-          "resourceSize": 5127
+          "transferSize": 2275,
+          "resourceSize": 4472
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876679,
-          "resourceSize": 1983880
+          "transferSize": 690206,
+          "resourceSize": 1366078
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2625,
-          "resourceSize": 5553
+          "transferSize": 2440,
+          "resourceSize": 4898
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876846,
-          "resourceSize": 1984306
+          "transferSize": 690376,
+          "resourceSize": 1366504
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2486,
-          "resourceSize": 5144
+          "transferSize": 2299,
+          "resourceSize": 4489
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876710,
-          "resourceSize": 1983897
+          "transferSize": 690233,
+          "resourceSize": 1366095
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2686,
-          "resourceSize": 5663
+          "transferSize": 2501,
+          "resourceSize": 5008
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876911,
-          "resourceSize": 1984417
+          "transferSize": 690436,
+          "resourceSize": 1366614
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3266,
-          "resourceSize": 7780
+          "transferSize": 3088,
+          "resourceSize": 7125
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877492,
-          "resourceSize": 1986534
+          "transferSize": 691029,
+          "resourceSize": 1368731
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3431,
-          "resourceSize": 7510
+          "transferSize": 3147,
+          "resourceSize": 6404
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3945,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282813,
-          "resourceSize": 3145937
+          "transferSize": 697502,
+          "resourceSize": 1380406
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.30.0.json
+++ b/.github/page_size_audit_results/v1.30.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.30.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:08.589Z"
+    "generatedAt": "2025-11-27T16:01:06.864Z"
   },
-  "timestamp": "2025-11-22T11:52:08.589Z",
+  "timestamp": "2025-11-27T16:01:06.864Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2333,
-          "resourceSize": 6300
+          "transferSize": 2136,
+          "resourceSize": 5624
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876976,
-          "resourceSize": 1966375
+          "transferSize": 690495,
+          "resourceSize": 1348552
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2305,
-          "resourceSize": 6321
+          "transferSize": 2109,
+          "resourceSize": 5645
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876948,
-          "resourceSize": 1966396
+          "transferSize": 690470,
+          "resourceSize": 1348573
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6028,
-          "resourceSize": 25345
+          "transferSize": 5705,
+          "resourceSize": 24098
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 11928,
-          "resourceSize": 13177
+          "transferSize": 9057,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069365,
-          "resourceSize": 2931423
+          "transferSize": 483970,
+          "resourceSize": 1165752
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2169,
-          "resourceSize": 5760
+          "transferSize": 1979,
+          "resourceSize": 5084
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876808,
-          "resourceSize": 1965835
+          "transferSize": 690337,
+          "resourceSize": 1348012
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2304,
-          "resourceSize": 6153
+          "transferSize": 2112,
+          "resourceSize": 5477
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876944,
-          "resourceSize": 1966228
+          "transferSize": 690471,
+          "resourceSize": 1348405
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2185,
-          "resourceSize": 5742
+          "transferSize": 1990,
+          "resourceSize": 5066
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876832,
-          "resourceSize": 1965818
+          "transferSize": 690349,
+          "resourceSize": 1347994
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2377,
-          "resourceSize": 6263
+          "transferSize": 2186,
+          "resourceSize": 5587
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877021,
-          "resourceSize": 1966339
+          "transferSize": 690537,
+          "resourceSize": 1348515
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3229,
-          "resourceSize": 9834
+          "transferSize": 3029,
+          "resourceSize": 9158
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1318,
+          "transferSize": 1324,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878419,
-          "resourceSize": 1970319
+          "transferSize": 691939,
+          "resourceSize": 1352495
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3179,
-          "resourceSize": 8171
+          "transferSize": 2872,
+          "resourceSize": 6992
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3948,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282712,
-          "resourceSize": 3126522
+          "transferSize": 697378,
+          "resourceSize": 1360918
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.31.0.json
+++ b/.github/page_size_audit_results/v1.31.0.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.31.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:32.905Z"
+    "generatedAt": "2025-11-27T16:01:14.409Z"
   },
-  "timestamp": "2025-11-22T11:49:32.906Z",
+  "timestamp": "2025-11-27T16:01:14.409Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2334,
-          "resourceSize": 6304
+          "transferSize": 2137,
+          "resourceSize": 5628
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876973,
-          "resourceSize": 1966379
+          "transferSize": 690491,
+          "resourceSize": 1348556
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2308,
-          "resourceSize": 6325
+          "transferSize": 2111,
+          "resourceSize": 5649
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876949,
-          "resourceSize": 1966400
+          "transferSize": 690468,
+          "resourceSize": 1348577
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6033,
-          "resourceSize": 25353
+          "transferSize": 5707,
+          "resourceSize": 24106
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12312,
-          "resourceSize": 13177
+          "transferSize": 9095,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069754,
-          "resourceSize": 2931431
+          "transferSize": 484010,
+          "resourceSize": 1165760
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2170,
-          "resourceSize": 5764
+          "transferSize": 1976,
+          "resourceSize": 5088
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876816,
-          "resourceSize": 1965839
+          "transferSize": 690329,
+          "resourceSize": 1348016
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2306,
-          "resourceSize": 6157
+          "transferSize": 2112,
+          "resourceSize": 5481
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876950,
-          "resourceSize": 1966232
+          "transferSize": 690470,
+          "resourceSize": 1348409
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2185,
-          "resourceSize": 5746
+          "transferSize": 1989,
+          "resourceSize": 5070
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876825,
-          "resourceSize": 1965821
+          "transferSize": 690349,
+          "resourceSize": 1347998
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2379,
-          "resourceSize": 6267
+          "transferSize": 2187,
+          "resourceSize": 5591
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877020,
-          "resourceSize": 1966343
+          "transferSize": 690540,
+          "resourceSize": 1348519
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3231,
-          "resourceSize": 9838
+          "transferSize": 3030,
+          "resourceSize": 9162
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1318,
+          "transferSize": 1312,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878421,
-          "resourceSize": 1970323
+          "transferSize": 691928,
+          "resourceSize": 1352499
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3181,
-          "resourceSize": 8175
+          "transferSize": 2874,
+          "resourceSize": 6996
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319904,
-          "resourceSize": 718238
+          "transferSize": 317282,
+          "resourceSize": 715948
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3945,
-          "resourceSize": 1443
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282711,
-          "resourceSize": 3126526
+          "transferSize": 697383,
+          "resourceSize": 1360922
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.32.0.json
+++ b/.github/page_size_audit_results/v1.32.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.32.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:20.458Z"
+    "generatedAt": "2025-11-27T16:01:16.221Z"
   },
-  "timestamp": "2025-11-22T11:49:20.459Z",
+  "timestamp": "2025-11-27T16:01:16.221Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2331,
-          "resourceSize": 6304
+          "transferSize": 2136,
+          "resourceSize": 5628
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319927,
-          "resourceSize": 718351
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876999,
-          "resourceSize": 1966492
+          "transferSize": 690520,
+          "resourceSize": 1348669
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2303,
-          "resourceSize": 6325
+          "transferSize": 2110,
+          "resourceSize": 5649
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319927,
-          "resourceSize": 718351
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876965,
-          "resourceSize": 1966513
+          "transferSize": 690494,
+          "resourceSize": 1348690
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6039,
-          "resourceSize": 25427
+          "transferSize": 5723,
+          "resourceSize": 24180
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319927,
-          "resourceSize": 718351
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12337,
-          "resourceSize": 13177
+          "transferSize": 9417,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069808,
-          "resourceSize": 2931618
+          "transferSize": 484371,
+          "resourceSize": 1165947
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2166,
-          "resourceSize": 5764
+          "transferSize": 1975,
+          "resourceSize": 5088
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319927,
-          "resourceSize": 718351
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876833,
-          "resourceSize": 1965952
+          "transferSize": 690361,
+          "resourceSize": 1348129
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2303,
-          "resourceSize": 6157
+          "transferSize": 2112,
+          "resourceSize": 5481
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319927,
-          "resourceSize": 718351
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876967,
-          "resourceSize": 1966345
+          "transferSize": 690492,
+          "resourceSize": 1348522
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2183,
-          "resourceSize": 5746
+          "transferSize": 1988,
+          "resourceSize": 5070
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319927,
-          "resourceSize": 718351
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876846,
-          "resourceSize": 1965934
+          "transferSize": 690367,
+          "resourceSize": 1348111
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2375,
-          "resourceSize": 6267
+          "transferSize": 2185,
+          "resourceSize": 5591
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319927,
-          "resourceSize": 718351
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877040,
-          "resourceSize": 1966456
+          "transferSize": 690561,
+          "resourceSize": 1348632
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3227,
-          "resourceSize": 9838
+          "transferSize": 3028,
+          "resourceSize": 9162
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319927,
-          "resourceSize": 718351
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1317,
+          "transferSize": 1314,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878439,
-          "resourceSize": 1970436
+          "transferSize": 691951,
+          "resourceSize": 1352612
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3177,
-          "resourceSize": 8175
+          "transferSize": 2874,
+          "resourceSize": 6996
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319927,
-          "resourceSize": 718351
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282732,
-          "resourceSize": 3126639
+          "transferSize": 697406,
+          "resourceSize": 1361035
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.32.1.json
+++ b/.github/page_size_audit_results/v1.32.1.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.32.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:04.773Z"
+    "generatedAt": "2025-11-27T16:00:54.802Z"
   },
-  "timestamp": "2025-11-22T11:52:04.773Z",
+  "timestamp": "2025-11-27T16:00:54.803Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2325,
-          "resourceSize": 6304
+          "transferSize": 2134,
+          "resourceSize": 5628
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877025,
-          "resourceSize": 1966629
+          "transferSize": 690549,
+          "resourceSize": 1348806
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2298,
-          "resourceSize": 6325
+          "transferSize": 2108,
+          "resourceSize": 5649
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877000,
-          "resourceSize": 1966650
+          "transferSize": 690526,
+          "resourceSize": 1348827
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6035,
-          "resourceSize": 25513
+          "transferSize": 5716,
+          "resourceSize": 24226
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12337,
-          "resourceSize": 13177
+          "transferSize": 9032,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069841,
-          "resourceSize": 2931841
+          "transferSize": 484016,
+          "resourceSize": 1166130
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2162,
-          "resourceSize": 5764
+          "transferSize": 1973,
+          "resourceSize": 5088
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876867,
-          "resourceSize": 1966089
+          "transferSize": 690387,
+          "resourceSize": 1348266
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2297,
-          "resourceSize": 6157
+          "transferSize": 2110,
+          "resourceSize": 5481
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877001,
-          "resourceSize": 1966482
+          "transferSize": 690523,
+          "resourceSize": 1348659
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2179,
-          "resourceSize": 5746
+          "transferSize": 1987,
+          "resourceSize": 5070
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876877,
-          "resourceSize": 1966072
+          "transferSize": 690402,
+          "resourceSize": 1348248
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2370,
-          "resourceSize": 6267
+          "transferSize": 2183,
+          "resourceSize": 5591
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877069,
-          "resourceSize": 1966593
+          "transferSize": 690595,
+          "resourceSize": 1348769
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3222,
-          "resourceSize": 9838
+          "transferSize": 3028,
+          "resourceSize": 9162
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1318,
+          "transferSize": 1314,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878472,
-          "resourceSize": 1970573
+          "transferSize": 691988,
+          "resourceSize": 1352749
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3172,
-          "resourceSize": 8175
+          "transferSize": 2870,
+          "resourceSize": 6996
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3948,
-          "resourceSize": 1443
+          "transferSize": 1118,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282765,
-          "resourceSize": 3126776
+          "transferSize": 697431,
+          "resourceSize": 1361172
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.33.0.json
+++ b/.github/page_size_audit_results/v1.33.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.33.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:21.367Z"
+    "generatedAt": "2025-11-27T16:06:21.402Z"
   },
-  "timestamp": "2025-11-22T11:49:21.368Z",
+  "timestamp": "2025-11-27T16:06:21.402Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2334,
-          "resourceSize": 6304
+          "transferSize": 2133,
+          "resourceSize": 5628
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877036,
-          "resourceSize": 1966629
+          "transferSize": 690545,
+          "resourceSize": 1348806
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2308,
-          "resourceSize": 6325
+          "transferSize": 2108,
+          "resourceSize": 5649
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877012,
-          "resourceSize": 1966650
+          "transferSize": 690523,
+          "resourceSize": 1348827
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6048,
-          "resourceSize": 25518
+          "transferSize": 5722,
+          "resourceSize": 24231
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12324,
-          "resourceSize": 13177
+          "transferSize": 9074,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069841,
-          "resourceSize": 2931846
+          "transferSize": 484064,
+          "resourceSize": 1166135
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2170,
-          "resourceSize": 5764
+          "transferSize": 1974,
+          "resourceSize": 5088
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876870,
-          "resourceSize": 1966089
+          "transferSize": 690393,
+          "resourceSize": 1348266
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2306,
-          "resourceSize": 6157
+          "transferSize": 2110,
+          "resourceSize": 5481
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877006,
-          "resourceSize": 1966482
+          "transferSize": 690528,
+          "resourceSize": 1348659
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2185,
-          "resourceSize": 5746
+          "transferSize": 1987,
+          "resourceSize": 5070
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876883,
-          "resourceSize": 1966071
+          "transferSize": 690403,
+          "resourceSize": 1348248
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2379,
-          "resourceSize": 6267
+          "transferSize": 2182,
+          "resourceSize": 5591
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877082,
-          "resourceSize": 1966593
+          "transferSize": 690597,
+          "resourceSize": 1348769
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3231,
-          "resourceSize": 9838
+          "transferSize": 3028,
+          "resourceSize": 9162
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1315,
+          "transferSize": 1321,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878478,
-          "resourceSize": 1970573
+          "transferSize": 691995,
+          "resourceSize": 1352749
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3182,
-          "resourceSize": 8175
+          "transferSize": 2871,
+          "resourceSize": 6996
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282774,
-          "resourceSize": 3126776
+          "transferSize": 697436,
+          "resourceSize": 1361172
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.34.0.json
+++ b/.github/page_size_audit_results/v1.34.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.34.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:17.744Z"
+    "generatedAt": "2025-11-27T16:03:34.907Z"
   },
-  "timestamp": "2025-11-22T11:49:17.744Z",
+  "timestamp": "2025-11-27T16:03:34.907Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2325,
-          "resourceSize": 6304
+          "transferSize": 2132,
+          "resourceSize": 5628
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877031,
-          "resourceSize": 1966629
+          "transferSize": 690548,
+          "resourceSize": 1348806
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2298,
-          "resourceSize": 6325
+          "transferSize": 2106,
+          "resourceSize": 5649
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876998,
-          "resourceSize": 1966650
+          "transferSize": 690517,
+          "resourceSize": 1348827
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5759,
-          "resourceSize": 25097
+          "transferSize": 5434,
+          "resourceSize": 23810
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12288,
-          "resourceSize": 13177
+          "transferSize": 9075,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069516,
-          "resourceSize": 2931425
+          "transferSize": 483777,
+          "resourceSize": 1165714
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2163,
-          "resourceSize": 5764
+          "transferSize": 1974,
+          "resourceSize": 5088
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876862,
-          "resourceSize": 1966089
+          "transferSize": 690393,
+          "resourceSize": 1348266
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2297,
-          "resourceSize": 6157
+          "transferSize": 2109,
+          "resourceSize": 5481
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876996,
-          "resourceSize": 1966482
+          "transferSize": 690523,
+          "resourceSize": 1348659
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2179,
-          "resourceSize": 5746
+          "transferSize": 1987,
+          "resourceSize": 5070
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876886,
-          "resourceSize": 1966071
+          "transferSize": 690399,
+          "resourceSize": 1348248
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2370,
-          "resourceSize": 6267
+          "transferSize": 2181,
+          "resourceSize": 5591
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877070,
-          "resourceSize": 1966593
+          "transferSize": 690593,
+          "resourceSize": 1348769
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3222,
-          "resourceSize": 9838
+          "transferSize": 3028,
+          "resourceSize": 9162
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1319,
+          "transferSize": 1318,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878473,
-          "resourceSize": 1970573
+          "transferSize": 691992,
+          "resourceSize": 1352749
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3158,
-          "resourceSize": 8173
+          "transferSize": 2859,
+          "resourceSize": 6994
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 319964,
-          "resourceSize": 718488
+          "transferSize": 317342,
+          "resourceSize": 716198
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3949,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282752,
-          "resourceSize": 3126774
+          "transferSize": 697425,
+          "resourceSize": 1361170
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.34.1.json
+++ b/.github/page_size_audit_results/v1.34.1.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.34.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:09.166Z"
+    "generatedAt": "2025-11-27T16:01:01.768Z"
   },
-  "timestamp": "2025-11-22T11:52:09.167Z",
+  "timestamp": "2025-11-27T16:01:01.769Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2347,
-          "resourceSize": 6358
+          "transferSize": 2149,
+          "resourceSize": 5682
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 320087,
-          "resourceSize": 720220
+          "transferSize": 317465,
+          "resourceSize": 717930
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877176,
-          "resourceSize": 1968415
+          "transferSize": 690693,
+          "resourceSize": 1350592
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2317,
-          "resourceSize": 6379
+          "transferSize": 2117,
+          "resourceSize": 5703
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 320087,
-          "resourceSize": 720220
+          "transferSize": 317465,
+          "resourceSize": 717930
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877143,
-          "resourceSize": 1968436
+          "transferSize": 690654,
+          "resourceSize": 1350613
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5780,
-          "resourceSize": 25151
+          "transferSize": 5438,
+          "resourceSize": 23864
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 320087,
-          "resourceSize": 720220
+          "transferSize": 317465,
+          "resourceSize": 717930
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 11955,
-          "resourceSize": 13177
+          "transferSize": 9121,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1069327,
-          "resourceSize": 2933211
+          "transferSize": 483950,
+          "resourceSize": 1167500
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2186,
-          "resourceSize": 5818
+          "transferSize": 1987,
+          "resourceSize": 5142
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 320087,
-          "resourceSize": 720220
+          "transferSize": 317465,
+          "resourceSize": 717930
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877011,
-          "resourceSize": 1967875
+          "transferSize": 690528,
+          "resourceSize": 1350052
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2321,
-          "resourceSize": 6211
+          "transferSize": 2123,
+          "resourceSize": 5535
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 320087,
-          "resourceSize": 720220
+          "transferSize": 317465,
+          "resourceSize": 717930
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877150,
-          "resourceSize": 1968268
+          "transferSize": 690657,
+          "resourceSize": 1350445
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2200,
-          "resourceSize": 5800
+          "transferSize": 2000,
+          "resourceSize": 5124
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 320087,
-          "resourceSize": 720220
+          "transferSize": 317465,
+          "resourceSize": 717930
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877022,
-          "resourceSize": 1967858
+          "transferSize": 690542,
+          "resourceSize": 1350034
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2393,
-          "resourceSize": 6321
+          "transferSize": 2197,
+          "resourceSize": 5645
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 320087,
-          "resourceSize": 720220
+          "transferSize": 317465,
+          "resourceSize": 717930
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877214,
-          "resourceSize": 1968379
+          "transferSize": 690736,
+          "resourceSize": 1350555
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3271,
-          "resourceSize": 9884
+          "transferSize": 3058,
+          "resourceSize": 9208
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329174,
-          "resourceSize": 1017420
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 320087,
-          "resourceSize": 720220
+          "transferSize": 317465,
+          "resourceSize": 717930
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1320,
+          "transferSize": 1317,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878646,
-          "resourceSize": 1972351
+          "transferSize": 692144,
+          "resourceSize": 1354527
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3201,
-          "resourceSize": 8227
+          "transferSize": 2873,
+          "resourceSize": 7048
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 730887,
-          "resourceSize": 2174447
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 320087,
-          "resourceSize": 720220
+          "transferSize": 317465,
+          "resourceSize": 717930
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3949,
-          "resourceSize": 1443
+          "transferSize": 1125,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282918,
-          "resourceSize": 3128560
+          "transferSize": 697564,
+          "resourceSize": 1362956
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.35.0.json
+++ b/.github/page_size_audit_results/v1.35.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.35.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:55.842Z"
+    "generatedAt": "2025-11-27T16:01:04.137Z"
   },
-  "timestamp": "2025-11-22T11:51:55.843Z",
+  "timestamp": "2025-11-27T16:01:04.138Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2352,
-          "resourceSize": 6371
+          "transferSize": 2149,
+          "resourceSize": 5695
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329198,
-          "resourceSize": 1017591
+          "transferSize": 145535,
+          "resourceSize": 402734
         },
         "stylesheet": {
-          "transferSize": 319035,
-          "resourceSize": 714970
+          "transferSize": 316413,
+          "resourceSize": 712680
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876148,
-          "resourceSize": 1963349
+          "transferSize": 689657,
+          "resourceSize": 1345526
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2321,
-          "resourceSize": 6388
+          "transferSize": 2120,
+          "resourceSize": 5712
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329198,
-          "resourceSize": 1017591
+          "transferSize": 145535,
+          "resourceSize": 402734
         },
         "stylesheet": {
-          "transferSize": 319035,
-          "resourceSize": 714970
+          "transferSize": 316413,
+          "resourceSize": 712680
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876115,
-          "resourceSize": 1963366
+          "transferSize": 689629,
+          "resourceSize": 1345543
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5572,
-          "resourceSize": 25011
+          "transferSize": 5229,
+          "resourceSize": 23724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 727125,
-          "resourceSize": 2165458
+          "transferSize": 147546,
+          "resourceSize": 404572
         },
         "stylesheet": {
-          "transferSize": 319035,
-          "resourceSize": 714970
+          "transferSize": 316413,
+          "resourceSize": 712680
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12317,
-          "resourceSize": 13177
+          "transferSize": 9051,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064667,
-          "resourceSize": 2918832
+          "transferSize": 478857,
+          "resourceSize": 1153121
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2188,
-          "resourceSize": 5827
+          "transferSize": 1989,
+          "resourceSize": 5151
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329198,
-          "resourceSize": 1017591
+          "transferSize": 145535,
+          "resourceSize": 402734
         },
         "stylesheet": {
-          "transferSize": 319035,
-          "resourceSize": 714970
+          "transferSize": 316413,
+          "resourceSize": 712680
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 875981,
-          "resourceSize": 1962805
+          "transferSize": 689506,
+          "resourceSize": 1344982
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2324,
-          "resourceSize": 6220
+          "transferSize": 2125,
+          "resourceSize": 5544
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329198,
-          "resourceSize": 1017591
+          "transferSize": 145535,
+          "resourceSize": 402734
         },
         "stylesheet": {
-          "transferSize": 319035,
-          "resourceSize": 714970
+          "transferSize": 316413,
+          "resourceSize": 712680
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876116,
-          "resourceSize": 1963198
+          "transferSize": 689633,
+          "resourceSize": 1345375
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2203,
-          "resourceSize": 5809
+          "transferSize": 2002,
+          "resourceSize": 5133
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329198,
-          "resourceSize": 1017591
+          "transferSize": 145535,
+          "resourceSize": 402734
         },
         "stylesheet": {
-          "transferSize": 319035,
-          "resourceSize": 714970
+          "transferSize": 316413,
+          "resourceSize": 712680
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 875997,
-          "resourceSize": 1962787
+          "transferSize": 689514,
+          "resourceSize": 1344964
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2396,
-          "resourceSize": 6330
+          "transferSize": 2198,
+          "resourceSize": 5654
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329198,
-          "resourceSize": 1017591
+          "transferSize": 145535,
+          "resourceSize": 402734
         },
         "stylesheet": {
-          "transferSize": 319035,
-          "resourceSize": 714970
+          "transferSize": 316413,
+          "resourceSize": 712680
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876192,
-          "resourceSize": 1963309
+          "transferSize": 689706,
+          "resourceSize": 1345485
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3282,
-          "resourceSize": 9925
+          "transferSize": 3071,
+          "resourceSize": 9249
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329198,
-          "resourceSize": 1017591
+          "transferSize": 145535,
+          "resourceSize": 402734
         },
         "stylesheet": {
-          "transferSize": 319035,
-          "resourceSize": 714970
+          "transferSize": 316413,
+          "resourceSize": 712680
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1288,
+          "transferSize": 1284,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877597,
-          "resourceSize": 1967266
+          "transferSize": 691096,
+          "resourceSize": 1349442
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2672,
-          "resourceSize": 7099
+          "transferSize": 2355,
+          "resourceSize": 5920
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 727125,
-          "resourceSize": 2165458
+          "transferSize": 147546,
+          "resourceSize": 404572
         },
         "stylesheet": {
-          "transferSize": 319035,
-          "resourceSize": 714970
+          "transferSize": 316413,
+          "resourceSize": 712680
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3943,
-          "resourceSize": 1443
+          "transferSize": 1117,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1277569,
-          "resourceSize": 3113193
+          "transferSize": 692224,
+          "resourceSize": 1347589
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.36.0.json
+++ b/.github/page_size_audit_results/v1.36.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.36.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:21.619Z"
+    "generatedAt": "2025-11-27T16:03:47.547Z"
   },
-  "timestamp": "2025-11-22T11:49:21.619Z",
+  "timestamp": "2025-11-27T16:03:47.547Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2349,
-          "resourceSize": 6376
+          "transferSize": 2153,
+          "resourceSize": 5700
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319058,
-          "resourceSize": 714997
+          "transferSize": 316436,
+          "resourceSize": 712707
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 875989,
-          "resourceSize": 1962935
+          "transferSize": 689511,
+          "resourceSize": 1345112
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2317,
-          "resourceSize": 6388
+          "transferSize": 2124,
+          "resourceSize": 5712
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319058,
-          "resourceSize": 714997
+          "transferSize": 316436,
+          "resourceSize": 712707
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 875956,
-          "resourceSize": 1962947
+          "transferSize": 689478,
+          "resourceSize": 1345124
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5568,
-          "resourceSize": 25011
+          "transferSize": 5234,
+          "resourceSize": 23724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 726946,
-          "resourceSize": 2165012
+          "transferSize": 147367,
+          "resourceSize": 404126
         },
         "stylesheet": {
-          "transferSize": 319058,
-          "resourceSize": 714997
+          "transferSize": 316436,
+          "resourceSize": 712707
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12318,
-          "resourceSize": 13177
+          "transferSize": 9045,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064508,
-          "resourceSize": 2918413
+          "transferSize": 478700,
+          "resourceSize": 1152702
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2185,
-          "resourceSize": 5827
+          "transferSize": 1992,
+          "resourceSize": 5151
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319058,
-          "resourceSize": 714997
+          "transferSize": 316436,
+          "resourceSize": 712707
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 875826,
-          "resourceSize": 1962386
+          "transferSize": 689343,
+          "resourceSize": 1344563
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2322,
-          "resourceSize": 6220
+          "transferSize": 2129,
+          "resourceSize": 5544
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319058,
-          "resourceSize": 714997
+          "transferSize": 316436,
+          "resourceSize": 712707
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 875958,
-          "resourceSize": 1962779
+          "transferSize": 689483,
+          "resourceSize": 1344956
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2200,
-          "resourceSize": 5809
+          "transferSize": 2005,
+          "resourceSize": 5133
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319058,
-          "resourceSize": 714997
+          "transferSize": 316436,
+          "resourceSize": 712707
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 875838,
-          "resourceSize": 1962368
+          "transferSize": 689355,
+          "resourceSize": 1344545
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2393,
-          "resourceSize": 6330
+          "transferSize": 2201,
+          "resourceSize": 5654
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319058,
-          "resourceSize": 714997
+          "transferSize": 316436,
+          "resourceSize": 712707
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876032,
-          "resourceSize": 1962890
+          "transferSize": 689550,
+          "resourceSize": 1345066
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3279,
-          "resourceSize": 9925
+          "transferSize": 3075,
+          "resourceSize": 9249
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319058,
-          "resourceSize": 714997
+          "transferSize": 316436,
+          "resourceSize": 712707
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1272,
+          "transferSize": 1285,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877422,
-          "resourceSize": 1966847
+          "transferSize": 690945,
+          "resourceSize": 1349023
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2669,
-          "resourceSize": 7099
+          "transferSize": 2359,
+          "resourceSize": 5920
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 726946,
-          "resourceSize": 2165012
+          "transferSize": 147367,
+          "resourceSize": 404126
         },
         "stylesheet": {
-          "transferSize": 319058,
-          "resourceSize": 714997
+          "transferSize": 316436,
+          "resourceSize": 712707
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3951,
-          "resourceSize": 1443
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1277418,
-          "resourceSize": 3112774
+          "transferSize": 692077,
+          "resourceSize": 1347170
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.37.0.json
+++ b/.github/page_size_audit_results/v1.37.0.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.37.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:23.258Z"
+    "generatedAt": "2025-11-27T16:03:29.563Z"
   },
-  "timestamp": "2025-11-22T11:52:23.258Z",
+  "timestamp": "2025-11-27T16:03:29.564Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2340,
-          "resourceSize": 6376
+          "transferSize": 2154,
+          "resourceSize": 5700
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876679,
-          "resourceSize": 1980726
+          "transferSize": 690208,
+          "resourceSize": 1362903
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2308,
-          "resourceSize": 6388
+          "transferSize": 2125,
+          "resourceSize": 5712
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876651,
-          "resourceSize": 1980738
+          "transferSize": 690180,
+          "resourceSize": 1362915
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5561,
-          "resourceSize": 25011
+          "transferSize": 5234,
+          "resourceSize": 23724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 726946,
-          "resourceSize": 2165012
+          "transferSize": 147367,
+          "resourceSize": 404126
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12311,
-          "resourceSize": 13177
+          "transferSize": 9090,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1065192,
-          "resourceSize": 2936204
+          "transferSize": 479443,
+          "resourceSize": 1170493
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2177,
-          "resourceSize": 5827
+          "transferSize": 1992,
+          "resourceSize": 5151
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876510,
-          "resourceSize": 1980177
+          "transferSize": 690047,
+          "resourceSize": 1362354
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2313,
-          "resourceSize": 6220
+          "transferSize": 2128,
+          "resourceSize": 5544
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876652,
-          "resourceSize": 1980570
+          "transferSize": 690178,
+          "resourceSize": 1362747
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2193,
-          "resourceSize": 5809
+          "transferSize": 2005,
+          "resourceSize": 5133
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876534,
-          "resourceSize": 1980159
+          "transferSize": 690055,
+          "resourceSize": 1362336
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2384,
-          "resourceSize": 6330
+          "transferSize": 2202,
+          "resourceSize": 5654
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876723,
-          "resourceSize": 1980681
+          "transferSize": 690257,
+          "resourceSize": 1362857
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3332,
-          "resourceSize": 10256
+          "transferSize": 3143,
+          "resourceSize": 9580
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329019,
-          "resourceSize": 1017145
+          "transferSize": 145356,
+          "resourceSize": 402288
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1285,
+          "transferSize": 1279,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878186,
-          "resourceSize": 1984969
+          "transferSize": 691705,
+          "resourceSize": 1367145
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2662,
-          "resourceSize": 7099
+          "transferSize": 2359,
+          "resourceSize": 5920
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 726946,
-          "resourceSize": 2165012
+          "transferSize": 147367,
+          "resourceSize": 404126
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3943,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1278101,
-          "resourceSize": 3130565
+          "transferSize": 692776,
+          "resourceSize": 1364961
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.38.0.json
+++ b/.github/page_size_audit_results/v1.38.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.38.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:53.823Z"
+    "generatedAt": "2025-11-27T16:03:37.469Z"
   },
-  "timestamp": "2025-11-22T11:51:53.824Z",
+  "timestamp": "2025-11-27T16:03:37.469Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2347,
-          "resourceSize": 6376
+          "transferSize": 2153,
+          "resourceSize": 5700
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876861,
-          "resourceSize": 1981019
+          "transferSize": 690379,
+          "resourceSize": 1363196
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2314,
-          "resourceSize": 6388
+          "transferSize": 2123,
+          "resourceSize": 5712
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876824,
-          "resourceSize": 1981031
+          "transferSize": 690350,
+          "resourceSize": 1363208
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5568,
-          "resourceSize": 25011
+          "transferSize": 5233,
+          "resourceSize": 23724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 727119,
-          "resourceSize": 2165305
+          "transferSize": 147540,
+          "resourceSize": 404419
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 11951,
-          "resourceSize": 13177
+          "transferSize": 9099,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1065012,
-          "resourceSize": 2936497
+          "transferSize": 479624,
+          "resourceSize": 1170786
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2195,
-          "resourceSize": 5882
+          "transferSize": 2004,
+          "resourceSize": 5206
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876709,
-          "resourceSize": 1980525
+          "transferSize": 690230,
+          "resourceSize": 1362702
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2325,
-          "resourceSize": 6258
+          "transferSize": 2134,
+          "resourceSize": 5582
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876836,
-          "resourceSize": 1980901
+          "transferSize": 690363,
+          "resourceSize": 1363078
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2197,
-          "resourceSize": 5809
+          "transferSize": 2005,
+          "resourceSize": 5133
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876705,
-          "resourceSize": 1980452
+          "transferSize": 690233,
+          "resourceSize": 1362629
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2396,
-          "resourceSize": 6368
+          "transferSize": 2209,
+          "resourceSize": 5692
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876905,
-          "resourceSize": 1981012
+          "transferSize": 690436,
+          "resourceSize": 1363188
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3347,
-          "resourceSize": 10324
+          "transferSize": 3159,
+          "resourceSize": 9648
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1277,
+          "transferSize": 1278,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878366,
-          "resourceSize": 1985330
+          "transferSize": 691893,
+          "resourceSize": 1367506
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2667,
-          "resourceSize": 7099
+          "transferSize": 2359,
+          "resourceSize": 5920
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 727119,
-          "resourceSize": 2165305
+          "transferSize": 147540,
+          "resourceSize": 404419
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732788
+          "transferSize": 317134,
+          "resourceSize": 730498
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1278282,
-          "resourceSize": 3130858
+          "transferSize": 692946,
+          "resourceSize": 1365254
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.39.0.json
+++ b/.github/page_size_audit_results/v1.39.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.39.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:54:34.560Z"
+    "generatedAt": "2025-11-27T16:03:50.751Z"
   },
-  "timestamp": "2025-11-22T11:54:34.560Z",
+  "timestamp": "2025-11-27T16:03:50.752Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2371,
-          "resourceSize": 6461
+          "transferSize": 2175,
+          "resourceSize": 5785
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732728
+          "transferSize": 317134,
+          "resourceSize": 730438
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876884,
-          "resourceSize": 1981044
+          "transferSize": 690401,
+          "resourceSize": 1363221
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2339,
-          "resourceSize": 6473
+          "transferSize": 2146,
+          "resourceSize": 5797
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732728
+          "transferSize": 317134,
+          "resourceSize": 730438
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876853,
-          "resourceSize": 1981056
+          "transferSize": 690366,
+          "resourceSize": 1363233
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5590,
-          "resourceSize": 25096
+          "transferSize": 5262,
+          "resourceSize": 23809
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 727119,
-          "resourceSize": 2165305
+          "transferSize": 147540,
+          "resourceSize": 404419
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732728
+          "transferSize": 317134,
+          "resourceSize": 730438
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12312,
-          "resourceSize": 13177
+          "transferSize": 9081,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1065395,
-          "resourceSize": 2936522
+          "transferSize": 479635,
+          "resourceSize": 1170811
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2220,
-          "resourceSize": 5967
+          "transferSize": 2028,
+          "resourceSize": 5291
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732728
+          "transferSize": 317134,
+          "resourceSize": 730438
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876732,
-          "resourceSize": 1980550
+          "transferSize": 690258,
+          "resourceSize": 1362727
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2349,
-          "resourceSize": 6343
+          "transferSize": 2157,
+          "resourceSize": 5667
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732728
+          "transferSize": 317134,
+          "resourceSize": 730438
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876860,
-          "resourceSize": 1980926
+          "transferSize": 690383,
+          "resourceSize": 1363103
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2223,
-          "resourceSize": 5894
+          "transferSize": 2028,
+          "resourceSize": 5218
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732728
+          "transferSize": 317134,
+          "resourceSize": 730438
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876736,
-          "resourceSize": 1980477
+          "transferSize": 690251,
+          "resourceSize": 1362654
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2420,
-          "resourceSize": 6453
+          "transferSize": 2231,
+          "resourceSize": 5777
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732728
+          "transferSize": 317134,
+          "resourceSize": 730438
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876932,
-          "resourceSize": 1981037
+          "transferSize": 690455,
+          "resourceSize": 1363213
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3390,
-          "resourceSize": 10409
+          "transferSize": 3186,
+          "resourceSize": 9733
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329192,
-          "resourceSize": 1017438
+          "transferSize": 145529,
+          "resourceSize": 402581
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732728
+          "transferSize": 317134,
+          "resourceSize": 730438
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1283,
+          "transferSize": 1287,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878415,
-          "resourceSize": 1985355
+          "transferSize": 691929,
+          "resourceSize": 1367531
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2693,
-          "resourceSize": 7184
+          "transferSize": 2382,
+          "resourceSize": 6005
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 727119,
-          "resourceSize": 2165305
+          "transferSize": 147540,
+          "resourceSize": 404419
         },
         "stylesheet": {
-          "transferSize": 319756,
-          "resourceSize": 732728
+          "transferSize": 317134,
+          "resourceSize": 730438
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3948,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1278310,
-          "resourceSize": 3130883
+          "transferSize": 692969,
+          "resourceSize": 1365279
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.4.0.json
+++ b/.github/page_size_audit_results/v1.4.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.4.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:20.132Z"
+    "generatedAt": "2025-11-27T16:00:59.640Z"
   },
-  "timestamp": "2025-11-22T11:49:20.132Z",
+  "timestamp": "2025-11-27T16:00:59.641Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2764,
-          "resourceSize": 6032
+          "transferSize": 2584,
+          "resourceSize": 5377
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876986,
-          "resourceSize": 1984785
+          "transferSize": 690517,
+          "resourceSize": 1366983
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2638,
-          "resourceSize": 5748
+          "transferSize": 2452,
+          "resourceSize": 5093
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876859,
-          "resourceSize": 1984501
+          "transferSize": 690388,
+          "resourceSize": 1366699
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5521,
-          "resourceSize": 17920
+          "transferSize": 5217,
+          "resourceSize": 16731
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7848,
-          "resourceSize": 6933
+          "transferSize": 4957,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064630,
-          "resourceSize": 2937830
+          "transferSize": 479234,
+          "resourceSize": 1172217
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2462,
-          "resourceSize": 5132
+          "transferSize": 2278,
+          "resourceSize": 4477
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876686,
-          "resourceSize": 1983885
+          "transferSize": 690215,
+          "resourceSize": 1366083
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2626,
-          "resourceSize": 5558
+          "transferSize": 2442,
+          "resourceSize": 4903
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876845,
-          "resourceSize": 1984311
+          "transferSize": 690372,
+          "resourceSize": 1366509
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2487,
-          "resourceSize": 5149
+          "transferSize": 2301,
+          "resourceSize": 4494
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 779,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876715,
-          "resourceSize": 1983902
+          "transferSize": 690238,
+          "resourceSize": 1366100
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2688,
-          "resourceSize": 5668
+          "transferSize": 2505,
+          "resourceSize": 5013
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 762,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876914,
-          "resourceSize": 1984422
+          "transferSize": 690431,
+          "resourceSize": 1366619
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3273,
-          "resourceSize": 7785
+          "transferSize": 3091,
+          "resourceSize": 7130
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877495,
-          "resourceSize": 1986539
+          "transferSize": 691021,
+          "resourceSize": 1368736
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3432,
-          "resourceSize": 7515
+          "transferSize": 3147,
+          "resourceSize": 6409
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3943,
-          "resourceSize": 1443
+          "transferSize": 1117,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282812,
-          "resourceSize": 3145942
+          "transferSize": 697499,
+          "resourceSize": 1380411
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.40.0.json
+++ b/.github/page_size_audit_results/v1.40.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.40.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:02.057Z"
+    "generatedAt": "2025-11-27T16:01:06.376Z"
   },
-  "timestamp": "2025-11-22T11:52:02.057Z",
+  "timestamp": "2025-11-27T16:01:06.376Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2386,
-          "resourceSize": 6510
+          "transferSize": 2192,
+          "resourceSize": 5834
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329880,
-          "resourceSize": 1019913
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319750,
-          "resourceSize": 732718
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877580,
-          "resourceSize": 1983558
+          "transferSize": 691098,
+          "resourceSize": 1365735
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2356,
-          "resourceSize": 6522
+          "transferSize": 2163,
+          "resourceSize": 5846
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329880,
-          "resourceSize": 1019913
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319750,
-          "resourceSize": 732718
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877549,
-          "resourceSize": 1983570
+          "transferSize": 691070,
+          "resourceSize": 1365747
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5568,
-          "resourceSize": 25117
+          "transferSize": 5243,
+          "resourceSize": 23830
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 727807,
-          "resourceSize": 2167780
+          "transferSize": 148228,
+          "resourceSize": 406894
         },
         "stylesheet": {
-          "transferSize": 319750,
-          "resourceSize": 732718
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12324,
-          "resourceSize": 13177
+          "transferSize": 9063,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1066067,
-          "resourceSize": 2939008
+          "transferSize": 480280,
+          "resourceSize": 1173297
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2238,
-          "resourceSize": 6016
+          "transferSize": 2043,
+          "resourceSize": 5340
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329880,
-          "resourceSize": 1019913
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319750,
-          "resourceSize": 732718
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877432,
-          "resourceSize": 1983064
+          "transferSize": 690953,
+          "resourceSize": 1365241
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2366,
-          "resourceSize": 6392
+          "transferSize": 2174,
+          "resourceSize": 5716
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329880,
-          "resourceSize": 1019913
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319750,
-          "resourceSize": 732718
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877555,
-          "resourceSize": 1983440
+          "transferSize": 691081,
+          "resourceSize": 1365617
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2238,
-          "resourceSize": 5943
+          "transferSize": 2043,
+          "resourceSize": 5267
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329880,
-          "resourceSize": 1019913
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319750,
-          "resourceSize": 732718
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877435,
-          "resourceSize": 1982991
+          "transferSize": 690945,
+          "resourceSize": 1365168
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2444,
-          "resourceSize": 6502
+          "transferSize": 2248,
+          "resourceSize": 5826
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329880,
-          "resourceSize": 1019913
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319750,
-          "resourceSize": 732718
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877636,
-          "resourceSize": 1983551
+          "transferSize": 691153,
+          "resourceSize": 1365727
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3404,
-          "resourceSize": 10458
+          "transferSize": 3201,
+          "resourceSize": 9782
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329880,
-          "resourceSize": 1019913
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319750,
-          "resourceSize": 732718
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1284,
+          "transferSize": 1275,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 879112,
-          "resourceSize": 1987869
+          "transferSize": 692614,
+          "resourceSize": 1370045
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2712,
-          "resourceSize": 7243
+          "transferSize": 2399,
+          "resourceSize": 6064
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 727807,
-          "resourceSize": 2167780
+          "transferSize": 148228,
+          "resourceSize": 406894
         },
         "stylesheet": {
-          "transferSize": 319750,
-          "resourceSize": 732718
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1124,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1279009,
-          "resourceSize": 3133407
+          "transferSize": 693672,
+          "resourceSize": 1367803
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.40.1.json
+++ b/.github/page_size_audit_results/v1.40.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.40.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:10.369Z"
+    "generatedAt": "2025-11-27T16:03:59.099Z"
   },
-  "timestamp": "2025-11-22T11:52:10.370Z",
+  "timestamp": "2025-11-27T16:03:59.100Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2373,
-          "resourceSize": 6398
+          "transferSize": 2173,
+          "resourceSize": 5722
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843607,
-          "resourceSize": 1897757
+          "transferSize": 657121,
+          "resourceSize": 1279934
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2343,
-          "resourceSize": 6410
+          "transferSize": 2143,
+          "resourceSize": 5734
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843584,
-          "resourceSize": 1897769
+          "transferSize": 657093,
+          "resourceSize": 1279946
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5554,
-          "resourceSize": 25005
+          "transferSize": 5219,
+          "resourceSize": 23718
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 693738,
-          "resourceSize": 2081664
+          "transferSize": 114159,
+          "resourceSize": 320778
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12294,
-          "resourceSize": 13177
+          "transferSize": 9079,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1032066,
-          "resourceSize": 2853207
+          "transferSize": 446315,
+          "resourceSize": 1087496
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2225,
-          "resourceSize": 5904
+          "transferSize": 2023,
+          "resourceSize": 5228
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843460,
-          "resourceSize": 1897263
+          "transferSize": 656972,
+          "resourceSize": 1279440
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2353,
-          "resourceSize": 6280
+          "transferSize": 2154,
+          "resourceSize": 5604
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843589,
-          "resourceSize": 1897639
+          "transferSize": 657105,
+          "resourceSize": 1279816
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2223,
-          "resourceSize": 5831
+          "transferSize": 2023,
+          "resourceSize": 5155
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843459,
-          "resourceSize": 1897190
+          "transferSize": 656972,
+          "resourceSize": 1279367
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2424,
-          "resourceSize": 6390
+          "transferSize": 2228,
+          "resourceSize": 5714
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 843656,
-          "resourceSize": 1897750
+          "transferSize": 657182,
+          "resourceSize": 1279926
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3373,
-          "resourceSize": 10346
+          "transferSize": 3178,
+          "resourceSize": 9670
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1286,
+          "transferSize": 1279,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 845126,
-          "resourceSize": 1902068
+          "transferSize": 658638,
+          "resourceSize": 1284244
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2697,
-          "resourceSize": 7131
+          "transferSize": 2379,
+          "resourceSize": 5952
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 693738,
-          "resourceSize": 2081664
+          "transferSize": 114159,
+          "resourceSize": 320778
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3953,
-          "resourceSize": 1443
+          "transferSize": 1129,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1245044,
-          "resourceSize": 3047606
+          "transferSize": 659700,
+          "resourceSize": 1282002
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.41.0.json
+++ b/.github/page_size_audit_results/v1.41.0.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:02.573Z"
+    "generatedAt": "2025-11-27T16:06:10.312Z"
   },
-  "timestamp": "2025-11-22T11:52:02.573Z",
+  "timestamp": "2025-11-27T16:06:10.312Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2369,
-          "resourceSize": 6404
+          "transferSize": 2175,
+          "resourceSize": 5728
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843607,
-          "resourceSize": 1897763
+          "transferSize": 657128,
+          "resourceSize": 1279940
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2338,
-          "resourceSize": 6416
+          "transferSize": 2144,
+          "resourceSize": 5740
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843582,
-          "resourceSize": 1897775
+          "transferSize": 657092,
+          "resourceSize": 1279952
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5544,
-          "resourceSize": 25011
+          "transferSize": 5225,
+          "resourceSize": 23724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 693738,
-          "resourceSize": 2081664
+          "transferSize": 114159,
+          "resourceSize": 320778
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12319,
-          "resourceSize": 13177
+          "transferSize": 9043,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1032081,
-          "resourceSize": 2853213
+          "transferSize": 446285,
+          "resourceSize": 1087502
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2219,
-          "resourceSize": 5910
+          "transferSize": 2025,
+          "resourceSize": 5234
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843455,
-          "resourceSize": 1897269
+          "transferSize": 656975,
+          "resourceSize": 1279446
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2348,
-          "resourceSize": 6286
+          "transferSize": 2155,
+          "resourceSize": 5610
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843586,
-          "resourceSize": 1897645
+          "transferSize": 657101,
+          "resourceSize": 1279822
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2220,
-          "resourceSize": 5837
+          "transferSize": 2026,
+          "resourceSize": 5161
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843459,
-          "resourceSize": 1897196
+          "transferSize": 656978,
+          "resourceSize": 1279373
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2424,
-          "resourceSize": 6396
+          "transferSize": 2229,
+          "resourceSize": 5720
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 843658,
-          "resourceSize": 1897756
+          "transferSize": 657182,
+          "resourceSize": 1279932
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3373,
-          "resourceSize": 10352
+          "transferSize": 3178,
+          "resourceSize": 9676
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1290,
+          "transferSize": 1280,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 845130,
-          "resourceSize": 1902074
+          "transferSize": 658639,
+          "resourceSize": 1284250
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2693,
-          "resourceSize": 7137
+          "transferSize": 2381,
+          "resourceSize": 5958
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 693738,
-          "resourceSize": 2081664
+          "transferSize": 114159,
+          "resourceSize": 320778
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1119,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1245034,
-          "resourceSize": 3047612
+          "transferSize": 659692,
+          "resourceSize": 1282008
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.41.1.json
+++ b/.github/page_size_audit_results/v1.41.1.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:56.038Z"
+    "generatedAt": "2025-11-27T16:03:43.573Z"
   },
-  "timestamp": "2025-11-22T11:51:56.038Z",
+  "timestamp": "2025-11-27T16:03:43.574Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2378,
-          "resourceSize": 6404
+          "transferSize": 2175,
+          "resourceSize": 5728
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843611,
-          "resourceSize": 1897763
+          "transferSize": 657123,
+          "resourceSize": 1279940
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2348,
-          "resourceSize": 6416
+          "transferSize": 2144,
+          "resourceSize": 5740
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843591,
-          "resourceSize": 1897775
+          "transferSize": 657095,
+          "resourceSize": 1279952
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5553,
-          "resourceSize": 25011
+          "transferSize": 5225,
+          "resourceSize": 23724
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 693738,
-          "resourceSize": 2081664
+          "transferSize": 114159,
+          "resourceSize": 320778
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 11926,
-          "resourceSize": 13177
+          "transferSize": 9036,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1031697,
-          "resourceSize": 2853213
+          "transferSize": 446278,
+          "resourceSize": 1087502
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2226,
-          "resourceSize": 5910
+          "transferSize": 2025,
+          "resourceSize": 5234
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843464,
-          "resourceSize": 1897269
+          "transferSize": 656973,
+          "resourceSize": 1279446
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2358,
-          "resourceSize": 6286
+          "transferSize": 2155,
+          "resourceSize": 5610
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843598,
-          "resourceSize": 1897645
+          "transferSize": 657101,
+          "resourceSize": 1279822
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2226,
-          "resourceSize": 5837
+          "transferSize": 2026,
+          "resourceSize": 5161
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 843463,
-          "resourceSize": 1897196
+          "transferSize": 656976,
+          "resourceSize": 1279373
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2429,
-          "resourceSize": 6396
+          "transferSize": 2229,
+          "resourceSize": 5720
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 843670,
-          "resourceSize": 1897756
+          "transferSize": 657178,
+          "resourceSize": 1279932
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3386,
-          "resourceSize": 10352
+          "transferSize": 3178,
+          "resourceSize": 9676
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295811,
-          "resourceSize": 933797
+          "transferSize": 112148,
+          "resourceSize": 318940
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1284,
+          "transferSize": 1280,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 845137,
-          "resourceSize": 1902074
+          "transferSize": 658639,
+          "resourceSize": 1284250
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2702,
-          "resourceSize": 7137
+          "transferSize": 2381,
+          "resourceSize": 5958
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 693738,
-          "resourceSize": 2081664
+          "transferSize": 114159,
+          "resourceSize": 320778
         },
         "stylesheet": {
-          "transferSize": 319862,
-          "resourceSize": 733145
+          "transferSize": 317240,
+          "resourceSize": 730855
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3944,
-          "resourceSize": 1443
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1245040,
-          "resourceSize": 3047612
+          "transferSize": 659699,
+          "resourceSize": 1282008
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.41.2.json
+++ b/.github/page_size_audit_results/v1.41.2.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:03.594Z"
+    "generatedAt": "2025-11-27T16:03:36.559Z"
   },
-  "timestamp": "2025-11-22T11:52:03.594Z",
+  "timestamp": "2025-11-27T16:03:36.560Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2374,
-          "resourceSize": 6404
+          "transferSize": 2177,
+          "resourceSize": 5728
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294103,
-          "resourceSize": 931993
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 319565,
-          "resourceSize": 730492
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 841605,
-          "resourceSize": 1893306
+          "transferSize": 655118,
+          "resourceSize": 1275483
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2344,
-          "resourceSize": 6416
+          "transferSize": 2147,
+          "resourceSize": 5740
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294103,
-          "resourceSize": 931993
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 319565,
-          "resourceSize": 730492
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 841575,
-          "resourceSize": 1893318
+          "transferSize": 655094,
+          "resourceSize": 1275495
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5562,
-          "resourceSize": 25016
+          "transferSize": 5223,
+          "resourceSize": 23729
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 692030,
-          "resourceSize": 2079860
+          "transferSize": 112451,
+          "resourceSize": 318974
         },
         "stylesheet": {
-          "transferSize": 319565,
-          "resourceSize": 730492
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12317,
-          "resourceSize": 13177
+          "transferSize": 9112,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1030092,
-          "resourceSize": 2848761
+          "transferSize": 444347,
+          "resourceSize": 1083050
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2226,
-          "resourceSize": 5910
+          "transferSize": 2030,
+          "resourceSize": 5234
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294103,
-          "resourceSize": 931993
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 319565,
-          "resourceSize": 730492
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 841453,
-          "resourceSize": 1892812
+          "transferSize": 654978,
+          "resourceSize": 1274989
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2354,
-          "resourceSize": 6286
+          "transferSize": 2159,
+          "resourceSize": 5610
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294103,
-          "resourceSize": 931993
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 319565,
-          "resourceSize": 730492
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 841589,
-          "resourceSize": 1893188
+          "transferSize": 655106,
+          "resourceSize": 1275365
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2226,
-          "resourceSize": 5837
+          "transferSize": 2030,
+          "resourceSize": 5161
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294103,
-          "resourceSize": 931993
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 319565,
-          "resourceSize": 730492
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 841460,
-          "resourceSize": 1892739
+          "transferSize": 654975,
+          "resourceSize": 1274916
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2426,
-          "resourceSize": 6396
+          "transferSize": 2233,
+          "resourceSize": 5720
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294103,
-          "resourceSize": 931993
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 319565,
-          "resourceSize": 730492
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 841657,
-          "resourceSize": 1893299
+          "transferSize": 655182,
+          "resourceSize": 1275475
         }
       },
       "themeResources": {
@@ -509,20 +509,20 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3384,
-          "resourceSize": 10352
+          "transferSize": 3183,
+          "resourceSize": 9676
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294103,
-          "resourceSize": 931993
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 319565,
-          "resourceSize": 730492
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
@@ -533,12 +533,12 @@
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 843130,
-          "resourceSize": 1897617
+          "transferSize": 656643,
+          "resourceSize": 1279793
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2699,
-          "resourceSize": 7142
+          "transferSize": 2384,
+          "resourceSize": 5963
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 692030,
-          "resourceSize": 2079860
+          "transferSize": 112451,
+          "resourceSize": 318974
         },
         "stylesheet": {
-          "transferSize": 319565,
-          "resourceSize": 730492
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3944,
-          "resourceSize": 1443
+          "transferSize": 1121,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1243032,
-          "resourceSize": 3043160
+          "transferSize": 657692,
+          "resourceSize": 1277556
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.0.json
+++ b/.github/page_size_audit_results/v1.42.0.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:19.074Z"
+    "generatedAt": "2025-11-27T16:06:21.861Z"
   },
-  "timestamp": "2025-11-22T11:52:19.075Z",
+  "timestamp": "2025-11-27T16:06:21.861Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2509,
-          "resourceSize": 6897
+          "transferSize": 2314,
+          "resourceSize": 6221
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197994,
-          "resourceSize": 646926
+          "transferSize": 14331,
+          "resourceSize": 32069
         },
         "stylesheet": {
-          "transferSize": 12921,
-          "resourceSize": 61220
+          "transferSize": 10299,
+          "resourceSize": 58930
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594839,
-          "resourceSize": 1095140
+          "transferSize": 408359,
+          "resourceSize": 477317
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2462,
-          "resourceSize": 6811
+          "transferSize": 2263,
+          "resourceSize": 6135
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197444,
-          "resourceSize": 646548
+          "transferSize": 13781,
+          "resourceSize": 31691
         },
         "stylesheet": {
-          "transferSize": 12921,
-          "resourceSize": 61220
+          "transferSize": 10299,
+          "resourceSize": 58930
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594240,
-          "resourceSize": 1094676
+          "transferSize": 407754,
+          "resourceSize": 476853
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5679,
-          "resourceSize": 25518
+          "transferSize": 5360,
+          "resourceSize": 24231
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 675086,
-          "resourceSize": 2033429
+          "transferSize": 95507,
+          "resourceSize": 272543
         },
         "stylesheet": {
-          "transferSize": 12921,
-          "resourceSize": 61220
+          "transferSize": 10299,
+          "resourceSize": 58930
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13066,
-          "resourceSize": 14202
+          "transferSize": 10195,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 863220,
-          "resourceSize": 2290265
+          "transferSize": 277829,
+          "resourceSize": 524554
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2324,
-          "resourceSize": 6198
+          "transferSize": 2125,
+          "resourceSize": 5522
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196373,
-          "resourceSize": 643762
+          "transferSize": 12710,
+          "resourceSize": 28905
         },
         "stylesheet": {
-          "transferSize": 12226,
-          "resourceSize": 60690
+          "transferSize": 9604,
+          "resourceSize": 58400
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592332,
-          "resourceSize": 1090747
+          "transferSize": 405851,
+          "resourceSize": 472924
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2457,
-          "resourceSize": 6574
+          "transferSize": 2255,
+          "resourceSize": 5898
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196373,
-          "resourceSize": 643762
+          "transferSize": 12710,
+          "resourceSize": 28905
         },
         "stylesheet": {
-          "transferSize": 12226,
-          "resourceSize": 60690
+          "transferSize": 9604,
+          "resourceSize": 58400
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592467,
-          "resourceSize": 1091123
+          "transferSize": 405982,
+          "resourceSize": 473300
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2323,
-          "resourceSize": 6125
+          "transferSize": 2128,
+          "resourceSize": 5449
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196373,
-          "resourceSize": 643762
+          "transferSize": 12710,
+          "resourceSize": 28905
         },
         "stylesheet": {
-          "transferSize": 12226,
-          "resourceSize": 60690
+          "transferSize": 9604,
+          "resourceSize": 58400
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592336,
-          "resourceSize": 1090675
+          "transferSize": 405859,
+          "resourceSize": 472851
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2530,
-          "resourceSize": 6684
+          "transferSize": 2330,
+          "resourceSize": 6008
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196373,
-          "resourceSize": 643762
+          "transferSize": 12710,
+          "resourceSize": 28905
         },
         "stylesheet": {
-          "transferSize": 12226,
-          "resourceSize": 60690
+          "transferSize": 9604,
+          "resourceSize": 58400
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592542,
-          "resourceSize": 1091234
+          "transferSize": 406053,
+          "resourceSize": 473410
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3494,
-          "resourceSize": 10634
+          "transferSize": 3297,
+          "resourceSize": 9958
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196203,
-          "resourceSize": 643762
+          "transferSize": 12540,
+          "resourceSize": 28905
         },
         "stylesheet": {
-          "transferSize": 13105,
-          "resourceSize": 61404
+          "transferSize": 10483,
+          "resourceSize": 59114
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1938,
+          "transferSize": 1944,
           "resourceSize": 1239
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 595384,
-          "resourceSize": 1096942
+          "transferSize": 408907,
+          "resourceSize": 479118
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2832,
-          "resourceSize": 7642
+          "transferSize": 2521,
+          "resourceSize": 6463
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 675086,
-          "resourceSize": 2033429
+          "transferSize": 95507,
+          "resourceSize": 272543
         },
         "stylesheet": {
-          "transferSize": 12921,
-          "resourceSize": 61220
+          "transferSize": 10299,
+          "resourceSize": 58930
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1129,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1075430,
-          "resourceSize": 2483637
+          "transferSize": 490100,
+          "resourceSize": 718034
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.1.json
+++ b/.github/page_size_audit_results/v1.42.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:57.313Z"
+    "generatedAt": "2025-11-27T16:03:46.224Z"
   },
-  "timestamp": "2025-11-22T11:51:57.313Z",
+  "timestamp": "2025-11-27T16:03:46.224Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3012,
-          "resourceSize": 8169
+          "transferSize": 2819,
+          "resourceSize": 7493
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198105,
-          "resourceSize": 647069
+          "transferSize": 14442,
+          "resourceSize": 32212
         },
         "stylesheet": {
-          "transferSize": 12437,
-          "resourceSize": 59130
+          "transferSize": 9815,
+          "resourceSize": 56840
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594968,
-          "resourceSize": 1094465
+          "transferSize": 408487,
+          "resourceSize": 476642
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2988,
-          "resourceSize": 8187
+          "transferSize": 2796,
+          "resourceSize": 7511
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197788,
-          "resourceSize": 646752
+          "transferSize": 14125,
+          "resourceSize": 31895
         },
         "stylesheet": {
-          "transferSize": 12437,
-          "resourceSize": 59130
+          "transferSize": 9815,
+          "resourceSize": 56840
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594623,
-          "resourceSize": 1094166
+          "transferSize": 408145,
+          "resourceSize": 476343
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6193,
-          "resourceSize": 26882
+          "transferSize": 5898,
+          "resourceSize": 25595
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 675206,
-          "resourceSize": 2033196
+          "transferSize": 95627,
+          "resourceSize": 272310
         },
         "stylesheet": {
-          "transferSize": 12437,
-          "resourceSize": 59130
+          "transferSize": 9815,
+          "resourceSize": 56840
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13017,
-          "resourceSize": 14202
+          "transferSize": 10183,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 863321,
-          "resourceSize": 2289306
+          "transferSize": 277991,
+          "resourceSize": 523595
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2850,
-          "resourceSize": 7567
+          "transferSize": 2655,
+          "resourceSize": 6891
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11742,
-          "resourceSize": 58600
+          "transferSize": 9120,
+          "resourceSize": 56310
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592726,
-          "resourceSize": 1090228
+          "transferSize": 406237,
+          "resourceSize": 472405
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2986,
-          "resourceSize": 7941
+          "transferSize": 2791,
+          "resourceSize": 7265
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11742,
-          "resourceSize": 58600
+          "transferSize": 9120,
+          "resourceSize": 56310
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592859,
-          "resourceSize": 1090603
+          "transferSize": 406376,
+          "resourceSize": 472779
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2850,
-          "resourceSize": 7506
+          "transferSize": 2655,
+          "resourceSize": 6830
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11742,
-          "resourceSize": 58600
+          "transferSize": 9120,
+          "resourceSize": 56310
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592726,
-          "resourceSize": 1090168
+          "transferSize": 406234,
+          "resourceSize": 472344
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3065,
-          "resourceSize": 8061
+          "transferSize": 2871,
+          "resourceSize": 7385
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11742,
-          "resourceSize": 58600
+          "transferSize": 9120,
+          "resourceSize": 56310
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592938,
-          "resourceSize": 1090723
+          "transferSize": 406453,
+          "resourceSize": 472899
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4027,
-          "resourceSize": 12010
+          "transferSize": 3858,
+          "resourceSize": 11334
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196515,
-          "resourceSize": 643934
+          "transferSize": 12852,
+          "resourceSize": 29077
         },
         "stylesheet": {
-          "transferSize": 12587,
-          "resourceSize": 59280
+          "transferSize": 9965,
+          "resourceSize": 56990
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1967,
+          "transferSize": 1924,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595740,
-          "resourceSize": 1096366
+          "transferSize": 409243,
+          "resourceSize": 478543
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3387,
-          "resourceSize": 9006
+          "transferSize": 3045,
+          "resourceSize": 7827
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 675206,
-          "resourceSize": 2033196
+          "transferSize": 95627,
+          "resourceSize": 272310
         },
         "stylesheet": {
-          "transferSize": 12437,
-          "resourceSize": 59130
+          "transferSize": 9815,
+          "resourceSize": 56840
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3944,
-          "resourceSize": 1443
+          "transferSize": 1121,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1075618,
-          "resourceSize": 2482678
+          "transferSize": 490252,
+          "resourceSize": 717075
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.10.json
+++ b/.github/page_size_audit_results/v1.42.10.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.10",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:54:32.031Z"
+    "generatedAt": "2025-11-27T16:04:01.758Z"
   },
-  "timestamp": "2025-11-22T11:54:32.031Z",
+  "timestamp": "2025-11-27T16:04:01.758Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3050,
-          "resourceSize": 8278
+          "transferSize": 2837,
+          "resourceSize": 7602
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198340,
-          "resourceSize": 647261
+          "transferSize": 14677,
+          "resourceSize": 32404
         },
         "stylesheet": {
-          "transferSize": 11986,
-          "resourceSize": 58380
+          "transferSize": 9364,
+          "resourceSize": 56090
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594791,
-          "resourceSize": 1094016
+          "transferSize": 408290,
+          "resourceSize": 476193
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3013,
-          "resourceSize": 8194
+          "transferSize": 2798,
+          "resourceSize": 7518
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197823,
-          "resourceSize": 646916
+          "transferSize": 14160,
+          "resourceSize": 32059
         },
         "stylesheet": {
-          "transferSize": 11986,
-          "resourceSize": 58380
+          "transferSize": 9364,
+          "resourceSize": 56090
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594233,
-          "resourceSize": 1093587
+          "transferSize": 407733,
+          "resourceSize": 475764
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5940,
-          "resourceSize": 26137
+          "transferSize": 5624,
+          "resourceSize": 24850
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597920,
-          "resourceSize": 1799624
+          "transferSize": 18341,
+          "resourceSize": 38738
         },
         "stylesheet": {
-          "transferSize": 13582,
-          "resourceSize": 64232
+          "transferSize": 10960,
+          "resourceSize": 61942
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13019,
-          "resourceSize": 14202
+          "transferSize": 10197,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 786929,
-          "resourceSize": 2060091
+          "transferSize": 201590,
+          "resourceSize": 294380
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2856,
-          "resourceSize": 7574
+          "transferSize": 2657,
+          "resourceSize": 6898
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592284,
-          "resourceSize": 1089501
+          "transferSize": 405799,
+          "resourceSize": 471678
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2990,
-          "resourceSize": 7948
+          "transferSize": 2792,
+          "resourceSize": 7272
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592426,
-          "resourceSize": 1089876
+          "transferSize": 405935,
+          "resourceSize": 472052
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2857,
-          "resourceSize": 7513
+          "transferSize": 2658,
+          "resourceSize": 6837
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592292,
-          "resourceSize": 1089441
+          "transferSize": 405802,
+          "resourceSize": 471617
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3067,
-          "resourceSize": 8068
+          "transferSize": 2874,
+          "resourceSize": 7392
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592501,
-          "resourceSize": 1089996
+          "transferSize": 406015,
+          "resourceSize": 472172
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4028,
-          "resourceSize": 12017
+          "transferSize": 3859,
+          "resourceSize": 11341
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196527,
-          "resourceSize": 643950
+          "transferSize": 12864,
+          "resourceSize": 29093
         },
         "stylesheet": {
-          "transferSize": 12136,
-          "resourceSize": 58530
+          "transferSize": 9514,
+          "resourceSize": 56240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1941,
+          "transferSize": 1937,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595276,
-          "resourceSize": 1095639
+          "transferSize": 408818,
+          "resourceSize": 477816
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3425,
-          "resourceSize": 9214
+          "transferSize": 3080,
+          "resourceSize": 8035
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 598437,
-          "resourceSize": 1799969
+          "transferSize": 18858,
+          "resourceSize": 39083
         },
         "stylesheet": {
-          "transferSize": 13582,
-          "resourceSize": 64232
+          "transferSize": 10960,
+          "resourceSize": 61942
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3943,
-          "resourceSize": 1443
+          "transferSize": 1120,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1000031,
-          "resourceSize": 2254761
+          "transferSize": 414662,
+          "resourceSize": 489158
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.11.json
+++ b/.github/page_size_audit_results/v1.42.11.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.11",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:54:30.289Z"
+    "generatedAt": "2025-11-27T16:03:49.209Z"
   },
-  "timestamp": "2025-11-22T11:54:30.290Z",
+  "timestamp": "2025-11-27T16:03:49.209Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3049,
-          "resourceSize": 8278
+          "transferSize": 2839,
+          "resourceSize": 7602
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198340,
-          "resourceSize": 647261
+          "transferSize": 14677,
+          "resourceSize": 32404
         },
         "stylesheet": {
-          "transferSize": 11986,
-          "resourceSize": 58380
+          "transferSize": 9364,
+          "resourceSize": 56090
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594793,
-          "resourceSize": 1094016
+          "transferSize": 408295,
+          "resourceSize": 476193
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3010,
-          "resourceSize": 8194
+          "transferSize": 2799,
+          "resourceSize": 7518
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197823,
-          "resourceSize": 646916
+          "transferSize": 14160,
+          "resourceSize": 32059
         },
         "stylesheet": {
-          "transferSize": 11986,
-          "resourceSize": 58380
+          "transferSize": 9364,
+          "resourceSize": 56090
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594227,
-          "resourceSize": 1093587
+          "transferSize": 407738,
+          "resourceSize": 475764
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5937,
-          "resourceSize": 26137
+          "transferSize": 5627,
+          "resourceSize": 24850
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597920,
-          "resourceSize": 1799624
+          "transferSize": 18341,
+          "resourceSize": 38738
         },
         "stylesheet": {
-          "transferSize": 13582,
-          "resourceSize": 64232
+          "transferSize": 10960,
+          "resourceSize": 61942
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13081,
-          "resourceSize": 14202
+          "transferSize": 10183,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 786988,
-          "resourceSize": 2060091
+          "transferSize": 201579,
+          "resourceSize": 294380
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2855,
-          "resourceSize": 7574
+          "transferSize": 2659,
+          "resourceSize": 6898
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592283,
-          "resourceSize": 1089501
+          "transferSize": 405812,
+          "resourceSize": 471678
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2988,
-          "resourceSize": 7948
+          "transferSize": 2794,
+          "resourceSize": 7272
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592420,
-          "resourceSize": 1089876
+          "transferSize": 405938,
+          "resourceSize": 472052
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2856,
-          "resourceSize": 7513
+          "transferSize": 2659,
+          "resourceSize": 6837
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592288,
-          "resourceSize": 1089441
+          "transferSize": 405801,
+          "resourceSize": 471617
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3065,
-          "resourceSize": 8068
+          "transferSize": 2876,
+          "resourceSize": 7392
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592500,
-          "resourceSize": 1089996
+          "transferSize": 406019,
+          "resourceSize": 472172
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4025,
-          "resourceSize": 12017
+          "transferSize": 3859,
+          "resourceSize": 11341
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196527,
-          "resourceSize": 643950
+          "transferSize": 12864,
+          "resourceSize": 29093
         },
         "stylesheet": {
-          "transferSize": 12136,
-          "resourceSize": 58530
+          "transferSize": 9514,
+          "resourceSize": 56240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1935,
+          "transferSize": 1937,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595267,
-          "resourceSize": 1095639
+          "transferSize": 408818,
+          "resourceSize": 477816
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3422,
-          "resourceSize": 9214
+          "transferSize": 3081,
+          "resourceSize": 8035
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 598437,
-          "resourceSize": 1799969
+          "transferSize": 18858,
+          "resourceSize": 39083
         },
         "stylesheet": {
-          "transferSize": 13582,
-          "resourceSize": 64232
+          "transferSize": 10960,
+          "resourceSize": 61942
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1119,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1000031,
-          "resourceSize": 2254761
+          "transferSize": 414662,
+          "resourceSize": 489158
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.12.json
+++ b/.github/page_size_audit_results/v1.42.12.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.12",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:16.094Z"
+    "generatedAt": "2025-11-27T16:04:02.386Z"
   },
-  "timestamp": "2025-11-22T11:52:16.095Z",
+  "timestamp": "2025-11-27T16:04:02.386Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3012,
-          "resourceSize": 8079
+          "transferSize": 2817,
+          "resourceSize": 7403
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197842,
-          "resourceSize": 647260
+          "transferSize": 14179,
+          "resourceSize": 32403
         },
         "stylesheet": {
-          "transferSize": 11430,
-          "resourceSize": 58379
+          "transferSize": 8808,
+          "resourceSize": 56089
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593701,
-          "resourceSize": 1093815
+          "transferSize": 407214,
+          "resourceSize": 475992
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2985,
-          "resourceSize": 8097
+          "transferSize": 2787,
+          "resourceSize": 7421
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197842,
-          "resourceSize": 647260
+          "transferSize": 14179,
+          "resourceSize": 32403
         },
         "stylesheet": {
-          "transferSize": 11430,
-          "resourceSize": 58379
+          "transferSize": 8808,
+          "resourceSize": 56089
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593670,
-          "resourceSize": 1093833
+          "transferSize": 407188,
+          "resourceSize": 476010
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5914,
-          "resourceSize": 25929
+          "transferSize": 5604,
+          "resourceSize": 24642
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597413,
-          "resourceSize": 1799614
+          "transferSize": 17834,
+          "resourceSize": 38728
         },
         "stylesheet": {
-          "transferSize": 13026,
-          "resourceSize": 64231
+          "transferSize": 10404,
+          "resourceSize": 61941
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13014,
-          "resourceSize": 14202
+          "transferSize": 10181,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785835,
-          "resourceSize": 2059872
+          "transferSize": 200491,
+          "resourceSize": 294161
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2861,
-          "resourceSize": 7583
+          "transferSize": 2664,
+          "resourceSize": 6907
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197842,
-          "resourceSize": 647260
+          "transferSize": 14179,
+          "resourceSize": 32403
         },
         "stylesheet": {
-          "transferSize": 11430,
-          "resourceSize": 58379
+          "transferSize": 8808,
+          "resourceSize": 56089
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593544,
-          "resourceSize": 1093319
+          "transferSize": 407063,
+          "resourceSize": 475496
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2994,
-          "resourceSize": 7957
+          "transferSize": 2799,
+          "resourceSize": 7281
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197842,
-          "resourceSize": 647260
+          "transferSize": 14179,
+          "resourceSize": 32403
         },
         "stylesheet": {
-          "transferSize": 11430,
-          "resourceSize": 58379
+          "transferSize": 8808,
+          "resourceSize": 56089
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593677,
-          "resourceSize": 1093693
+          "transferSize": 407198,
+          "resourceSize": 475870
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2859,
-          "resourceSize": 7522
+          "transferSize": 2663,
+          "resourceSize": 6846
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197842,
-          "resourceSize": 647260
+          "transferSize": 14179,
+          "resourceSize": 32403
         },
         "stylesheet": {
-          "transferSize": 11430,
-          "resourceSize": 58379
+          "transferSize": 8808,
+          "resourceSize": 56089
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593550,
-          "resourceSize": 1093259
+          "transferSize": 407061,
+          "resourceSize": 475435
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3069,
-          "resourceSize": 8077
+          "transferSize": 2878,
+          "resourceSize": 7401
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197842,
-          "resourceSize": 647260
+          "transferSize": 14179,
+          "resourceSize": 32403
         },
         "stylesheet": {
-          "transferSize": 11430,
-          "resourceSize": 58379
+          "transferSize": 8808,
+          "resourceSize": 56089
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593754,
-          "resourceSize": 1093814
+          "transferSize": 407275,
+          "resourceSize": 475990
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4052,
-          "resourceSize": 12130
+          "transferSize": 3865,
+          "resourceSize": 11454
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197842,
-          "resourceSize": 647260
+          "transferSize": 14179,
+          "resourceSize": 32403
         },
         "stylesheet": {
-          "transferSize": 12275,
-          "resourceSize": 59059
+          "transferSize": 9653,
+          "resourceSize": 56769
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1939,
+          "transferSize": 1930,
           "resourceSize": 1239
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 596752,
-          "resourceSize": 1099591
+          "transferSize": 410270,
+          "resourceSize": 481767
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3404,
-          "resourceSize": 9015
+          "transferSize": 3058,
+          "resourceSize": 7836
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597939,
-          "resourceSize": 1799968
+          "transferSize": 18360,
+          "resourceSize": 39082
         },
         "stylesheet": {
-          "transferSize": 13026,
-          "resourceSize": 64231
+          "transferSize": 10404,
+          "resourceSize": 61941
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998960,
-          "resourceSize": 2254560
+          "transferSize": 413589,
+          "resourceSize": 488957
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.13.json
+++ b/.github/page_size_audit_results/v1.42.13.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.13",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:18.947Z"
+    "generatedAt": "2025-11-27T16:06:14.614Z"
   },
-  "timestamp": "2025-11-22T11:52:18.948Z",
+  "timestamp": "2025-11-27T16:06:14.614Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3040,
-          "resourceSize": 8275
+          "transferSize": 2835,
+          "resourceSize": 7599
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198723,
-          "resourceSize": 647969
+          "transferSize": 15060,
+          "resourceSize": 33112
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594329,
-          "resourceSize": 1094076
+          "transferSize": 407832,
+          "resourceSize": 476253
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3018,
-          "resourceSize": 8295
+          "transferSize": 2811,
+          "resourceSize": 7619
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198723,
-          "resourceSize": 647969
+          "transferSize": 15060,
+          "resourceSize": 33112
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594302,
-          "resourceSize": 1094096
+          "transferSize": 407812,
+          "resourceSize": 476273
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5839,
-          "resourceSize": 25954
+          "transferSize": 5546,
+          "resourceSize": 24667
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 598294,
-          "resourceSize": 1800323
+          "transferSize": 18715,
+          "resourceSize": 39437
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13084,
-          "resourceSize": 14202
+          "transferSize": 10167,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 786431,
-          "resourceSize": 2059962
+          "transferSize": 201020,
+          "resourceSize": 294251
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2880,
-          "resourceSize": 7786
+          "transferSize": 2688,
+          "resourceSize": 7110
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198723,
-          "resourceSize": 647969
+          "transferSize": 15060,
+          "resourceSize": 33112
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594165,
-          "resourceSize": 1093587
+          "transferSize": 407685,
+          "resourceSize": 475764
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3011,
-          "resourceSize": 8160
+          "transferSize": 2823,
+          "resourceSize": 7484
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198723,
-          "resourceSize": 647969
+          "transferSize": 15060,
+          "resourceSize": 33112
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
@@ -320,12 +320,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 594296,
-          "resourceSize": 1093962
+          "transferSize": 407822,
+          "resourceSize": 476138
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2879,
-          "resourceSize": 7725
+          "transferSize": 2688,
+          "resourceSize": 7049
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198723,
-          "resourceSize": 647969
+          "transferSize": 15060,
+          "resourceSize": 33112
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 594166,
-          "resourceSize": 1093527
+          "transferSize": 407683,
+          "resourceSize": 475703
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3108,
-          "resourceSize": 8280
+          "transferSize": 2906,
+          "resourceSize": 7604
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198723,
-          "resourceSize": 647969
+          "transferSize": 15060,
+          "resourceSize": 33112
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 594389,
-          "resourceSize": 1094082
+          "transferSize": 407906,
+          "resourceSize": 476258
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3939,
-          "resourceSize": 12092
+          "transferSize": 3760,
+          "resourceSize": 11416
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198723,
-          "resourceSize": 647969
+          "transferSize": 15060,
+          "resourceSize": 33112
         },
         "stylesheet": {
-          "transferSize": 11995,
-          "resourceSize": 58415
+          "transferSize": 9373,
+          "resourceSize": 56125
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1932,
+          "transferSize": 1943,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 597233,
-          "resourceSize": 1099618
+          "transferSize": 410780,
+          "resourceSize": 481795
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3393,
-          "resourceSize": 9238
+          "transferSize": 3077,
+          "resourceSize": 8059
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 598820,
-          "resourceSize": 1800677
+          "transferSize": 19241,
+          "resourceSize": 39791
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3948,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 999551,
-          "resourceSize": 2254848
+          "transferSize": 414209,
+          "resourceSize": 489245
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.14.json
+++ b/.github/page_size_audit_results/v1.42.14.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.14",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:02.373Z"
+    "generatedAt": "2025-11-27T16:06:18.305Z"
   },
-  "timestamp": "2025-11-22T11:52:02.374Z",
+  "timestamp": "2025-11-27T16:06:18.305Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3067,
-          "resourceSize": 8274
+          "transferSize": 2862,
+          "resourceSize": 7598
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197764,
-          "resourceSize": 647029
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593396,
-          "resourceSize": 1093135
+          "transferSize": 406898,
+          "resourceSize": 475312
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3042,
-          "resourceSize": 8294
+          "transferSize": 2836,
+          "resourceSize": 7618
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197764,
-          "resourceSize": 647029
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593367,
-          "resourceSize": 1093155
+          "transferSize": 406880,
+          "resourceSize": 475332
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6000,
-          "resourceSize": 26660
+          "transferSize": 5679,
+          "resourceSize": 25373
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597330,
-          "resourceSize": 1799366
+          "transferSize": 17751,
+          "resourceSize": 38480
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13024,
-          "resourceSize": 14202
+          "transferSize": 10197,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785568,
-          "resourceSize": 2059711
+          "transferSize": 200219,
+          "resourceSize": 294000
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2903,
-          "resourceSize": 7785
+          "transferSize": 2714,
+          "resourceSize": 7109
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197764,
-          "resourceSize": 647029
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593236,
-          "resourceSize": 1092646
+          "transferSize": 406752,
+          "resourceSize": 474823
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3082,
-          "resourceSize": 8296
+          "transferSize": 2880,
+          "resourceSize": 7620
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197764,
-          "resourceSize": 647029
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593407,
-          "resourceSize": 1093157
+          "transferSize": 406931,
+          "resourceSize": 475334
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2901,
-          "resourceSize": 7724
+          "transferSize": 2714,
+          "resourceSize": 7048
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197764,
-          "resourceSize": 647029
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593229,
-          "resourceSize": 1092586
+          "transferSize": 406761,
+          "resourceSize": 474762
         }
       },
       "themeResources": {
@@ -438,20 +438,20 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3174,
-          "resourceSize": 8438
+          "transferSize": 2970,
+          "resourceSize": 7762
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197764,
-          "resourceSize": 647029
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
@@ -462,12 +462,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593501,
-          "resourceSize": 1093300
+          "transferSize": 407011,
+          "resourceSize": 475476
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3998,
-          "resourceSize": 12244
+          "transferSize": 3821,
+          "resourceSize": 11568
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197764,
-          "resourceSize": 647029
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 11995,
-          "resourceSize": 58415
+          "transferSize": 9373,
+          "resourceSize": 56125
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1932,
+          "transferSize": 1939,
           "resourceSize": 1239
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 596333,
-          "resourceSize": 1098830
+          "transferSize": 409877,
+          "resourceSize": 481006
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3419,
-          "resourceSize": 9237
+          "transferSize": 3102,
+          "resourceSize": 8058
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597856,
-          "resourceSize": 1799720
+          "transferSize": 18277,
+          "resourceSize": 38834
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3945,
-          "resourceSize": 1443
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998610,
-          "resourceSize": 2253890
+          "transferSize": 413273,
+          "resourceSize": 488287
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.2.json
+++ b/.github/page_size_audit_results/v1.42.2.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:59.035Z"
+    "generatedAt": "2025-11-27T16:06:10.816Z"
   },
-  "timestamp": "2025-11-22T11:51:59.035Z",
+  "timestamp": "2025-11-27T16:06:10.817Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3015,
-          "resourceSize": 8169
+          "transferSize": 2821,
+          "resourceSize": 7493
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198105,
-          "resourceSize": 647069
+          "transferSize": 14442,
+          "resourceSize": 32212
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594995,
-          "resourceSize": 1094514
+          "transferSize": 408511,
+          "resourceSize": 476691
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2986,
-          "resourceSize": 8187
+          "transferSize": 2795,
+          "resourceSize": 7511
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197788,
-          "resourceSize": 646752
+          "transferSize": 14125,
+          "resourceSize": 31895
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594646,
-          "resourceSize": 1094215
+          "transferSize": 408164,
+          "resourceSize": 476392
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5891,
-          "resourceSize": 25886
+          "transferSize": 5584,
+          "resourceSize": 24599
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597766,
-          "resourceSize": 1799154
+          "transferSize": 18187,
+          "resourceSize": 38268
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13088,
-          "resourceSize": 14202
+          "transferSize": 10166,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785671,
-          "resourceSize": 2054317
+          "transferSize": 200241,
+          "resourceSize": 288606
         }
       },
       "themeResources": {
@@ -225,20 +225,20 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2851,
-          "resourceSize": 7567
+          "transferSize": 2653,
+          "resourceSize": 6891
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592745,
-          "resourceSize": 1090277
+          "transferSize": 406262,
+          "resourceSize": 472454
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2985,
-          "resourceSize": 7941
+          "transferSize": 2791,
+          "resourceSize": 7265
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592875,
-          "resourceSize": 1090651
+          "transferSize": 406398,
+          "resourceSize": 472828
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2848,
-          "resourceSize": 7506
+          "transferSize": 2654,
+          "resourceSize": 6830
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592741,
-          "resourceSize": 1090217
+          "transferSize": 406265,
+          "resourceSize": 472393
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3062,
-          "resourceSize": 8061
+          "transferSize": 2872,
+          "resourceSize": 7385
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592955,
-          "resourceSize": 1090772
+          "transferSize": 406477,
+          "resourceSize": 472948
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4028,
-          "resourceSize": 12010
+          "transferSize": 3857,
+          "resourceSize": 11334
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196515,
-          "resourceSize": 643934
+          "transferSize": 12852,
+          "resourceSize": 29077
         },
         "stylesheet": {
-          "transferSize": 12608,
-          "resourceSize": 59329
+          "transferSize": 9986,
+          "resourceSize": 57039
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1951,
+          "transferSize": 1954,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595746,
-          "resourceSize": 1096415
+          "transferSize": 409293,
+          "resourceSize": 478592
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3389,
-          "resourceSize": 9006
+          "transferSize": 3045,
+          "resourceSize": 7827
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597766,
-          "resourceSize": 1799154
+          "transferSize": 18187,
+          "resourceSize": 38268
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998203,
-          "resourceSize": 2248685
+          "transferSize": 412835,
+          "resourceSize": 483082
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.3.json
+++ b/.github/page_size_audit_results/v1.42.3.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:00.677Z"
+    "generatedAt": "2025-11-27T16:06:22.201Z"
   },
-  "timestamp": "2025-11-22T11:52:00.677Z",
+  "timestamp": "2025-11-27T16:06:22.201Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3010,
-          "resourceSize": 8169
+          "transferSize": 2824,
+          "resourceSize": 7493
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198105,
-          "resourceSize": 647069
+          "transferSize": 14442,
+          "resourceSize": 32212
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594986,
-          "resourceSize": 1094514
+          "transferSize": 408513,
+          "resourceSize": 476691
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2986,
-          "resourceSize": 8187
+          "transferSize": 2799,
+          "resourceSize": 7511
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197788,
-          "resourceSize": 646752
+          "transferSize": 14125,
+          "resourceSize": 31895
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594641,
-          "resourceSize": 1094215
+          "transferSize": 408176,
+          "resourceSize": 476392
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5884,
-          "resourceSize": 25886
+          "transferSize": 5588,
+          "resourceSize": 24599
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597750,
-          "resourceSize": 1799125
+          "transferSize": 18171,
+          "resourceSize": 38239
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13039,
-          "resourceSize": 14202
+          "transferSize": 10219,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785599,
-          "resourceSize": 2054288
+          "transferSize": 200282,
+          "resourceSize": 288577
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2850,
-          "resourceSize": 7567
+          "transferSize": 2657,
+          "resourceSize": 6891
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592747,
-          "resourceSize": 1090277
+          "transferSize": 406257,
+          "resourceSize": 472454
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2983,
-          "resourceSize": 7941
+          "transferSize": 2792,
+          "resourceSize": 7265
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
@@ -320,12 +320,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592875,
-          "resourceSize": 1090652
+          "transferSize": 406398,
+          "resourceSize": 472828
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2848,
-          "resourceSize": 7506
+          "transferSize": 2656,
+          "resourceSize": 6830
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592742,
-          "resourceSize": 1090217
+          "transferSize": 406261,
+          "resourceSize": 472393
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3062,
-          "resourceSize": 8061
+          "transferSize": 2874,
+          "resourceSize": 7385
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592950,
-          "resourceSize": 1090772
+          "transferSize": 406478,
+          "resourceSize": 472948
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4029,
-          "resourceSize": 12010
+          "transferSize": 3861,
+          "resourceSize": 11334
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196515,
-          "resourceSize": 643934
+          "transferSize": 12852,
+          "resourceSize": 29077
         },
         "stylesheet": {
-          "transferSize": 12608,
-          "resourceSize": 59329
+          "transferSize": 9986,
+          "resourceSize": 57039
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1942,
+          "transferSize": 1936,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595738,
-          "resourceSize": 1096415
+          "transferSize": 409279,
+          "resourceSize": 478592
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3389,
-          "resourceSize": 9006
+          "transferSize": 3049,
+          "resourceSize": 7827
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597750,
-          "resourceSize": 1799125
+          "transferSize": 18171,
+          "resourceSize": 38239
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3945,
-          "resourceSize": 1443
+          "transferSize": 1119,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998186,
-          "resourceSize": 2248656
+          "transferSize": 412819,
+          "resourceSize": 483053
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.4.json
+++ b/.github/page_size_audit_results/v1.42.4.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:04.025Z"
+    "generatedAt": "2025-11-27T16:03:42.454Z"
   },
-  "timestamp": "2025-11-22T11:52:04.026Z",
+  "timestamp": "2025-11-27T16:03:42.454Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3015,
-          "resourceSize": 8169
+          "transferSize": 2822,
+          "resourceSize": 7493
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198105,
-          "resourceSize": 647069
+          "transferSize": 14442,
+          "resourceSize": 32212
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594993,
-          "resourceSize": 1094514
+          "transferSize": 408511,
+          "resourceSize": 476691
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2988,
-          "resourceSize": 8187
+          "transferSize": 2796,
+          "resourceSize": 7511
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197788,
-          "resourceSize": 646752
+          "transferSize": 14125,
+          "resourceSize": 31895
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594646,
-          "resourceSize": 1094215
+          "transferSize": 408171,
+          "resourceSize": 476392
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5886,
-          "resourceSize": 25886
+          "transferSize": 5588,
+          "resourceSize": 24599
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597750,
-          "resourceSize": 1799125
+          "transferSize": 18171,
+          "resourceSize": 38239
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13092,
-          "resourceSize": 14202
+          "transferSize": 10200,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785654,
-          "resourceSize": 2054288
+          "transferSize": 200263,
+          "resourceSize": 288577
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2850,
-          "resourceSize": 7567
+          "transferSize": 2658,
+          "resourceSize": 6891
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592742,
-          "resourceSize": 1090277
+          "transferSize": 406264,
+          "resourceSize": 472454
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2987,
-          "resourceSize": 7941
+          "transferSize": 2792,
+          "resourceSize": 7265
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592874,
-          "resourceSize": 1090652
+          "transferSize": 406392,
+          "resourceSize": 472828
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2849,
-          "resourceSize": 7506
+          "transferSize": 2656,
+          "resourceSize": 6830
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592749,
-          "resourceSize": 1090217
+          "transferSize": 406260,
+          "resourceSize": 472393
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3066,
-          "resourceSize": 8061
+          "transferSize": 2872,
+          "resourceSize": 7385
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196715,
-          "resourceSize": 643964
+          "transferSize": 13052,
+          "resourceSize": 29107
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592960,
-          "resourceSize": 1090772
+          "transferSize": 406476,
+          "resourceSize": 472948
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4030,
-          "resourceSize": 12010
+          "transferSize": 3860,
+          "resourceSize": 11334
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196515,
-          "resourceSize": 643934
+          "transferSize": 12852,
+          "resourceSize": 29077
         },
         "stylesheet": {
-          "transferSize": 12608,
-          "resourceSize": 59329
+          "transferSize": 9986,
+          "resourceSize": 57039
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1941,
+          "transferSize": 1937,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595738,
-          "resourceSize": 1096415
+          "transferSize": 409279,
+          "resourceSize": 478592
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3387,
-          "resourceSize": 9006
+          "transferSize": 3050,
+          "resourceSize": 7827
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597750,
-          "resourceSize": 1799125
+          "transferSize": 18171,
+          "resourceSize": 38239
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3948,
-          "resourceSize": 1443
+          "transferSize": 1128,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998187,
-          "resourceSize": 2248656
+          "transferSize": 412829,
+          "resourceSize": 483053
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.5.json
+++ b/.github/page_size_audit_results/v1.42.5.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.5",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:10.057Z"
+    "generatedAt": "2025-11-27T16:03:42.441Z"
   },
-  "timestamp": "2025-11-22T11:52:10.058Z",
+  "timestamp": "2025-11-27T16:03:42.441Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3036,
-          "resourceSize": 8271
+          "transferSize": 2832,
+          "resourceSize": 7595
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198307,
-          "resourceSize": 647099
+          "transferSize": 14644,
+          "resourceSize": 32242
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 595214,
-          "resourceSize": 1094646
+          "transferSize": 408724,
+          "resourceSize": 476823
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2983,
-          "resourceSize": 8187
+          "transferSize": 2794,
+          "resourceSize": 7511
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197790,
-          "resourceSize": 646754
+          "transferSize": 14127,
+          "resourceSize": 31897
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594644,
-          "resourceSize": 1094217
+          "transferSize": 408168,
+          "resourceSize": 476394
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5880,
-          "resourceSize": 25886
+          "transferSize": 5580,
+          "resourceSize": 24599
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597752,
-          "resourceSize": 1799127
+          "transferSize": 18173,
+          "resourceSize": 38241
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13035,
-          "resourceSize": 14202
+          "transferSize": 10186,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785593,
-          "resourceSize": 2054290
+          "transferSize": 200243,
+          "resourceSize": 288579
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2846,
-          "resourceSize": 7567
+          "transferSize": 2655,
+          "resourceSize": 6891
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196717,
-          "resourceSize": 643966
+          "transferSize": 13054,
+          "resourceSize": 29109
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592736,
-          "resourceSize": 1090279
+          "transferSize": 406261,
+          "resourceSize": 472456
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2980,
-          "resourceSize": 7941
+          "transferSize": 2790,
+          "resourceSize": 7265
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196717,
-          "resourceSize": 643966
+          "transferSize": 13054,
+          "resourceSize": 29109
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592875,
-          "resourceSize": 1090654
+          "transferSize": 406391,
+          "resourceSize": 472830
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2845,
-          "resourceSize": 7506
+          "transferSize": 2653,
+          "resourceSize": 6830
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196717,
-          "resourceSize": 643966
+          "transferSize": 13054,
+          "resourceSize": 29109
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592736,
-          "resourceSize": 1090219
+          "transferSize": 406256,
+          "resourceSize": 472395
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3059,
-          "resourceSize": 8061
+          "transferSize": 2870,
+          "resourceSize": 7385
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196717,
-          "resourceSize": 643966
+          "transferSize": 13054,
+          "resourceSize": 29109
         },
         "stylesheet": {
-          "transferSize": 11763,
-          "resourceSize": 58649
+          "transferSize": 9141,
+          "resourceSize": 56359
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592952,
-          "resourceSize": 1090774
+          "transferSize": 406474,
+          "resourceSize": 472950
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4019,
-          "resourceSize": 12010
+          "transferSize": 3854,
+          "resourceSize": 11334
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196517,
-          "resourceSize": 643936
+          "transferSize": 12854,
+          "resourceSize": 29079
         },
         "stylesheet": {
-          "transferSize": 12608,
-          "resourceSize": 59329
+          "transferSize": 9986,
+          "resourceSize": 57039
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1914,
+          "transferSize": 1946,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595702,
-          "resourceSize": 1096417
+          "transferSize": 409284,
+          "resourceSize": 478594
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3402,
-          "resourceSize": 9108
+          "transferSize": 3057,
+          "resourceSize": 7929
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 598269,
-          "resourceSize": 1799472
+          "transferSize": 18690,
+          "resourceSize": 38586
         },
         "stylesheet": {
-          "transferSize": 12458,
-          "resourceSize": 59179
+          "transferSize": 9836,
+          "resourceSize": 56889
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3944,
-          "resourceSize": 1443
+          "transferSize": 1116,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998717,
-          "resourceSize": 2249105
+          "transferSize": 413343,
+          "resourceSize": 483502
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.6.json
+++ b/.github/page_size_audit_results/v1.42.6.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.6",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:03.835Z"
+    "generatedAt": "2025-11-27T16:06:02.934Z"
   },
-  "timestamp": "2025-11-22T11:52:03.835Z",
+  "timestamp": "2025-11-27T16:06:02.934Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3047,
-          "resourceSize": 8271
+          "transferSize": 2840,
+          "resourceSize": 7595
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198306,
-          "resourceSize": 647099
+          "transferSize": 14643,
+          "resourceSize": 32242
         },
         "stylesheet": {
-          "transferSize": 12506,
-          "resourceSize": 59229
+          "transferSize": 9884,
+          "resourceSize": 56939
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 595271,
-          "resourceSize": 1094696
+          "transferSize": 408779,
+          "resourceSize": 476873
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2994,
-          "resourceSize": 8187
+          "transferSize": 2800,
+          "resourceSize": 7511
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197789,
-          "resourceSize": 646754
+          "transferSize": 14126,
+          "resourceSize": 31897
         },
         "stylesheet": {
-          "transferSize": 12506,
-          "resourceSize": 59229
+          "transferSize": 9884,
+          "resourceSize": 56939
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594702,
-          "resourceSize": 1094267
+          "transferSize": 408223,
+          "resourceSize": 476444
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5891,
-          "resourceSize": 25886
+          "transferSize": 5588,
+          "resourceSize": 24599
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597751,
-          "resourceSize": 1799127
+          "transferSize": 18172,
+          "resourceSize": 38241
         },
         "stylesheet": {
-          "transferSize": 12506,
-          "resourceSize": 59229
+          "transferSize": 9884,
+          "resourceSize": 56939
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13033,
-          "resourceSize": 14202
+          "transferSize": 10201,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785649,
-          "resourceSize": 2054340
+          "transferSize": 200313,
+          "resourceSize": 288629
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2855,
-          "resourceSize": 7567
+          "transferSize": 2662,
+          "resourceSize": 6891
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196717,
-          "resourceSize": 643966
+          "transferSize": 13054,
+          "resourceSize": 29109
         },
         "stylesheet": {
-          "transferSize": 11811,
-          "resourceSize": 58699
+          "transferSize": 9189,
+          "resourceSize": 56409
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592797,
-          "resourceSize": 1090329
+          "transferSize": 406318,
+          "resourceSize": 472506
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2989,
-          "resourceSize": 7941
+          "transferSize": 2795,
+          "resourceSize": 7265
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196717,
-          "resourceSize": 643966
+          "transferSize": 13054,
+          "resourceSize": 29109
         },
         "stylesheet": {
-          "transferSize": 11811,
-          "resourceSize": 58699
+          "transferSize": 9189,
+          "resourceSize": 56409
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592929,
-          "resourceSize": 1090704
+          "transferSize": 406448,
+          "resourceSize": 472880
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2856,
-          "resourceSize": 7506
+          "transferSize": 2660,
+          "resourceSize": 6830
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196717,
-          "resourceSize": 643966
+          "transferSize": 13054,
+          "resourceSize": 29109
         },
         "stylesheet": {
-          "transferSize": 11811,
-          "resourceSize": 58699
+          "transferSize": 9189,
+          "resourceSize": 56409
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592799,
-          "resourceSize": 1090269
+          "transferSize": 406319,
+          "resourceSize": 472445
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3063,
-          "resourceSize": 8061
+          "transferSize": 2875,
+          "resourceSize": 7385
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196717,
-          "resourceSize": 643966
+          "transferSize": 13054,
+          "resourceSize": 29109
         },
         "stylesheet": {
-          "transferSize": 11811,
-          "resourceSize": 58699
+          "transferSize": 9189,
+          "resourceSize": 56409
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593003,
-          "resourceSize": 1090824
+          "transferSize": 406527,
+          "resourceSize": 473000
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4028,
-          "resourceSize": 12010
+          "transferSize": 3862,
+          "resourceSize": 11334
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196517,
-          "resourceSize": 643936
+          "transferSize": 12854,
+          "resourceSize": 29079
         },
         "stylesheet": {
-          "transferSize": 12656,
-          "resourceSize": 59379
+          "transferSize": 10034,
+          "resourceSize": 57089
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1939,
+          "transferSize": 1935,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595784,
-          "resourceSize": 1096467
+          "transferSize": 409329,
+          "resourceSize": 478644
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3411,
-          "resourceSize": 9108
+          "transferSize": 3068,
+          "resourceSize": 7929
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 598268,
-          "resourceSize": 1799472
+          "transferSize": 18689,
+          "resourceSize": 38586
         },
         "stylesheet": {
-          "transferSize": 12506,
-          "resourceSize": 59229
+          "transferSize": 9884,
+          "resourceSize": 56939
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3948,
-          "resourceSize": 1443
+          "transferSize": 1119,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998777,
-          "resourceSize": 2249155
+          "transferSize": 413404,
+          "resourceSize": 483552
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.7.json
+++ b/.github/page_size_audit_results/v1.42.7.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.7",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:54:34.330Z"
+    "generatedAt": "2025-11-27T16:03:53.554Z"
   },
-  "timestamp": "2025-11-22T11:54:34.330Z",
+  "timestamp": "2025-11-27T16:03:53.554Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3050,
-          "resourceSize": 8277
+          "transferSize": 2844,
+          "resourceSize": 7601
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198360,
-          "resourceSize": 647333
+          "transferSize": 14697,
+          "resourceSize": 32476
         },
         "stylesheet": {
-          "transferSize": 11781,
-          "resourceSize": 53987
+          "transferSize": 9159,
+          "resourceSize": 51697
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594609,
-          "resourceSize": 1089694
+          "transferSize": 408109,
+          "resourceSize": 471871
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3006,
-          "resourceSize": 8193
+          "transferSize": 2802,
+          "resourceSize": 7517
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197843,
-          "resourceSize": 646988
+          "transferSize": 14180,
+          "resourceSize": 32131
         },
         "stylesheet": {
-          "transferSize": 11781,
-          "resourceSize": 53987
+          "transferSize": 9159,
+          "resourceSize": 51697
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594039,
-          "resourceSize": 1089265
+          "transferSize": 407551,
+          "resourceSize": 471442
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5938,
-          "resourceSize": 26136
+          "transferSize": 5634,
+          "resourceSize": 24849
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597843,
-          "resourceSize": 1799518
+          "transferSize": 18264,
+          "resourceSize": 38632
         },
         "stylesheet": {
-          "transferSize": 13349,
-          "resourceSize": 59847
+          "transferSize": 10727,
+          "resourceSize": 57557
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13033,
-          "resourceSize": 14202
+          "transferSize": 10194,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 786631,
-          "resourceSize": 2055599
+          "transferSize": 201287,
+          "resourceSize": 289888
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2853,
-          "resourceSize": 7573
+          "transferSize": 2663,
+          "resourceSize": 6897
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196747,
-          "resourceSize": 644052
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 11086,
-          "resourceSize": 53457
+          "transferSize": 8464,
+          "resourceSize": 51167
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592097,
-          "resourceSize": 1085179
+          "transferSize": 405628,
+          "resourceSize": 467356
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2990,
-          "resourceSize": 7947
+          "transferSize": 2800,
+          "resourceSize": 7271
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196747,
-          "resourceSize": 644052
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 11086,
-          "resourceSize": 53457
+          "transferSize": 8464,
+          "resourceSize": 51167
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592240,
-          "resourceSize": 1085554
+          "transferSize": 405759,
+          "resourceSize": 467730
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2856,
-          "resourceSize": 7512
+          "transferSize": 2664,
+          "resourceSize": 6836
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196747,
-          "resourceSize": 644052
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 11086,
-          "resourceSize": 53457
+          "transferSize": 8464,
+          "resourceSize": 51167
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592103,
-          "resourceSize": 1085119
+          "transferSize": 405630,
+          "resourceSize": 467295
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3070,
-          "resourceSize": 8067
+          "transferSize": 2881,
+          "resourceSize": 7391
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196747,
-          "resourceSize": 644052
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 11086,
-          "resourceSize": 53457
+          "transferSize": 8464,
+          "resourceSize": 51167
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592312,
-          "resourceSize": 1085674
+          "transferSize": 405847,
+          "resourceSize": 467850
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4028,
-          "resourceSize": 12016
+          "transferSize": 3863,
+          "resourceSize": 11340
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196547,
-          "resourceSize": 644022
+          "transferSize": 12884,
+          "resourceSize": 29165
         },
         "stylesheet": {
-          "transferSize": 11931,
-          "resourceSize": 54137
+          "transferSize": 9309,
+          "resourceSize": 51847
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1937,
+          "transferSize": 1934,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595087,
-          "resourceSize": 1091317
+          "transferSize": 408634,
+          "resourceSize": 473494
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3426,
-          "resourceSize": 9213
+          "transferSize": 3088,
+          "resourceSize": 8034
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 598360,
-          "resourceSize": 1799863
+          "transferSize": 18781,
+          "resourceSize": 38977
         },
         "stylesheet": {
-          "transferSize": 13349,
-          "resourceSize": 59847
+          "transferSize": 10727,
+          "resourceSize": 57557
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3944,
-          "resourceSize": 1443
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 999723,
-          "resourceSize": 2250269
+          "transferSize": 414366,
+          "resourceSize": 484666
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.8.json
+++ b/.github/page_size_audit_results/v1.42.8.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.8",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:08.917Z"
+    "generatedAt": "2025-11-27T16:03:36.808Z"
   },
-  "timestamp": "2025-11-22T11:52:08.918Z",
+  "timestamp": "2025-11-27T16:03:36.808Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3050,
-          "resourceSize": 8277
+          "transferSize": 2837,
+          "resourceSize": 7601
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198360,
-          "resourceSize": 647333
+          "transferSize": 14697,
+          "resourceSize": 32476
         },
         "stylesheet": {
-          "transferSize": 11971,
-          "resourceSize": 58352
+          "transferSize": 9349,
+          "resourceSize": 56062
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594793,
-          "resourceSize": 1094059
+          "transferSize": 408296,
+          "resourceSize": 476236
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3012,
-          "resourceSize": 8193
+          "transferSize": 2798,
+          "resourceSize": 7517
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197843,
-          "resourceSize": 646988
+          "transferSize": 14180,
+          "resourceSize": 32131
         },
         "stylesheet": {
-          "transferSize": 11971,
-          "resourceSize": 58352
+          "transferSize": 9349,
+          "resourceSize": 56062
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594238,
-          "resourceSize": 1093630
+          "transferSize": 407738,
+          "resourceSize": 475807
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5938,
-          "resourceSize": 26136
+          "transferSize": 5627,
+          "resourceSize": 24849
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597843,
-          "resourceSize": 1799518
+          "transferSize": 18264,
+          "resourceSize": 38632
         },
         "stylesheet": {
-          "transferSize": 13539,
-          "resourceSize": 64212
+          "transferSize": 10917,
+          "resourceSize": 61922
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13051,
-          "resourceSize": 14202
+          "transferSize": 10153,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 786839,
-          "resourceSize": 2059964
+          "transferSize": 201429,
+          "resourceSize": 294253
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2858,
-          "resourceSize": 7573
+          "transferSize": 2659,
+          "resourceSize": 6897
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196747,
-          "resourceSize": 644052
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 11276,
-          "resourceSize": 57822
+          "transferSize": 8654,
+          "resourceSize": 55532
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592289,
-          "resourceSize": 1089544
+          "transferSize": 405806,
+          "resourceSize": 471721
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2991,
-          "resourceSize": 7947
+          "transferSize": 2794,
+          "resourceSize": 7271
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196747,
-          "resourceSize": 644052
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 11276,
-          "resourceSize": 57822
+          "transferSize": 8654,
+          "resourceSize": 55532
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592430,
-          "resourceSize": 1089919
+          "transferSize": 405943,
+          "resourceSize": 472095
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2859,
-          "resourceSize": 7512
+          "transferSize": 2659,
+          "resourceSize": 6836
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196747,
-          "resourceSize": 644052
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 11276,
-          "resourceSize": 57822
+          "transferSize": 8654,
+          "resourceSize": 55532
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592298,
-          "resourceSize": 1089484
+          "transferSize": 405808,
+          "resourceSize": 471660
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3068,
-          "resourceSize": 8067
+          "transferSize": 2876,
+          "resourceSize": 7391
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196747,
-          "resourceSize": 644052
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 11276,
-          "resourceSize": 57822
+          "transferSize": 8654,
+          "resourceSize": 55532
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592503,
-          "resourceSize": 1090039
+          "transferSize": 406023,
+          "resourceSize": 472215
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4029,
-          "resourceSize": 12016
+          "transferSize": 3856,
+          "resourceSize": 11340
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196547,
-          "resourceSize": 644022
+          "transferSize": 12884,
+          "resourceSize": 29165
         },
         "stylesheet": {
-          "transferSize": 12121,
-          "resourceSize": 58502
+          "transferSize": 9499,
+          "resourceSize": 56212
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1948,
+          "transferSize": 1941,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595289,
-          "resourceSize": 1095682
+          "transferSize": 408824,
+          "resourceSize": 477859
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3427,
-          "resourceSize": 9213
+          "transferSize": 3080,
+          "resourceSize": 8034
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 598360,
-          "resourceSize": 1799863
+          "transferSize": 18781,
+          "resourceSize": 38977
         },
         "stylesheet": {
-          "transferSize": 13539,
-          "resourceSize": 64212
+          "transferSize": 10917,
+          "resourceSize": 61922
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3945,
-          "resourceSize": 1443
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 999915,
-          "resourceSize": 2254634
+          "transferSize": 414544,
+          "resourceSize": 489031
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.9.json
+++ b/.github/page_size_audit_results/v1.42.9.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.9",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:57.174Z"
+    "generatedAt": "2025-11-27T16:03:46.222Z"
   },
-  "timestamp": "2025-11-22T11:51:57.175Z",
+  "timestamp": "2025-11-27T16:03:46.223Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3050,
-          "resourceSize": 8277
+          "transferSize": 2839,
+          "resourceSize": 7601
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 198340,
-          "resourceSize": 647261
+          "transferSize": 14677,
+          "resourceSize": 32404
         },
         "stylesheet": {
-          "transferSize": 11986,
-          "resourceSize": 58380
+          "transferSize": 9364,
+          "resourceSize": 56090
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594791,
-          "resourceSize": 1094015
+          "transferSize": 408293,
+          "resourceSize": 476192
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3008,
-          "resourceSize": 8193
+          "transferSize": 2798,
+          "resourceSize": 7517
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197823,
-          "resourceSize": 646916
+          "transferSize": 14160,
+          "resourceSize": 32059
         },
         "stylesheet": {
-          "transferSize": 11986,
-          "resourceSize": 58380
+          "transferSize": 9364,
+          "resourceSize": 56090
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594229,
-          "resourceSize": 1093586
+          "transferSize": 407734,
+          "resourceSize": 475763
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5940,
-          "resourceSize": 26136
+          "transferSize": 5627,
+          "resourceSize": 24849
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597906,
-          "resourceSize": 1799600
+          "transferSize": 18327,
+          "resourceSize": 38714
         },
         "stylesheet": {
-          "transferSize": 13575,
-          "resourceSize": 64371
+          "transferSize": 10953,
+          "resourceSize": 62081
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13020,
-          "resourceSize": 14202
+          "transferSize": 10207,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 786909,
-          "resourceSize": 2060205
+          "transferSize": 201582,
+          "resourceSize": 294494
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2854,
-          "resourceSize": 7573
+          "transferSize": 2659,
+          "resourceSize": 6897
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592280,
-          "resourceSize": 1089500
+          "transferSize": 405801,
+          "resourceSize": 471677
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2988,
-          "resourceSize": 7947
+          "transferSize": 2793,
+          "resourceSize": 7271
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592418,
-          "resourceSize": 1089875
+          "transferSize": 405935,
+          "resourceSize": 472051
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2856,
-          "resourceSize": 7512
+          "transferSize": 2659,
+          "resourceSize": 6836
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592287,
-          "resourceSize": 1089440
+          "transferSize": 405803,
+          "resourceSize": 471616
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3068,
-          "resourceSize": 8067
+          "transferSize": 2874,
+          "resourceSize": 7391
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196727,
-          "resourceSize": 643980
+          "transferSize": 13064,
+          "resourceSize": 29123
         },
         "stylesheet": {
-          "transferSize": 11291,
-          "resourceSize": 57850
+          "transferSize": 8669,
+          "resourceSize": 55560
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592502,
-          "resourceSize": 1089995
+          "transferSize": 406027,
+          "resourceSize": 472171
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4028,
-          "resourceSize": 12016
+          "transferSize": 3857,
+          "resourceSize": 11340
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196527,
-          "resourceSize": 643950
+          "transferSize": 12864,
+          "resourceSize": 29093
         },
         "stylesheet": {
-          "transferSize": 12136,
-          "resourceSize": 58530
+          "transferSize": 9514,
+          "resourceSize": 56240
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1936,
+          "transferSize": 1934,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 595271,
-          "resourceSize": 1095638
+          "transferSize": 408813,
+          "resourceSize": 477815
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3424,
-          "resourceSize": 9213
+          "transferSize": 3078,
+          "resourceSize": 8034
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 598423,
-          "resourceSize": 1799945
+          "transferSize": 18844,
+          "resourceSize": 39059
         },
         "stylesheet": {
-          "transferSize": 13575,
-          "resourceSize": 64371
+          "transferSize": 10953,
+          "resourceSize": 62081
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1000013,
-          "resourceSize": 2254875
+          "transferSize": 414641,
+          "resourceSize": 489272
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.43.0.json
+++ b/.github/page_size_audit_results/v1.43.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.43.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:07.028Z"
+    "generatedAt": "2025-11-27T16:04:04.303Z"
   },
-  "timestamp": "2025-11-22T11:52:07.028Z",
+  "timestamp": "2025-11-27T16:04:04.303Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3071,
-          "resourceSize": 8273
+          "transferSize": 2864,
+          "resourceSize": 7597
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593407,
-          "resourceSize": 1093165
+          "transferSize": 406916,
+          "resourceSize": 475342
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3043,
-          "resourceSize": 8293
+          "transferSize": 2837,
+          "resourceSize": 7617
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593381,
-          "resourceSize": 1093185
+          "transferSize": 406887,
+          "resourceSize": 475362
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6004,
-          "resourceSize": 26659
+          "transferSize": 5685,
+          "resourceSize": 25372
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597339,
-          "resourceSize": 1799397
+          "transferSize": 17760,
+          "resourceSize": 38511
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13045,
-          "resourceSize": 14202
+          "transferSize": 10180,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785602,
-          "resourceSize": 2059741
+          "transferSize": 200217,
+          "resourceSize": 294030
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2903,
-          "resourceSize": 7784
+          "transferSize": 2717,
+          "resourceSize": 7108
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593239,
-          "resourceSize": 1092676
+          "transferSize": 406767,
+          "resourceSize": 474853
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3088,
-          "resourceSize": 8295
+          "transferSize": 2882,
+          "resourceSize": 7619
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593422,
-          "resourceSize": 1093187
+          "transferSize": 406933,
+          "resourceSize": 475364
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2904,
-          "resourceSize": 7723
+          "transferSize": 2718,
+          "resourceSize": 7047
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593240,
-          "resourceSize": 1092616
+          "transferSize": 406772,
+          "resourceSize": 474792
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3179,
-          "resourceSize": 8437
+          "transferSize": 2974,
+          "resourceSize": 7761
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593523,
-          "resourceSize": 1093330
+          "transferSize": 407024,
+          "resourceSize": 475506
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 4002,
-          "resourceSize": 12243
+          "transferSize": 3825,
+          "resourceSize": 11567
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11995,
-          "resourceSize": 58415
+          "transferSize": 9373,
+          "resourceSize": 56125
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1942,
+          "transferSize": 1940,
           "resourceSize": 1239
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 596356,
-          "resourceSize": 1098860
+          "transferSize": 409891,
+          "resourceSize": 481036
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3423,
-          "resourceSize": 9236
+          "transferSize": 3107,
+          "resourceSize": 8057
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597865,
-          "resourceSize": 1799751
+          "transferSize": 18286,
+          "resourceSize": 38865
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998624,
-          "resourceSize": 2253920
+          "transferSize": 413284,
+          "resourceSize": 488317
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.43.1.json
+++ b/.github/page_size_audit_results/v1.43.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.43.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:13.628Z"
+    "generatedAt": "2025-11-27T16:03:45.631Z"
   },
-  "timestamp": "2025-11-22T11:52:13.628Z",
+  "timestamp": "2025-11-27T16:03:45.632Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3047,
-          "resourceSize": 8167
+          "transferSize": 2857,
+          "resourceSize": 7491
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593384,
-          "resourceSize": 1093059
+          "transferSize": 406907,
+          "resourceSize": 475236
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3019,
-          "resourceSize": 8187
+          "transferSize": 2830,
+          "resourceSize": 7511
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593351,
-          "resourceSize": 1093079
+          "transferSize": 406876,
+          "resourceSize": 475256
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5988,
-          "resourceSize": 26500
+          "transferSize": 5673,
+          "resourceSize": 25213
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597339,
-          "resourceSize": 1799397
+          "transferSize": 17760,
+          "resourceSize": 38511
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13037,
-          "resourceSize": 14202
+          "transferSize": 10163,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785578,
-          "resourceSize": 2059582
+          "transferSize": 200188,
+          "resourceSize": 293871
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2897,
-          "resourceSize": 7678
+          "transferSize": 2710,
+          "resourceSize": 7002
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593232,
-          "resourceSize": 1092570
+          "transferSize": 406759,
+          "resourceSize": 474747
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3062,
-          "resourceSize": 8189
+          "transferSize": 2874,
+          "resourceSize": 7513
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593393,
-          "resourceSize": 1093081
+          "transferSize": 406923,
+          "resourceSize": 475258
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2896,
-          "resourceSize": 7617
+          "transferSize": 2708,
+          "resourceSize": 6941
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593233,
-          "resourceSize": 1092510
+          "transferSize": 406757,
+          "resourceSize": 474686
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3170,
-          "resourceSize": 8331
+          "transferSize": 2964,
+          "resourceSize": 7655
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593506,
-          "resourceSize": 1093224
+          "transferSize": 407018,
+          "resourceSize": 475400
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3997,
-          "resourceSize": 12137
+          "transferSize": 3816,
+          "resourceSize": 11461
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197773,
-          "resourceSize": 647060
+          "transferSize": 14110,
+          "resourceSize": 32203
         },
         "stylesheet": {
-          "transferSize": 11995,
-          "resourceSize": 58415
+          "transferSize": 9373,
+          "resourceSize": 56125
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1908,
+          "transferSize": 1939,
           "resourceSize": 1239
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 596317,
-          "resourceSize": 1098754
+          "transferSize": 409881,
+          "resourceSize": 480930
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3413,
-          "resourceSize": 9130
+          "transferSize": 3098,
+          "resourceSize": 7951
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597865,
-          "resourceSize": 1799751
+          "transferSize": 18286,
+          "resourceSize": 38865
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3945,
-          "resourceSize": 1443
+          "transferSize": 1119,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998613,
-          "resourceSize": 2253814
+          "transferSize": 413271,
+          "resourceSize": 488211
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.44.0.json
+++ b/.github/page_size_audit_results/v1.44.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.44.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:54:36.478Z"
+    "generatedAt": "2025-11-27T16:03:54.322Z"
   },
-  "timestamp": "2025-11-22T11:54:36.478Z",
+  "timestamp": "2025-11-27T16:03:54.323Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3047,
-          "resourceSize": 8167
+          "transferSize": 2860,
+          "resourceSize": 7491
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593391,
-          "resourceSize": 1093039
+          "transferSize": 406913,
+          "resourceSize": 475216
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3023,
-          "resourceSize": 8187
+          "transferSize": 2834,
+          "resourceSize": 7511
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593365,
-          "resourceSize": 1093059
+          "transferSize": 406883,
+          "resourceSize": 475236
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5997,
-          "resourceSize": 26522
+          "transferSize": 5681,
+          "resourceSize": 25235
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597342,
-          "resourceSize": 1799377
+          "transferSize": 17763,
+          "resourceSize": 38491
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13034,
-          "resourceSize": 14202
+          "transferSize": 10178,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785587,
-          "resourceSize": 2059584
+          "transferSize": 200214,
+          "resourceSize": 293873
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2900,
-          "resourceSize": 7678
+          "transferSize": 2714,
+          "resourceSize": 7002
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593234,
-          "resourceSize": 1092550
+          "transferSize": 406768,
+          "resourceSize": 474727
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3065,
-          "resourceSize": 8189
+          "transferSize": 2879,
+          "resourceSize": 7513
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593408,
-          "resourceSize": 1093061
+          "transferSize": 406931,
+          "resourceSize": 475238
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2901,
-          "resourceSize": 7617
+          "transferSize": 2711,
+          "resourceSize": 6941
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593240,
-          "resourceSize": 1092490
+          "transferSize": 406770,
+          "resourceSize": 474666
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3169,
-          "resourceSize": 8331
+          "transferSize": 2966,
+          "resourceSize": 7655
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593510,
-          "resourceSize": 1093204
+          "transferSize": 407014,
+          "resourceSize": 475380
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3996,
-          "resourceSize": 12150
+          "transferSize": 3818,
+          "resourceSize": 11474
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11995,
-          "resourceSize": 58415
+          "transferSize": 9373,
+          "resourceSize": 56125
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1946,
+          "transferSize": 1939,
           "resourceSize": 1239
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 596357,
-          "resourceSize": 1098747
+          "transferSize": 409886,
+          "resourceSize": 480923
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3433,
-          "resourceSize": 9254
+          "transferSize": 3123,
+          "resourceSize": 8075
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597868,
-          "resourceSize": 1799731
+          "transferSize": 18289,
+          "resourceSize": 38845
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3950,
-          "resourceSize": 1443
+          "transferSize": 1124,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998641,
-          "resourceSize": 2253918
+          "transferSize": 413304,
+          "resourceSize": 488315
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.45.0.json
+++ b/.github/page_size_audit_results/v1.45.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:58.558Z"
+    "generatedAt": "2025-11-27T16:06:19.573Z"
   },
-  "timestamp": "2025-11-22T11:51:58.558Z",
+  "timestamp": "2025-11-27T16:06:19.573Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3062,
-          "resourceSize": 8209
+          "transferSize": 2862,
+          "resourceSize": 7533
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593404,
-          "resourceSize": 1093081
+          "transferSize": 406917,
+          "resourceSize": 475258
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3064,
-          "resourceSize": 8236
+          "transferSize": 2862,
+          "resourceSize": 7560
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593406,
-          "resourceSize": 1093108
+          "transferSize": 406910,
+          "resourceSize": 475285
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5993,
-          "resourceSize": 26522
+          "transferSize": 5678,
+          "resourceSize": 25235
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597342,
-          "resourceSize": 1799377
+          "transferSize": 17763,
+          "resourceSize": 38491
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13009,
-          "resourceSize": 14202
+          "transferSize": 10181,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785558,
-          "resourceSize": 2059584
+          "transferSize": 200214,
+          "resourceSize": 293873
         }
       },
       "themeResources": {
@@ -225,20 +225,20 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2896,
-          "resourceSize": 7678
+          "transferSize": 2714,
+          "resourceSize": 7002
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593236,
-          "resourceSize": 1092550
+          "transferSize": 406769,
+          "resourceSize": 474727
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3085,
-          "resourceSize": 8277
+          "transferSize": 2882,
+          "resourceSize": 7601
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593423,
-          "resourceSize": 1093149
+          "transferSize": 406936,
+          "resourceSize": 475326
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2896,
-          "resourceSize": 7617
+          "transferSize": 2711,
+          "resourceSize": 6941
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
@@ -391,12 +391,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593236,
-          "resourceSize": 1092490
+          "transferSize": 406765,
+          "resourceSize": 474666
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3179,
-          "resourceSize": 8419
+          "transferSize": 2975,
+          "resourceSize": 7743
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593518,
-          "resourceSize": 1093292
+          "transferSize": 407032,
+          "resourceSize": 475468
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3334,
-          "resourceSize": 9388
+          "transferSize": 3151,
+          "resourceSize": 8712
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197776,
-          "resourceSize": 647040
+          "transferSize": 14113,
+          "resourceSize": 32183
         },
         "stylesheet": {
-          "transferSize": 11995,
-          "resourceSize": 58415
+          "transferSize": 9373,
+          "resourceSize": 56125
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 594518,
-          "resourceSize": 1094941
+          "transferSize": 408050,
+          "resourceSize": 477117
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3430,
-          "resourceSize": 9254
+          "transferSize": 3123,
+          "resourceSize": 8075
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597868,
-          "resourceSize": 1799731
+          "transferSize": 18289,
+          "resourceSize": 38845
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3950,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998638,
-          "resourceSize": 2253918
+          "transferSize": 413303,
+          "resourceSize": 488315
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.45.1.json
+++ b/.github/page_size_audit_results/v1.45.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:03.827Z"
+    "generatedAt": "2025-11-27T16:06:38.629Z"
   },
-  "timestamp": "2025-11-22T11:52:03.827Z",
+  "timestamp": "2025-11-27T16:06:38.629Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3070,
-          "resourceSize": 8209
+          "transferSize": 2861,
+          "resourceSize": 7533
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593406,
-          "resourceSize": 1093094
+          "transferSize": 406915,
+          "resourceSize": 475271
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3072,
-          "resourceSize": 8236
+          "transferSize": 2861,
+          "resourceSize": 7560
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593401,
-          "resourceSize": 1093121
+          "transferSize": 406905,
+          "resourceSize": 475298
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5998,
-          "resourceSize": 26522
+          "transferSize": 5682,
+          "resourceSize": 25235
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597377,
-          "resourceSize": 1799511
+          "transferSize": 17798,
+          "resourceSize": 38625
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13081,
-          "resourceSize": 14202
+          "transferSize": 10215,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785670,
-          "resourceSize": 2059718
+          "transferSize": 200287,
+          "resourceSize": 294007
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2904,
-          "resourceSize": 7678
+          "transferSize": 2714,
+          "resourceSize": 7002
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593235,
-          "resourceSize": 1092563
+          "transferSize": 406763,
+          "resourceSize": 474740
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3092,
-          "resourceSize": 8277
+          "transferSize": 2881,
+          "resourceSize": 7601
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593427,
-          "resourceSize": 1093162
+          "transferSize": 406928,
+          "resourceSize": 475339
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2900,
-          "resourceSize": 7617
+          "transferSize": 2709,
+          "resourceSize": 6941
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593228,
-          "resourceSize": 1092503
+          "transferSize": 406755,
+          "resourceSize": 474679
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3189,
-          "resourceSize": 8419
+          "transferSize": 2977,
+          "resourceSize": 7743
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593521,
-          "resourceSize": 1093305
+          "transferSize": 407019,
+          "resourceSize": 475481
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3339,
-          "resourceSize": 9388
+          "transferSize": 3148,
+          "resourceSize": 8712
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11995,
-          "resourceSize": 58415
+          "transferSize": 9373,
+          "resourceSize": 56125
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 594519,
-          "resourceSize": 1094954
+          "transferSize": 408037,
+          "resourceSize": 477130
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3434,
-          "resourceSize": 9254
+          "transferSize": 3121,
+          "resourceSize": 8075
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597911,
-          "resourceSize": 1799873
+          "transferSize": 18332,
+          "resourceSize": 38987
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3943,
-          "resourceSize": 1443
+          "transferSize": 1124,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998678,
-          "resourceSize": 2254060
+          "transferSize": 413345,
+          "resourceSize": 488457
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.45.2.json
+++ b/.github/page_size_audit_results/v1.45.2.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:54:40.166Z"
+    "generatedAt": "2025-11-27T16:03:48.481Z"
   },
-  "timestamp": "2025-11-22T11:54:40.166Z",
+  "timestamp": "2025-11-27T16:03:48.481Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3069,
-          "resourceSize": 8209
+          "transferSize": 2860,
+          "resourceSize": 7533
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593399,
-          "resourceSize": 1093094
+          "transferSize": 406906,
+          "resourceSize": 475271
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3069,
-          "resourceSize": 8236
+          "transferSize": 2861,
+          "resourceSize": 7560
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593397,
-          "resourceSize": 1093121
+          "transferSize": 406909,
+          "resourceSize": 475298
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5996,
-          "resourceSize": 26522
+          "transferSize": 5679,
+          "resourceSize": 25235
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597377,
-          "resourceSize": 1799511
+          "transferSize": 17798,
+          "resourceSize": 38625
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13032,
-          "resourceSize": 14202
+          "transferSize": 10184,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785619,
-          "resourceSize": 2059718
+          "transferSize": 200253,
+          "resourceSize": 294007
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2901,
-          "resourceSize": 7678
+          "transferSize": 2712,
+          "resourceSize": 7002
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593234,
-          "resourceSize": 1092563
+          "transferSize": 406755,
+          "resourceSize": 474740
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3089,
-          "resourceSize": 8277
+          "transferSize": 2881,
+          "resourceSize": 7601
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593417,
-          "resourceSize": 1093162
+          "transferSize": 406928,
+          "resourceSize": 475339
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2899,
-          "resourceSize": 7617
+          "transferSize": 2708,
+          "resourceSize": 6941
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593230,
-          "resourceSize": 1092503
+          "transferSize": 406754,
+          "resourceSize": 474679
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3183,
-          "resourceSize": 8419
+          "transferSize": 2973,
+          "resourceSize": 7743
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11150,
-          "resourceSize": 57735
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593514,
-          "resourceSize": 1093305
+          "transferSize": 407020,
+          "resourceSize": 475481
         }
       },
       "themeResources": {
@@ -509,20 +509,20 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3337,
-          "resourceSize": 9388
+          "transferSize": 3148,
+          "resourceSize": 8712
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11995,
-          "resourceSize": 58415
+          "transferSize": 9373,
+          "resourceSize": 56125
         },
         "image": {
           "transferSize": 224175,
@@ -533,12 +533,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 594517,
-          "resourceSize": 1094954
+          "transferSize": 408042,
+          "resourceSize": 477130
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3432,
-          "resourceSize": 9254
+          "transferSize": 3117,
+          "resourceSize": 8075
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597911,
-          "resourceSize": 1799873
+          "transferSize": 18332,
+          "resourceSize": 38987
         },
         "stylesheet": {
-          "transferSize": 12746,
-          "resourceSize": 63587
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998680,
-          "resourceSize": 2254060
+          "transferSize": 413340,
+          "resourceSize": 488457
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.45.3.json
+++ b/.github/page_size_audit_results/v1.45.3.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:11.685Z"
+    "generatedAt": "2025-11-27T16:04:07.919Z"
   },
-  "timestamp": "2025-11-22T11:52:11.686Z",
+  "timestamp": "2025-11-27T16:04:07.919Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3064,
-          "resourceSize": 8209
+          "transferSize": 2862,
+          "resourceSize": 7533
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11172,
-          "resourceSize": 57776
+          "transferSize": 8550,
+          "resourceSize": 55486
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593418,
-          "resourceSize": 1093135
+          "transferSize": 406932,
+          "resourceSize": 475312
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3067,
-          "resourceSize": 8236
+          "transferSize": 2862,
+          "resourceSize": 7560
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11172,
-          "resourceSize": 57776
+          "transferSize": 8550,
+          "resourceSize": 55486
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593425,
-          "resourceSize": 1093162
+          "transferSize": 406930,
+          "resourceSize": 475339
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6009,
-          "resourceSize": 26575
+          "transferSize": 5685,
+          "resourceSize": 25288
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597377,
-          "resourceSize": 1799511
+          "transferSize": 17798,
+          "resourceSize": 38625
         },
         "stylesheet": {
-          "transferSize": 12768,
-          "resourceSize": 63628
+          "transferSize": 10146,
+          "resourceSize": 61338
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13018,
-          "resourceSize": 14202
+          "transferSize": 10163,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785640,
-          "resourceSize": 2059812
+          "transferSize": 200260,
+          "resourceSize": 294101
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2910,
-          "resourceSize": 7788
+          "transferSize": 2727,
+          "resourceSize": 7112
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11451,
-          "resourceSize": 57890
+          "transferSize": 8829,
+          "resourceSize": 55600
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593547,
-          "resourceSize": 1092828
+          "transferSize": 407072,
+          "resourceSize": 475005
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3092,
-          "resourceSize": 8373
+          "transferSize": 2883,
+          "resourceSize": 7697
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11409,
-          "resourceSize": 57849
+          "transferSize": 8787,
+          "resourceSize": 55559
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593684,
-          "resourceSize": 1093372
+          "transferSize": 407188,
+          "resourceSize": 475549
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2894,
-          "resourceSize": 7617
+          "transferSize": 2708,
+          "resourceSize": 6941
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11172,
-          "resourceSize": 57776
+          "transferSize": 8550,
+          "resourceSize": 55486
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593254,
-          "resourceSize": 1092544
+          "transferSize": 406773,
+          "resourceSize": 474720
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3180,
-          "resourceSize": 8419
+          "transferSize": 2974,
+          "resourceSize": 7743
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11172,
-          "resourceSize": 57776
+          "transferSize": 8550,
+          "resourceSize": 55486
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593538,
-          "resourceSize": 1093346
+          "transferSize": 407048,
+          "resourceSize": 475522
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3335,
-          "resourceSize": 9388
+          "transferSize": 3150,
+          "resourceSize": 8712
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 12017,
-          "resourceSize": 58456
+          "transferSize": 9395,
+          "resourceSize": 56166
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 594537,
-          "resourceSize": 1094995
+          "transferSize": 408060,
+          "resourceSize": 477172
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3429,
-          "resourceSize": 9254
+          "transferSize": 3119,
+          "resourceSize": 8075
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597911,
-          "resourceSize": 1799873
+          "transferSize": 18332,
+          "resourceSize": 38987
         },
         "stylesheet": {
-          "transferSize": 12768,
-          "resourceSize": 63628
+          "transferSize": 10146,
+          "resourceSize": 61338
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3949,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998701,
-          "resourceSize": 2254101
+          "transferSize": 413364,
+          "resourceSize": 488498
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.45.4.json
+++ b/.github/page_size_audit_results/v1.45.4.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:54:37.316Z"
+    "generatedAt": "2025-11-27T16:06:10.730Z"
   },
-  "timestamp": "2025-11-22T11:54:37.317Z",
+  "timestamp": "2025-11-27T16:06:10.730Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3066,
-          "resourceSize": 8209
+          "transferSize": 2860,
+          "resourceSize": 7533
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11172,
-          "resourceSize": 57776
+          "transferSize": 8550,
+          "resourceSize": 55486
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593419,
-          "resourceSize": 1093135
+          "transferSize": 406925,
+          "resourceSize": 475312
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3068,
-          "resourceSize": 8236
+          "transferSize": 2860,
+          "resourceSize": 7560
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11172,
-          "resourceSize": 57776
+          "transferSize": 8550,
+          "resourceSize": 55486
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593420,
-          "resourceSize": 1093162
+          "transferSize": 406927,
+          "resourceSize": 475339
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6012,
-          "resourceSize": 26575
+          "transferSize": 5684,
+          "resourceSize": 25288
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597377,
-          "resourceSize": 1799511
+          "transferSize": 17798,
+          "resourceSize": 38625
         },
         "stylesheet": {
-          "transferSize": 12768,
-          "resourceSize": 63628
+          "transferSize": 10146,
+          "resourceSize": 61338
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13064,
-          "resourceSize": 14202
+          "transferSize": 10196,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785689,
-          "resourceSize": 2059812
+          "transferSize": 200292,
+          "resourceSize": 294101
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2917,
-          "resourceSize": 7788
+          "transferSize": 2727,
+          "resourceSize": 7112
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11451,
-          "resourceSize": 57890
+          "transferSize": 8829,
+          "resourceSize": 55600
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593549,
-          "resourceSize": 1092828
+          "transferSize": 407076,
+          "resourceSize": 475005
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3092,
-          "resourceSize": 8373
+          "transferSize": 2882,
+          "resourceSize": 7697
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11409,
-          "resourceSize": 57849
+          "transferSize": 8787,
+          "resourceSize": 55559
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593681,
-          "resourceSize": 1093372
+          "transferSize": 407189,
+          "resourceSize": 475549
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2899,
-          "resourceSize": 7617
+          "transferSize": 2708,
+          "resourceSize": 6941
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11172,
-          "resourceSize": 57776
+          "transferSize": 8550,
+          "resourceSize": 55486
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593252,
-          "resourceSize": 1092544
+          "transferSize": 406771,
+          "resourceSize": 474720
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3184,
-          "resourceSize": 8419
+          "transferSize": 2974,
+          "resourceSize": 7743
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 11172,
-          "resourceSize": 57776
+          "transferSize": 8550,
+          "resourceSize": 55486
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593540,
-          "resourceSize": 1093346
+          "transferSize": 407039,
+          "resourceSize": 475522
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3337,
-          "resourceSize": 9388
+          "transferSize": 3149,
+          "resourceSize": 8712
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197769,
-          "resourceSize": 647053
+          "transferSize": 14106,
+          "resourceSize": 32196
         },
         "stylesheet": {
-          "transferSize": 12017,
-          "resourceSize": 58456
+          "transferSize": 9395,
+          "resourceSize": 56166
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 594533,
-          "resourceSize": 1094995
+          "transferSize": 408057,
+          "resourceSize": 477172
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3435,
-          "resourceSize": 9254
+          "transferSize": 3120,
+          "resourceSize": 8075
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597911,
-          "resourceSize": 1799873
+          "transferSize": 18332,
+          "resourceSize": 38987
         },
         "stylesheet": {
-          "transferSize": 12768,
-          "resourceSize": 63628
+          "transferSize": 10146,
+          "resourceSize": 61338
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3949,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998707,
-          "resourceSize": 2254101
+          "transferSize": 413365,
+          "resourceSize": 488498
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.46.0.json
+++ b/.github/page_size_audit_results/v1.46.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.46.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:04.344Z"
+    "generatedAt": "2025-11-27T16:03:55.181Z"
   },
-  "timestamp": "2025-11-22T11:52:04.344Z",
+  "timestamp": "2025-11-27T16:03:55.181Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3087,
-          "resourceSize": 8395
+          "transferSize": 2881,
+          "resourceSize": 7719
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197690,
-          "resourceSize": 646867
+          "transferSize": 14027,
+          "resourceSize": 32010
         },
         "stylesheet": {
-          "transferSize": 11826,
-          "resourceSize": 56943
+          "transferSize": 9204,
+          "resourceSize": 54653
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594017,
-          "resourceSize": 1092302
+          "transferSize": 407523,
+          "resourceSize": 474479
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3078,
-          "resourceSize": 8322
+          "transferSize": 2863,
+          "resourceSize": 7646
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197690,
-          "resourceSize": 646867
+          "transferSize": 14027,
+          "resourceSize": 32010
         },
         "stylesheet": {
-          "transferSize": 11399,
-          "resourceSize": 56681
+          "transferSize": 8777,
+          "resourceSize": 54391
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593579,
-          "resourceSize": 1091967
+          "transferSize": 407080,
+          "resourceSize": 474144
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6005,
-          "resourceSize": 26526
+          "transferSize": 5680,
+          "resourceSize": 25239
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597261,
-          "resourceSize": 1799296
+          "transferSize": 17682,
+          "resourceSize": 38410
         },
         "stylesheet": {
-          "transferSize": 12408,
-          "resourceSize": 62111
+          "transferSize": 9786,
+          "resourceSize": 59821
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13013,
-          "resourceSize": 14202
+          "transferSize": 10158,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785155,
-          "resourceSize": 2058031
+          "transferSize": 199774,
+          "resourceSize": 292320
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2890,
-          "resourceSize": 7739
+          "transferSize": 2703,
+          "resourceSize": 7063
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197651,
-          "resourceSize": 646828
+          "transferSize": 13988,
+          "resourceSize": 31971
         },
         "stylesheet": {
-          "transferSize": 11091,
-          "resourceSize": 56373
+          "transferSize": 8469,
+          "resourceSize": 54083
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593044,
-          "resourceSize": 1091037
+          "transferSize": 406570,
+          "resourceSize": 473214
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3087,
-          "resourceSize": 8348
+          "transferSize": 2870,
+          "resourceSize": 7672
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197651,
-          "resourceSize": 646828
+          "transferSize": 13988,
+          "resourceSize": 31971
         },
         "stylesheet": {
-          "transferSize": 11049,
-          "resourceSize": 56332
+          "transferSize": 8427,
+          "resourceSize": 54042
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593205,
-          "resourceSize": 1091606
+          "transferSize": 406694,
+          "resourceSize": 473782
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2876,
-          "resourceSize": 7568
+          "transferSize": 2685,
+          "resourceSize": 6892
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197651,
-          "resourceSize": 646828
+          "transferSize": 13988,
+          "resourceSize": 31971
         },
         "stylesheet": {
-          "transferSize": 10812,
-          "resourceSize": 56259
+          "transferSize": 8190,
+          "resourceSize": 53969
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592752,
-          "resourceSize": 1090753
+          "transferSize": 406274,
+          "resourceSize": 472929
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3172,
-          "resourceSize": 8394
+          "transferSize": 2962,
+          "resourceSize": 7718
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197651,
-          "resourceSize": 646828
+          "transferSize": 13988,
+          "resourceSize": 31971
         },
         "stylesheet": {
-          "transferSize": 10812,
-          "resourceSize": 56259
+          "transferSize": 8190,
+          "resourceSize": 53969
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593051,
-          "resourceSize": 1091579
+          "transferSize": 406549,
+          "resourceSize": 473755
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3334,
-          "resourceSize": 9363
+          "transferSize": 3140,
+          "resourceSize": 8687
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197651,
-          "resourceSize": 646828
+          "transferSize": 13988,
+          "resourceSize": 31971
         },
         "stylesheet": {
-          "transferSize": 11657,
-          "resourceSize": 56939
+          "transferSize": 9035,
+          "resourceSize": 54649
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 594053,
-          "resourceSize": 1093228
+          "transferSize": 407575,
+          "resourceSize": 475405
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3414,
-          "resourceSize": 9205
+          "transferSize": 3101,
+          "resourceSize": 8026
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597795,
-          "resourceSize": 1799658
+          "transferSize": 18216,
+          "resourceSize": 38772
         },
         "stylesheet": {
-          "transferSize": 12408,
-          "resourceSize": 62111
+          "transferSize": 9786,
+          "resourceSize": 59821
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3952,
-          "resourceSize": 1443
+          "transferSize": 1125,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998213,
-          "resourceSize": 2252320
+          "transferSize": 412872,
+          "resourceSize": 486717
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.47.0.json
+++ b/.github/page_size_audit_results/v1.47.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.47.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:52:09.816Z"
+    "generatedAt": "2025-11-27T16:03:50.991Z"
   },
-  "timestamp": "2025-11-22T11:52:09.816Z",
+  "timestamp": "2025-11-27T16:03:50.992Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3090,
-          "resourceSize": 8452
+          "transferSize": 2881,
+          "resourceSize": 7714
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197690,
-          "resourceSize": 646867
+          "transferSize": 14027,
+          "resourceSize": 32010
         },
         "stylesheet": {
-          "transferSize": 11826,
-          "resourceSize": 56943
+          "transferSize": 9204,
+          "resourceSize": 54653
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 594018,
-          "resourceSize": 1092359
+          "transferSize": 407525,
+          "resourceSize": 474474
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3081,
-          "resourceSize": 8379
+          "transferSize": 2866,
+          "resourceSize": 7641
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197690,
-          "resourceSize": 646867
+          "transferSize": 14027,
+          "resourceSize": 32010
         },
         "stylesheet": {
-          "transferSize": 11399,
-          "resourceSize": 56681
+          "transferSize": 8777,
+          "resourceSize": 54391
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593582,
-          "resourceSize": 1092024
+          "transferSize": 407086,
+          "resourceSize": 474139
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 6009,
-          "resourceSize": 26640
+          "transferSize": 5682,
+          "resourceSize": 25229
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597261,
-          "resourceSize": 1799296
+          "transferSize": 17682,
+          "resourceSize": 38410
         },
         "stylesheet": {
-          "transferSize": 12408,
-          "resourceSize": 62111
+          "transferSize": 9786,
+          "resourceSize": 59821
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13015,
-          "resourceSize": 14202
+          "transferSize": 10186,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 785161,
-          "resourceSize": 2058145
+          "transferSize": 199804,
+          "resourceSize": 292310
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2897,
-          "resourceSize": 7796
+          "transferSize": 2705,
+          "resourceSize": 7058
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197651,
-          "resourceSize": 646828
+          "transferSize": 13988,
+          "resourceSize": 31971
         },
         "stylesheet": {
-          "transferSize": 11091,
-          "resourceSize": 56373
+          "transferSize": 8469,
+          "resourceSize": 54083
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 593055,
-          "resourceSize": 1091094
+          "transferSize": 406574,
+          "resourceSize": 473209
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3086,
-          "resourceSize": 8405
+          "transferSize": 2873,
+          "resourceSize": 7667
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197651,
-          "resourceSize": 646828
+          "transferSize": 13988,
+          "resourceSize": 31971
         },
         "stylesheet": {
-          "transferSize": 11049,
-          "resourceSize": 56332
+          "transferSize": 8427,
+          "resourceSize": 54042
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593207,
-          "resourceSize": 1091663
+          "transferSize": 406698,
+          "resourceSize": 473777
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2881,
-          "resourceSize": 7625
+          "transferSize": 2686,
+          "resourceSize": 6887
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197651,
-          "resourceSize": 646828
+          "transferSize": 13988,
+          "resourceSize": 31971
         },
         "stylesheet": {
-          "transferSize": 10812,
-          "resourceSize": 56259
+          "transferSize": 8190,
+          "resourceSize": 53969
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592763,
-          "resourceSize": 1090810
+          "transferSize": 406272,
+          "resourceSize": 472924
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3177,
-          "resourceSize": 8451
+          "transferSize": 2963,
+          "resourceSize": 7713
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197651,
-          "resourceSize": 646828
+          "transferSize": 13988,
+          "resourceSize": 31971
         },
         "stylesheet": {
-          "transferSize": 10812,
-          "resourceSize": 56259
+          "transferSize": 8190,
+          "resourceSize": 53969
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 593053,
-          "resourceSize": 1091636
+          "transferSize": 406552,
+          "resourceSize": 473750
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3335,
-          "resourceSize": 9420
+          "transferSize": 3144,
+          "resourceSize": 8682
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 197651,
-          "resourceSize": 646828
+          "transferSize": 13988,
+          "resourceSize": 31971
         },
         "stylesheet": {
-          "transferSize": 11657,
-          "resourceSize": 56939
+          "transferSize": 9035,
+          "resourceSize": 54649
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 779,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 594066,
-          "resourceSize": 1093285
+          "transferSize": 407578,
+          "resourceSize": 475400
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3420,
-          "resourceSize": 9262
+          "transferSize": 3102,
+          "resourceSize": 8021
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 597795,
-          "resourceSize": 1799658
+          "transferSize": 18216,
+          "resourceSize": 38772
         },
         "stylesheet": {
-          "transferSize": 12408,
-          "resourceSize": 62111
+          "transferSize": 9786,
+          "resourceSize": 59821
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3949,
-          "resourceSize": 1443
+          "transferSize": 1119,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 998216,
-          "resourceSize": 2252377
+          "transferSize": 412867,
+          "resourceSize": 486712
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.48.0.json
+++ b/.github/page_size_audit_results/v1.48.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T12:46:39.461Z"
+    "generatedAt": "2025-11-27T16:05:57.929Z"
   },
-  "timestamp": "2025-11-22T12:46:39.462Z",
+  "timestamp": "2025-11-27T16:05:57.930Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3063,
-          "resourceSize": 8432
+          "transferSize": 2848,
+          "resourceSize": 7694
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196082,
-          "resourceSize": 643816
+          "transferSize": 12419,
+          "resourceSize": 28959
         },
         "stylesheet": {
-          "transferSize": 12422,
-          "resourceSize": 56944
+          "transferSize": 9800,
+          "resourceSize": 54654
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592983,
-          "resourceSize": 1089289
+          "transferSize": 406477,
+          "resourceSize": 471404
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3056,
-          "resourceSize": 8359
+          "transferSize": 2835,
+          "resourceSize": 7621
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196082,
-          "resourceSize": 643816
+          "transferSize": 12419,
+          "resourceSize": 28959
         },
         "stylesheet": {
-          "transferSize": 11995,
-          "resourceSize": 56682
+          "transferSize": 9373,
+          "resourceSize": 54392
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592548,
-          "resourceSize": 1088954
+          "transferSize": 406036,
+          "resourceSize": 471069
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5958,
-          "resourceSize": 26511
+          "transferSize": 5647,
+          "resourceSize": 25100
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 595653,
-          "resourceSize": 1796245
+          "transferSize": 16074,
+          "resourceSize": 35359
         },
         "stylesheet": {
-          "transferSize": 11981,
-          "resourceSize": 60014
+          "transferSize": 9359,
+          "resourceSize": 57724
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13006,
-          "resourceSize": 14202
+          "transferSize": 10209,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 783066,
-          "resourceSize": 2052868
+          "transferSize": 197757,
+          "resourceSize": 287033
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2875,
-          "resourceSize": 7776
+          "transferSize": 2672,
+          "resourceSize": 7038
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 11687,
-          "resourceSize": 56374
+          "transferSize": 9065,
+          "resourceSize": 54084
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 592016,
-          "resourceSize": 1088024
+          "transferSize": 405532,
+          "resourceSize": 470139
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3060,
-          "resourceSize": 8385
+          "transferSize": 2840,
+          "resourceSize": 7647
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 11645,
-          "resourceSize": 56333
+          "transferSize": 9023,
+          "resourceSize": 54043
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592161,
-          "resourceSize": 1088593
+          "transferSize": 405664,
+          "resourceSize": 470707
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2857,
-          "resourceSize": 7605
+          "transferSize": 2651,
+          "resourceSize": 6867
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 11408,
-          "resourceSize": 56260
+          "transferSize": 8786,
+          "resourceSize": 53970
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 591729,
-          "resourceSize": 1087740
+          "transferSize": 405232,
+          "resourceSize": 469854
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3146,
-          "resourceSize": 8431
+          "transferSize": 2929,
+          "resourceSize": 7693
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 11408,
-          "resourceSize": 56260
+          "transferSize": 8786,
+          "resourceSize": 53970
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 592010,
-          "resourceSize": 1088566
+          "transferSize": 405505,
+          "resourceSize": 470680
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3307,
-          "resourceSize": 9400
+          "transferSize": 3111,
+          "resourceSize": 8662
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 12253,
-          "resourceSize": 56940
+          "transferSize": 9631,
+          "resourceSize": 54650
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 593019,
-          "resourceSize": 1090215
+          "transferSize": 406541,
+          "resourceSize": 472330
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3357,
-          "resourceSize": 9022
+          "transferSize": 3037,
+          "resourceSize": 7781
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 593970,
-          "resourceSize": 1791644
+          "transferSize": 14391,
+          "resourceSize": 30758
         },
         "stylesheet": {
-          "transferSize": 11408,
-          "resourceSize": 56260
+          "transferSize": 8786,
+          "resourceSize": 53970
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3951,
-          "resourceSize": 1443
+          "transferSize": 1125,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 993330,
-          "resourceSize": 2238272
+          "transferSize": 407983,
+          "resourceSize": 472607
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.48.1.json
+++ b/.github/page_size_audit_results/v1.48.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-23T14:54:59.080Z"
+    "generatedAt": "2025-11-27T16:03:40.787Z"
   },
-  "timestamp": "2025-11-23T14:54:59.080Z",
+  "timestamp": "2025-11-27T16:03:40.787Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3044,
-          "resourceSize": 8635
+          "transferSize": 2823,
+          "resourceSize": 7918
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196082,
-          "resourceSize": 643816
+          "transferSize": 12419,
+          "resourceSize": 28959
         },
         "stylesheet": {
-          "transferSize": 23081,
-          "resourceSize": 76252
+          "transferSize": 20459,
+          "resourceSize": 73962
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 261127,
-          "resourceSize": 766146
+          "transferSize": 74630,
+          "resourceSize": 148282
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3030,
-          "resourceSize": 8563
+          "transferSize": 2816,
+          "resourceSize": 7846
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196082,
-          "resourceSize": 643816
+          "transferSize": 12419,
+          "resourceSize": 28959
         },
         "stylesheet": {
-          "transferSize": 22654,
-          "resourceSize": 75990
+          "transferSize": 20032,
+          "resourceSize": 73700
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 260694,
-          "resourceSize": 765812
+          "transferSize": 74194,
+          "resourceSize": 147948
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5843,
-          "resourceSize": 25923
+          "transferSize": 5528,
+          "resourceSize": 24554
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 595653,
-          "resourceSize": 1796245
+          "transferSize": 16074,
+          "resourceSize": 35359
         },
         "stylesheet": {
-          "transferSize": 22640,
-          "resourceSize": 79322
+          "transferSize": 20018,
+          "resourceSize": 77032
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12999,
-          "resourceSize": 14202
+          "transferSize": 10205,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 661419,
-          "resourceSize": 1939236
+          "transferSize": 76109,
+          "resourceSize": 173443
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2846,
-          "resourceSize": 7984
+          "transferSize": 2651,
+          "resourceSize": 7267
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 22346,
-          "resourceSize": 75682
+          "transferSize": 19724,
+          "resourceSize": 73392
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 260161,
-          "resourceSize": 764886
+          "transferSize": 73682,
+          "resourceSize": 147022
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3035,
-          "resourceSize": 8589
+          "transferSize": 2814,
+          "resourceSize": 7872
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 22304,
-          "resourceSize": 75641
+          "transferSize": 19682,
+          "resourceSize": 73351
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 260313,
-          "resourceSize": 765451
+          "transferSize": 73801,
+          "resourceSize": 147586
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2828,
-          "resourceSize": 7813
+          "transferSize": 2630,
+          "resourceSize": 7096
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 22067,
-          "resourceSize": 75568
+          "transferSize": 19445,
+          "resourceSize": 73278
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 259865,
-          "resourceSize": 764602
+          "transferSize": 73378,
+          "resourceSize": 146737
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3119,
-          "resourceSize": 8635
+          "transferSize": 2904,
+          "resourceSize": 7918
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 22067,
-          "resourceSize": 75568
+          "transferSize": 19445,
+          "resourceSize": 73278
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 260152,
-          "resourceSize": 765424
+          "transferSize": 73658,
+          "resourceSize": 147559
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3364,
-          "resourceSize": 10049
+          "transferSize": 3138,
+          "resourceSize": 9332
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 22912,
-          "resourceSize": 76248
+          "transferSize": 20290,
+          "resourceSize": 73958
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 261249,
-          "resourceSize": 767518
+          "transferSize": 74736,
+          "resourceSize": 149654
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3331,
-          "resourceSize": 9201
+          "transferSize": 3012,
+          "resourceSize": 7981
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 593970,
-          "resourceSize": 1791644
+          "transferSize": 14391,
+          "resourceSize": 30758
         },
         "stylesheet": {
-          "transferSize": 22067,
-          "resourceSize": 75568
+          "transferSize": 19445,
+          "resourceSize": 73278
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 3952,
-          "resourceSize": 1443
+          "transferSize": 1130,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 661478,
-          "resourceSize": 1915105
+          "transferSize": 76136,
+          "resourceSize": 149461
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.48.2.json
+++ b/.github/page_size_audit_results/v1.48.2.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-24T17:05:36.888Z"
+    "generatedAt": "2025-11-27T16:06:17.427Z"
   },
-  "timestamp": "2025-11-24T17:05:36.888Z",
+  "timestamp": "2025-11-27T16:06:17.428Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3069,
-          "resourceSize": 8668
+          "transferSize": 2841,
+          "resourceSize": 7951
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 22409,
-          "resourceSize": 72544
+          "transferSize": 19787,
+          "resourceSize": 70254
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 260446,
-          "resourceSize": 762432
+          "transferSize": 73940,
+          "resourceSize": 144568
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3084,
-          "resourceSize": 8898
+          "transferSize": 2862,
+          "resourceSize": 8181
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 22655,
-          "resourceSize": 72626
+          "transferSize": 20033,
+          "resourceSize": 70336
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 260705,
-          "resourceSize": 762744
+          "transferSize": 74206,
+          "resourceSize": 144880
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5857,
-          "resourceSize": 26025
+          "transferSize": 5546,
+          "resourceSize": 24656
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 595653,
-          "resourceSize": 1796245
+          "transferSize": 16074,
+          "resourceSize": 35359
         },
         "stylesheet": {
-          "transferSize": 22902,
-          "resourceSize": 78116
+          "transferSize": 20280,
+          "resourceSize": 75826
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13037,
-          "resourceSize": 14202
+          "transferSize": 10199,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 661733,
-          "resourceSize": 1938132
+          "transferSize": 76383,
+          "resourceSize": 172339
         }
       },
       "themeResources": {
@@ -225,20 +225,20 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2847,
-          "resourceSize": 7984
+          "transferSize": 2648,
+          "resourceSize": 7267
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 21513,
-          "resourceSize": 71813
+          "transferSize": 18891,
+          "resourceSize": 69523
         },
         "image": {
           "transferSize": 13873,
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 259330,
-          "resourceSize": 761017
+          "transferSize": 72846,
+          "resourceSize": 143153
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3106,
-          "resourceSize": 8922
+          "transferSize": 2898,
+          "resourceSize": 8205
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 22892,
-          "resourceSize": 72699
+          "transferSize": 20270,
+          "resourceSize": 70409
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 260970,
-          "resourceSize": 762842
+          "transferSize": 74472,
+          "resourceSize": 144977
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2835,
-          "resourceSize": 7813
+          "transferSize": 2629,
+          "resourceSize": 7096
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 21234,
-          "resourceSize": 71699
+          "transferSize": 18612,
+          "resourceSize": 69409
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 259040,
-          "resourceSize": 760733
+          "transferSize": 72550,
+          "resourceSize": 142868
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3192,
-          "resourceSize": 8968
+          "transferSize": 2987,
+          "resourceSize": 8251
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 22655,
-          "resourceSize": 72626
+          "transferSize": 20033,
+          "resourceSize": 70336
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 260816,
-          "resourceSize": 762815
+          "transferSize": 74330,
+          "resourceSize": 144951
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3437,
-          "resourceSize": 10373
+          "transferSize": 3209,
+          "resourceSize": 9656
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196043,
-          "resourceSize": 643777
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 24263,
-          "resourceSize": 75544
+          "transferSize": 21641,
+          "resourceSize": 73254
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 262673,
-          "resourceSize": 767138
+          "transferSize": 76162,
+          "resourceSize": 149274
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3355,
-          "resourceSize": 9303
+          "transferSize": 3020,
+          "resourceSize": 8083
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 593970,
-          "resourceSize": 1791644
+          "transferSize": 14391,
+          "resourceSize": 30758
         },
         "stylesheet": {
-          "transferSize": 22243,
-          "resourceSize": 74019
+          "transferSize": 19621,
+          "resourceSize": 71729
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1123,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 661673,
-          "resourceSize": 1913658
+          "transferSize": 76313,
+          "resourceSize": 148014
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.48.3.json
+++ b/.github/page_size_audit_results/v1.48.3.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-26T08:37:10.330Z"
+    "generatedAt": "2025-11-27T16:06:32.197Z"
   },
-  "timestamp": "2025-11-26T08:37:10.330Z",
+  "timestamp": "2025-11-27T16:06:32.197Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3022,
-          "resourceSize": 8661
+          "transferSize": 2798,
+          "resourceSize": 7944
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196583,
-          "resourceSize": 643752
+          "transferSize": 12920,
+          "resourceSize": 28895
         },
         "stylesheet": {
-          "transferSize": 22364,
-          "resourceSize": 72483
+          "transferSize": 19742,
+          "resourceSize": 70193
         },
         "image": {
           "transferSize": 13873,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 260894,
-          "resourceSize": 762339
+          "transferSize": 74385,
+          "resourceSize": 144475
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 3040,
-          "resourceSize": 8759
+          "transferSize": 2817,
+          "resourceSize": 8042
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196583,
-          "resourceSize": 643752
+          "transferSize": 12920,
+          "resourceSize": 28895
         },
         "stylesheet": {
-          "transferSize": 22610,
-          "resourceSize": 72565
+          "transferSize": 19988,
+          "resourceSize": 70275
         },
         "image": {
           "transferSize": 13873,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 261159,
-          "resourceSize": 762519
+          "transferSize": 74651,
+          "resourceSize": 144655
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5856,
-          "resourceSize": 26155
+          "transferSize": 5541,
+          "resourceSize": 24786
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 596203,
-          "resourceSize": 1796230
+          "transferSize": 16624,
+          "resourceSize": 35344
         },
         "stylesheet": {
-          "transferSize": 23290,
-          "resourceSize": 78066
+          "transferSize": 20668,
+          "resourceSize": 75776
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 12998,
-          "resourceSize": 14202
+          "transferSize": 10168,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 662631,
-          "resourceSize": 1938197
+          "transferSize": 77285,
+          "resourceSize": 172404
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2828,
-          "resourceSize": 8004
+          "transferSize": 2625,
+          "resourceSize": 7287
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196583,
-          "resourceSize": 643752
+          "transferSize": 12920,
+          "resourceSize": 28895
         },
         "stylesheet": {
-          "transferSize": 21478,
-          "resourceSize": 71762
+          "transferSize": 18856,
+          "resourceSize": 69472
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 259815,
-          "resourceSize": 760961
+          "transferSize": 73325,
+          "resourceSize": 143097
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 3056,
-          "resourceSize": 8902
+          "transferSize": 2830,
+          "resourceSize": 8185
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196583,
-          "resourceSize": 643752
+          "transferSize": 12920,
+          "resourceSize": 28895
         },
         "stylesheet": {
-          "transferSize": 22847,
-          "resourceSize": 72638
+          "transferSize": 20225,
+          "resourceSize": 70348
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 261417,
-          "resourceSize": 762736
+          "transferSize": 74906,
+          "resourceSize": 144871
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2816,
-          "resourceSize": 7827
+          "transferSize": 2612,
+          "resourceSize": 7110
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196583,
-          "resourceSize": 643752
+          "transferSize": 12920,
+          "resourceSize": 28895
         },
         "stylesheet": {
-          "transferSize": 21199,
-          "resourceSize": 71648
+          "transferSize": 18577,
+          "resourceSize": 69358
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 259531,
-          "resourceSize": 760671
+          "transferSize": 73044,
+          "resourceSize": 142806
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3148,
-          "resourceSize": 8943
+          "transferSize": 2944,
+          "resourceSize": 8226
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196583,
-          "resourceSize": 643752
+          "transferSize": 12920,
+          "resourceSize": 28895
         },
         "stylesheet": {
-          "transferSize": 22610,
-          "resourceSize": 72565
+          "transferSize": 19988,
+          "resourceSize": 70275
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 261267,
-          "resourceSize": 762704
+          "transferSize": 74777,
+          "resourceSize": 144840
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3390,
-          "resourceSize": 10347
+          "transferSize": 3160,
+          "resourceSize": 9630
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 196583,
-          "resourceSize": 643752
+          "transferSize": 12920,
+          "resourceSize": 28895
         },
         "stylesheet": {
-          "transferSize": 24218,
-          "resourceSize": 75483
+          "transferSize": 21596,
+          "resourceSize": 73193
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 263119,
-          "resourceSize": 767026
+          "transferSize": 76599,
+          "resourceSize": 149162
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3331,
-          "resourceSize": 9320
+          "transferSize": 2999,
+          "resourceSize": 8100
         },
         "font": {
           "transferSize": 23666,
           "resourceSize": 23328
         },
         "script": {
-          "transferSize": 594510,
-          "resourceSize": 1791619
+          "transferSize": 14931,
+          "resourceSize": 30733
         },
         "stylesheet": {
-          "transferSize": 22208,
-          "resourceSize": 73968
+          "transferSize": 19586,
+          "resourceSize": 71678
         },
         "image": {
           "transferSize": 13873,
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1117,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 662153,
-          "resourceSize": 1913599
+          "transferSize": 76791,
+          "resourceSize": 147955
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.5.0.json
+++ b/.github/page_size_audit_results/v1.5.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.5.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:20.428Z"
+    "generatedAt": "2025-11-27T16:01:12.985Z"
   },
-  "timestamp": "2025-11-22T11:49:20.428Z",
+  "timestamp": "2025-11-27T16:01:12.985Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2765,
-          "resourceSize": 6032
+          "transferSize": 2581,
+          "resourceSize": 5377
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876984,
-          "resourceSize": 1984785
+          "transferSize": 690514,
+          "resourceSize": 1366983
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2641,
-          "resourceSize": 5748
+          "transferSize": 2449,
+          "resourceSize": 5093
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876861,
-          "resourceSize": 1984501
+          "transferSize": 690382,
+          "resourceSize": 1366699
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5523,
-          "resourceSize": 17920
+          "transferSize": 5213,
+          "resourceSize": 16731
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7825,
-          "resourceSize": 6933
+          "transferSize": 4973,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064609,
-          "resourceSize": 2937830
+          "transferSize": 479246,
+          "resourceSize": 1172217
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2464,
-          "resourceSize": 5132
+          "transferSize": 2275,
+          "resourceSize": 4477
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876683,
-          "resourceSize": 1983885
+          "transferSize": 690206,
+          "resourceSize": 1366083
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2630,
-          "resourceSize": 5558
+          "transferSize": 2439,
+          "resourceSize": 4903
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876847,
-          "resourceSize": 1984311
+          "transferSize": 690376,
+          "resourceSize": 1366509
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2481,
-          "resourceSize": 5114
+          "transferSize": 2289,
+          "resourceSize": 4459
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876698,
-          "resourceSize": 1983867
+          "transferSize": 690223,
+          "resourceSize": 1366065
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2690,
-          "resourceSize": 5668
+          "transferSize": 2502,
+          "resourceSize": 5013
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876914,
-          "resourceSize": 1984422
+          "transferSize": 690432,
+          "resourceSize": 1366619
         }
       },
       "themeResources": {
@@ -509,20 +509,20 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3276,
-          "resourceSize": 7785
+          "transferSize": 3088,
+          "resourceSize": 7130
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
@@ -533,12 +533,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877494,
-          "resourceSize": 1986539
+          "transferSize": 691020,
+          "resourceSize": 1368736
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3436,
-          "resourceSize": 7515
+          "transferSize": 3145,
+          "resourceSize": 6409
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319627,
-          "resourceSize": 712050
+          "transferSize": 317005,
+          "resourceSize": 709760
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3944,
-          "resourceSize": 1443
+          "transferSize": 1125,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282817,
-          "resourceSize": 3145942
+          "transferSize": 697505,
+          "resourceSize": 1380411
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.6.0.json
+++ b/.github/page_size_audit_results/v1.6.0.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.6.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:17.643Z"
+    "generatedAt": "2025-11-27T16:01:03.380Z"
   },
-  "timestamp": "2025-11-22T11:49:17.643Z",
+  "timestamp": "2025-11-27T16:01:03.380Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2767,
-          "resourceSize": 6043
+          "transferSize": 2582,
+          "resourceSize": 5388
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319640,
-          "resourceSize": 712073
+          "transferSize": 317018,
+          "resourceSize": 709783
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876999,
-          "resourceSize": 1984819
+          "transferSize": 690529,
+          "resourceSize": 1367017
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2642,
-          "resourceSize": 5759
+          "transferSize": 2452,
+          "resourceSize": 5104
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319640,
-          "resourceSize": 712073
+          "transferSize": 317018,
+          "resourceSize": 709783
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876875,
-          "resourceSize": 1984535
+          "transferSize": 690399,
+          "resourceSize": 1366733
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5523,
-          "resourceSize": 17931
+          "transferSize": 5216,
+          "resourceSize": 16742
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319640,
-          "resourceSize": 712073
+          "transferSize": 317018,
+          "resourceSize": 709783
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7845,
-          "resourceSize": 6933
+          "transferSize": 4968,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064642,
-          "resourceSize": 2937864
+          "transferSize": 479257,
+          "resourceSize": 1172251
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2465,
-          "resourceSize": 5143
+          "transferSize": 2280,
+          "resourceSize": 4488
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319640,
-          "resourceSize": 712073
+          "transferSize": 317018,
+          "resourceSize": 709783
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876695,
-          "resourceSize": 1983919
+          "transferSize": 690224,
+          "resourceSize": 1366117
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2631,
-          "resourceSize": 5569
+          "transferSize": 2443,
+          "resourceSize": 4914
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319640,
-          "resourceSize": 712073
+          "transferSize": 317018,
+          "resourceSize": 709783
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876861,
-          "resourceSize": 1984345
+          "transferSize": 690388,
+          "resourceSize": 1366543
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2483,
-          "resourceSize": 5125
+          "transferSize": 2293,
+          "resourceSize": 4470
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319640,
-          "resourceSize": 712073
+          "transferSize": 317018,
+          "resourceSize": 709783
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876713,
-          "resourceSize": 1983901
+          "transferSize": 690243,
+          "resourceSize": 1366099
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2692,
-          "resourceSize": 5679
+          "transferSize": 2505,
+          "resourceSize": 5024
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319640,
-          "resourceSize": 712073
+          "transferSize": 317018,
+          "resourceSize": 709783
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876920,
-          "resourceSize": 1984456
+          "transferSize": 690452,
+          "resourceSize": 1366653
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3279,
-          "resourceSize": 7796
+          "transferSize": 3094,
+          "resourceSize": 7141
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319640,
-          "resourceSize": 712073
+          "transferSize": 317018,
+          "resourceSize": 709783
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877513,
-          "resourceSize": 1986573
+          "transferSize": 691037,
+          "resourceSize": 1368770
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3438,
-          "resourceSize": 7526
+          "transferSize": 3149,
+          "resourceSize": 6420
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319640,
-          "resourceSize": 712073
+          "transferSize": 317018,
+          "resourceSize": 709783
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1119,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 1282835,
-          "resourceSize": 3145976
+          "transferSize": 697516,
+          "resourceSize": 1380445
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.6.1.json
+++ b/.github/page_size_audit_results/v1.6.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.6.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:21.129Z"
+    "generatedAt": "2025-11-27T16:01:05.912Z"
   },
-  "timestamp": "2025-11-22T11:49:21.129Z",
+  "timestamp": "2025-11-27T16:01:05.912Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2759,
-          "resourceSize": 6044
+          "transferSize": 2699,
+          "resourceSize": 5763
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 181924,
+          "resourceSize": 534981
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 318191,
+          "resourceSize": 710799
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876997,
-          "resourceSize": 1984832
+          "transferSize": 728381,
+          "resourceSize": 1475960
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2634,
-          "resourceSize": 5760
+          "transferSize": 2574,
+          "resourceSize": 5479
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 181924,
+          "resourceSize": 534981
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 318191,
+          "resourceSize": 710799
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876870,
-          "resourceSize": 1984548
+          "transferSize": 728251,
+          "resourceSize": 1475676
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5520,
-          "resourceSize": 17932
+          "transferSize": 5329,
+          "resourceSize": 17218
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 187995,
+          "resourceSize": 547377
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 318191,
+          "resourceSize": 710799
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7850,
-          "resourceSize": 6933
+          "transferSize": 4965,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064647,
-          "resourceSize": 2937877
+          "transferSize": 517098,
+          "resourceSize": 1281295
         }
       },
       "themeResources": {
@@ -225,20 +225,20 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2463,
-          "resourceSize": 5144
+          "transferSize": 2397,
+          "resourceSize": 4863
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 181924,
+          "resourceSize": 534981
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 318191,
+          "resourceSize": 710799
         },
         "image": {
           "transferSize": 224175,
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876700,
-          "resourceSize": 1983932
+          "transferSize": 728077,
+          "resourceSize": 1475060
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2624,
-          "resourceSize": 5570
+          "transferSize": 2564,
+          "resourceSize": 5289
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 181924,
+          "resourceSize": 534981
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 318191,
+          "resourceSize": 710799
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876864,
-          "resourceSize": 1984358
+          "transferSize": 728237,
+          "resourceSize": 1475486
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2476,
-          "resourceSize": 5126
+          "transferSize": 2411,
+          "resourceSize": 4845
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 181924,
+          "resourceSize": 534981
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 318191,
+          "resourceSize": 710799
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 876712,
-          "resourceSize": 1983914
+          "transferSize": 728087,
+          "resourceSize": 1475042
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2686,
-          "resourceSize": 5680
+          "transferSize": 2626,
+          "resourceSize": 5399
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 181924,
+          "resourceSize": 534981
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 318191,
+          "resourceSize": 710799
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 876921,
-          "resourceSize": 1984469
+          "transferSize": 728302,
+          "resourceSize": 1475596
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3271,
-          "resourceSize": 7797
+          "transferSize": 3207,
+          "resourceSize": 7516
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 181924,
+          "resourceSize": 534981
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 318191,
+          "resourceSize": 710799
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877505,
-          "resourceSize": 1986586
+          "transferSize": 728885,
+          "resourceSize": 1477713
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3428,
-          "resourceSize": 7527
+          "transferSize": 3262,
+          "resourceSize": 6795
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 187995,
+          "resourceSize": 547377
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 318191,
+          "resourceSize": 710799
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3945,
-          "resourceSize": 1443
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 619,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1282826,
-          "resourceSize": 3145989
+          "transferSize": 735368,
+          "resourceSize": 1489389
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.7.0.json
+++ b/.github/page_size_audit_results/v1.7.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.7.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:23.373Z"
+    "generatedAt": "2025-11-27T16:03:25.928Z"
   },
-  "timestamp": "2025-11-22T11:49:23.373Z",
+  "timestamp": "2025-11-27T16:03:25.929Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2813,
-          "resourceSize": 6116
+          "transferSize": 2631,
+          "resourceSize": 5461
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877476,
-          "resourceSize": 1984904
+          "transferSize": 691001,
+          "resourceSize": 1367102
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2689,
-          "resourceSize": 5832
+          "transferSize": 2507,
+          "resourceSize": 5177
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877350,
-          "resourceSize": 1984620
+          "transferSize": 690882,
+          "resourceSize": 1366818
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5527,
-          "resourceSize": 17932
+          "transferSize": 5220,
+          "resourceSize": 16743
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7866,
-          "resourceSize": 6933
+          "transferSize": 4968,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064670,
-          "resourceSize": 2937877
+          "transferSize": 479264,
+          "resourceSize": 1172264
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2517,
-          "resourceSize": 5216
+          "transferSize": 2327,
+          "resourceSize": 4561
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877176,
-          "resourceSize": 1984004
+          "transferSize": 690697,
+          "resourceSize": 1366202
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2676,
-          "resourceSize": 5642
+          "transferSize": 2496,
+          "resourceSize": 4987
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877336,
-          "resourceSize": 1984430
+          "transferSize": 690869,
+          "resourceSize": 1366628
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2531,
-          "resourceSize": 5198
+          "transferSize": 2342,
+          "resourceSize": 4543
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877188,
-          "resourceSize": 1983987
+          "transferSize": 690720,
+          "resourceSize": 1366184
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2737,
-          "resourceSize": 5752
+          "transferSize": 2554,
+          "resourceSize": 5097
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877399,
-          "resourceSize": 1984541
+          "transferSize": 690934,
+          "resourceSize": 1366738
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3372,
-          "resourceSize": 8069
+          "transferSize": 3191,
+          "resourceSize": 7414
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878041,
-          "resourceSize": 2210864
+          "transferSize": 691565,
+          "resourceSize": 1593061
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3484,
-          "resourceSize": 7599
+          "transferSize": 3194,
+          "resourceSize": 6493
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3953,
-          "resourceSize": 1443
+          "transferSize": 1121,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1283315,
-          "resourceSize": 3146061
+          "transferSize": 697992,
+          "resourceSize": 1380531
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.8.0.json
+++ b/.github/page_size_audit_results/v1.8.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:51:56.150Z"
+    "generatedAt": "2025-11-27T16:00:57.235Z"
   },
-  "timestamp": "2025-11-22T11:51:56.150Z",
+  "timestamp": "2025-11-27T16:00:57.235Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2809,
-          "resourceSize": 6121
+          "transferSize": 2632,
+          "resourceSize": 5466
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877472,
-          "resourceSize": 1984909
+          "transferSize": 691004,
+          "resourceSize": 1367107
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2686,
-          "resourceSize": 5837
+          "transferSize": 2509,
+          "resourceSize": 5182
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877347,
-          "resourceSize": 1984625
+          "transferSize": 690881,
+          "resourceSize": 1366823
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5520,
-          "resourceSize": 17937
+          "transferSize": 5217,
+          "resourceSize": 16748
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7818,
-          "resourceSize": 6933
+          "transferSize": 4996,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064615,
-          "resourceSize": 2937882
+          "transferSize": 479289,
+          "resourceSize": 1172269
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2514,
-          "resourceSize": 5221
+          "transferSize": 2328,
+          "resourceSize": 4566
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877175,
-          "resourceSize": 1984009
+          "transferSize": 690702,
+          "resourceSize": 1366207
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2673,
-          "resourceSize": 5647
+          "transferSize": 2498,
+          "resourceSize": 4992
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877331,
-          "resourceSize": 1984435
+          "transferSize": 690868,
+          "resourceSize": 1366633
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2527,
-          "resourceSize": 5203
+          "transferSize": 2343,
+          "resourceSize": 4548
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877184,
-          "resourceSize": 1983992
+          "transferSize": 690722,
+          "resourceSize": 1366189
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2734,
-          "resourceSize": 5757
+          "transferSize": 2555,
+          "resourceSize": 5102
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877398,
-          "resourceSize": 1984546
+          "transferSize": 690931,
+          "resourceSize": 1366743
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3369,
-          "resourceSize": 8074
+          "transferSize": 3193,
+          "resourceSize": 7419
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878028,
-          "resourceSize": 2210869
+          "transferSize": 691569,
+          "resourceSize": 1593066
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3481,
-          "resourceSize": 7604
+          "transferSize": 3198,
+          "resourceSize": 6498
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3947,
-          "resourceSize": 1443
+          "transferSize": 1125,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1283306,
-          "resourceSize": 3146066
+          "transferSize": 698000,
+          "resourceSize": 1380536
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.8.1.json
+++ b/.github/page_size_audit_results/v1.8.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:20.554Z"
+    "generatedAt": "2025-11-27T16:03:33.056Z"
   },
-  "timestamp": "2025-11-22T11:49:20.554Z",
+  "timestamp": "2025-11-27T16:03:33.057Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2808,
-          "resourceSize": 6121
+          "transferSize": 2629,
+          "resourceSize": 5466
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 780,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877478,
-          "resourceSize": 1984909
+          "transferSize": 691000,
+          "resourceSize": 1367107
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2684,
-          "resourceSize": 5837
+          "transferSize": 2505,
+          "resourceSize": 5182
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877342,
-          "resourceSize": 1984625
+          "transferSize": 690882,
+          "resourceSize": 1366823
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5518,
-          "resourceSize": 17937
+          "transferSize": 5215,
+          "resourceSize": 16748
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7841,
-          "resourceSize": 6933
+          "transferSize": 4962,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064636,
-          "resourceSize": 2937882
+          "transferSize": 479253,
+          "resourceSize": 1172269
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2514,
-          "resourceSize": 5221
+          "transferSize": 2326,
+          "resourceSize": 4566
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877176,
-          "resourceSize": 1984009
+          "transferSize": 690698,
+          "resourceSize": 1366207
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2672,
-          "resourceSize": 5647
+          "transferSize": 2495,
+          "resourceSize": 4992
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877330,
-          "resourceSize": 1984435
+          "transferSize": 690871,
+          "resourceSize": 1366633
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2526,
-          "resourceSize": 5203
+          "transferSize": 2340,
+          "resourceSize": 4548
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877192,
-          "resourceSize": 1983992
+          "transferSize": 690715,
+          "resourceSize": 1366189
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2733,
-          "resourceSize": 5757
+          "transferSize": 2552,
+          "resourceSize": 5102
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877393,
-          "resourceSize": 1984546
+          "transferSize": 690929,
+          "resourceSize": 1366743
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3368,
-          "resourceSize": 8074
+          "transferSize": 3189,
+          "resourceSize": 7419
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878028,
-          "resourceSize": 2210869
+          "transferSize": 691566,
+          "resourceSize": 1593066
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3481,
-          "resourceSize": 7604
+          "transferSize": 3194,
+          "resourceSize": 6498
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3946,
-          "resourceSize": 1443
+          "transferSize": 1121,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1283305,
-          "resourceSize": 3146066
+          "transferSize": 697992,
+          "resourceSize": 1380536
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.9.0.json
+++ b/.github/page_size_audit_results/v1.9.0.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.9.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-22T11:49:20.131Z"
+    "generatedAt": "2025-11-27T16:01:03.833Z"
   },
-  "timestamp": "2025-11-22T11:49:20.132Z",
+  "timestamp": "2025-11-27T16:01:03.833Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2814,
-          "resourceSize": 6160
+          "transferSize": 2639,
+          "resourceSize": 5505
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877473,
-          "resourceSize": 1984948
+          "transferSize": 691013,
+          "resourceSize": 1367146
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2690,
-          "resourceSize": 5876
+          "transferSize": 2515,
+          "resourceSize": 5221
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877353,
-          "resourceSize": 1984664
+          "transferSize": 690893,
+          "resourceSize": 1366862
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5527,
-          "resourceSize": 17976
+          "transferSize": 5233,
+          "resourceSize": 16787
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7825,
-          "resourceSize": 6933
+          "transferSize": 4955,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1064629,
-          "resourceSize": 2937921
+          "transferSize": 479264,
+          "resourceSize": 1172308
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2521,
-          "resourceSize": 5260
+          "transferSize": 2337,
+          "resourceSize": 4605
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877182,
-          "resourceSize": 1984048
+          "transferSize": 690712,
+          "resourceSize": 1366246
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2677,
-          "resourceSize": 5686
+          "transferSize": 2506,
+          "resourceSize": 5031
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 877334,
-          "resourceSize": 1984474
+          "transferSize": 690877,
+          "resourceSize": 1366672
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2530,
-          "resourceSize": 5242
+          "transferSize": 2350,
+          "resourceSize": 4587
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877194,
-          "resourceSize": 1984031
+          "transferSize": 690723,
+          "resourceSize": 1366228
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2739,
-          "resourceSize": 5796
+          "transferSize": 2562,
+          "resourceSize": 5141
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 877404,
-          "resourceSize": 1984585
+          "transferSize": 690933,
+          "resourceSize": 1366782
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3372,
-          "resourceSize": 8113
+          "transferSize": 3195,
+          "resourceSize": 7458
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 329029,
-          "resourceSize": 1042286
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 878029,
-          "resourceSize": 2210908
+          "transferSize": 691564,
+          "resourceSize": 1593105
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3485,
-          "resourceSize": 7643
+          "transferSize": 3207,
+          "resourceSize": 6537
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 731016,
-          "resourceSize": 2200711
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 319643,
-          "resourceSize": 712085
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3950,
-          "resourceSize": 1443
+          "transferSize": 1121,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1283313,
-          "resourceSize": 3146105
+          "transferSize": 698005,
+          "resourceSize": 1380575
         }
       },
       "themeResources": {


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.0.0
- **End Version:** latest

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Size Audit workflow*