### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.0.0.json
+++ b/.github/page_size_audit_results/v1.0.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.0.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:08.225Z"
+    "generatedAt": "2025-11-27T17:06:23.666Z"
   },
-  "timestamp": "2025-11-27T16:01:08.225Z",
+  "timestamp": "2025-11-27T17:06:23.666Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693868,
+          "transferSize": 693864,
           "resourceSize": 1370293
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2342,
+          "transferSize": 2343,
           "resourceSize": 5135
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693714,
+          "transferSize": 693715,
           "resourceSize": 1369835
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5029,
+          "transferSize": 5028,
           "resourceSize": 16192
         },
         "font": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 480943,
+          "transferSize": 480942,
           "resourceSize": 1172833
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693543,
+          "transferSize": 693548,
           "resourceSize": 1369308
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2338,
+          "transferSize": 2337,
           "resourceSize": 5034
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693704,
+          "transferSize": 693710,
           "resourceSize": 1369734
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693572,
+          "transferSize": 693570,
           "resourceSize": 1369325
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2401,
+          "transferSize": 2400,
           "resourceSize": 5144
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693767,
+          "transferSize": 693773,
           "resourceSize": 1369844
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 694364,
+          "transferSize": 694370,
           "resourceSize": 1371936
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 700802,
+          "transferSize": 700805,
           "resourceSize": 1383566
         }
       },

--- a/.github/page_size_audit_results/v1.0.1.json
+++ b/.github/page_size_audit_results/v1.0.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.0.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:34.920Z"
+    "generatedAt": "2025-11-27T17:03:50.545Z"
   },
-  "timestamp": "2025-11-27T16:03:34.920Z",
+  "timestamp": "2025-11-27T17:03:50.546Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693675,
+          "transferSize": 693677,
           "resourceSize": 1371175
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2039,
+          "transferSize": 2040,
           "resourceSize": 4179
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693520,
+          "transferSize": 693517,
           "resourceSize": 1370717
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 3409,
+          "transferSize": 3411,
           "resourceSize": 3746
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 480756,
+          "transferSize": 480758,
           "resourceSize": 1173715
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693357,
+          "transferSize": 693359,
           "resourceSize": 1370190
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693518,
+          "transferSize": 693520,
           "resourceSize": 1370616
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693384,
+          "transferSize": 693387,
           "resourceSize": 1370207
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693589,
+          "transferSize": 693597,
           "resourceSize": 1370726
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 694197,
+          "transferSize": 694195,
           "resourceSize": 1372818
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 700630,
+          "transferSize": 700633,
           "resourceSize": 1384448
         }
       },

--- a/.github/page_size_audit_results/v1.1.0.json
+++ b/.github/page_size_audit_results/v1.1.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:31.941Z"
+    "generatedAt": "2025-11-27T17:03:45.519Z"
   },
-  "timestamp": "2025-11-27T16:03:31.941Z",
+  "timestamp": "2025-11-27T17:03:45.519Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2164,
+          "transferSize": 2165,
           "resourceSize": 4554
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693641,
+          "transferSize": 693651,
           "resourceSize": 1371092
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2033,
+          "transferSize": 2034,
           "resourceSize": 4163
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693513,
+          "transferSize": 693517,
           "resourceSize": 1370701
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 4731,
+          "transferSize": 4730,
           "resourceSize": 15220
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 3423,
+          "transferSize": 3420,
           "resourceSize": 3746
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 480763,
+          "transferSize": 480759,
           "resourceSize": 1173699
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693353,
+          "transferSize": 693361,
           "resourceSize": 1370174
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2031,
+          "transferSize": 2030,
           "resourceSize": 4062
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693512,
+          "transferSize": 693514,
           "resourceSize": 1370600
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693376,
+          "transferSize": 693380,
           "resourceSize": 1370191
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2102,
+          "transferSize": 2101,
           "resourceSize": 4172
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 694187,
+          "transferSize": 694188,
           "resourceSize": 1372802
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 700628,
+          "transferSize": 700631,
           "resourceSize": 1384432
         }
       },

--- a/.github/page_size_audit_results/v1.1.1.json
+++ b/.github/page_size_audit_results/v1.1.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:03.816Z"
+    "generatedAt": "2025-11-27T17:03:57.556Z"
   },
-  "timestamp": "2025-11-27T16:01:03.816Z",
+  "timestamp": "2025-11-27T17:03:57.556Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2162,
+          "transferSize": 2164,
           "resourceSize": 4554
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693631,
+          "transferSize": 693638,
           "resourceSize": 1371059
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2031,
+          "transferSize": 2033,
           "resourceSize": 4163
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693502,
+          "transferSize": 693503,
           "resourceSize": 1370668
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 4793,
+          "transferSize": 4796,
           "resourceSize": 15748
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4399,
+          "transferSize": 4404,
           "resourceSize": 5113
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 481790,
+          "transferSize": 481798,
           "resourceSize": 1175561
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1868,
+          "transferSize": 1871,
           "resourceSize": 3636
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2028,
+          "transferSize": 2030,
           "resourceSize": 4062
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693500,
+          "transferSize": 693499,
           "resourceSize": 1370567
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1893,
+          "transferSize": 1896,
           "resourceSize": 3653
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693364,
+          "transferSize": 693366,
           "resourceSize": 1370158
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2099,
+          "transferSize": 2101,
           "resourceSize": 4172
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693569,
+          "transferSize": 693571,
           "resourceSize": 1370677
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2699,
+          "transferSize": 2703,
           "resourceSize": 6264
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 694168,
+          "transferSize": 694174,
           "resourceSize": 1372769
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2717,
+          "transferSize": 2720,
           "resourceSize": 5498
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 700614,
+          "transferSize": 700612,
           "resourceSize": 1384399
         }
       },

--- a/.github/page_size_audit_results/v1.1.2.json
+++ b/.github/page_size_audit_results/v1.1.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:17.617Z"
+    "generatedAt": "2025-11-27T17:06:25.075Z"
   },
-  "timestamp": "2025-11-27T16:01:17.618Z",
+  "timestamp": "2025-11-27T17:06:25.075Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2826,
+          "transferSize": 2823,
           "resourceSize": 5930
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691982,
+          "transferSize": 691977,
           "resourceSize": 1368962
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2704,
+          "transferSize": 2702,
           "resourceSize": 5687
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691868,
+          "transferSize": 691863,
           "resourceSize": 1368719
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5456,
+          "transferSize": 5452,
           "resourceSize": 17293
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4974,
+          "transferSize": 4966,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 480714,
+          "transferSize": 480702,
           "resourceSize": 1174205
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2525,
+          "transferSize": 2523,
           "resourceSize": 5071
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691681,
+          "transferSize": 691679,
           "resourceSize": 1368103
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2692,
+          "transferSize": 2689,
           "resourceSize": 5497
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691857,
+          "transferSize": 691850,
           "resourceSize": 1368529
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2551,
+          "transferSize": 2548,
           "resourceSize": 5088
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691713,
+          "transferSize": 691707,
           "resourceSize": 1368120
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2750,
+          "transferSize": 2747,
           "resourceSize": 5607
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691906,
+          "transferSize": 691904,
           "resourceSize": 1368639
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3332,
+          "transferSize": 3328,
           "resourceSize": 7702
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 779,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692499,
+          "transferSize": 692489,
           "resourceSize": 1370734
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3369,
+          "transferSize": 3366,
           "resourceSize": 6933
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 698954,
+          "transferSize": 698947,
           "resourceSize": 1382361
         }
       },

--- a/.github/page_size_audit_results/v1.1.3.json
+++ b/.github/page_size_audit_results/v1.1.3.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:00.688Z"
+    "generatedAt": "2025-11-27T17:04:09.454Z"
   },
-  "timestamp": "2025-11-27T16:01:00.688Z",
+  "timestamp": "2025-11-27T17:04:09.454Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2800,
+          "transferSize": 2797,
           "resourceSize": 5883
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691952,
+          "transferSize": 691956,
           "resourceSize": 1368915
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2680,
+          "transferSize": 2677,
           "resourceSize": 5627
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691834,
+          "transferSize": 691832,
           "resourceSize": 1368659
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5427,
+          "transferSize": 5424,
           "resourceSize": 17233
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4962,
+          "transferSize": 4969,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 480673,
+          "transferSize": 480677,
           "resourceSize": 1174145
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691652,
+          "transferSize": 691661,
           "resourceSize": 1368043
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2668,
+          "transferSize": 2665,
           "resourceSize": 5437
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691819,
+          "transferSize": 691820,
           "resourceSize": 1368469
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2523,
+          "transferSize": 2520,
           "resourceSize": 5028
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691680,
+          "transferSize": 691683,
           "resourceSize": 1368060
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2725,
+          "transferSize": 2721,
           "resourceSize": 5547
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691882,
+          "transferSize": 691877,
           "resourceSize": 1368579
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3308,
+          "transferSize": 3304,
           "resourceSize": 7657
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692460,
+          "transferSize": 692463,
           "resourceSize": 1370689
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3346,
+          "transferSize": 3343,
           "resourceSize": 6873
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 698925,
+          "transferSize": 698924,
           "resourceSize": 1382301
         }
       },

--- a/.github/page_size_audit_results/v1.1.4.json
+++ b/.github/page_size_audit_results/v1.1.4.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:10.009Z"
+    "generatedAt": "2025-11-27T17:03:53.120Z"
   },
-  "timestamp": "2025-11-27T16:01:10.009Z",
+  "timestamp": "2025-11-27T17:03:53.120Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2801,
+          "transferSize": 2802,
           "resourceSize": 5889
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 779,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691968,
+          "transferSize": 691963,
           "resourceSize": 1368921
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2681,
+          "transferSize": 2682,
           "resourceSize": 5633
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691845,
+          "transferSize": 691841,
           "resourceSize": 1368665
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5431,
+          "transferSize": 5432,
           "resourceSize": 17239
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4988,
+          "transferSize": 4965,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 480703,
+          "transferSize": 480681,
           "resourceSize": 1174151
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691664,
+          "transferSize": 691658,
           "resourceSize": 1368049
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691830,
+          "transferSize": 691827,
           "resourceSize": 1368475
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691683,
+          "transferSize": 691681,
           "resourceSize": 1368066
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692464,
+          "transferSize": 692467,
           "resourceSize": 1370695
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 698928,
+          "transferSize": 698932,
           "resourceSize": 1382307
         }
       },

--- a/.github/page_size_audit_results/v1.10.0.json
+++ b/.github/page_size_audit_results/v1.10.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:09.521Z"
+    "generatedAt": "2025-11-27T17:06:53.765Z"
   },
-  "timestamp": "2025-11-27T16:01:09.521Z",
+  "timestamp": "2025-11-27T17:06:53.765Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2682,
+          "transferSize": 2679,
           "resourceSize": 5857
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691053,
+          "transferSize": 691051,
           "resourceSize": 1367498
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2593,
+          "transferSize": 2591,
           "resourceSize": 5657
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5294,
+          "transferSize": 5292,
           "resourceSize": 17438
         },
         "font": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479339,
+          "transferSize": 479337,
           "resourceSize": 1172959
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2407,
+          "transferSize": 2405,
           "resourceSize": 5031
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690785,
+          "transferSize": 690779,
           "resourceSize": 1366672
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2583,
+          "transferSize": 2580,
           "resourceSize": 5467
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690956,
+          "transferSize": 690954,
           "resourceSize": 1367108
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2421,
+          "transferSize": 2419,
           "resourceSize": 5013
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690799,
+          "transferSize": 690795,
           "resourceSize": 1366654
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2640,
+          "transferSize": 2636,
           "resourceSize": 5577
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691011,
+          "transferSize": 691015,
           "resourceSize": 1367218
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3250,
+          "transferSize": 3247,
           "resourceSize": 7730
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691626,
+          "transferSize": 691619,
           "resourceSize": 1593377
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3289,
+          "transferSize": 3287,
           "resourceSize": 6929
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1118,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 698084,
+          "transferSize": 698090,
           "resourceSize": 1380967
         }
       },

--- a/.github/page_size_audit_results/v1.10.1.json
+++ b/.github/page_size_audit_results/v1.10.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:00:58.099Z"
+    "generatedAt": "2025-11-27T17:03:47.959Z"
   },
-  "timestamp": "2025-11-27T16:00:58.100Z",
+  "timestamp": "2025-11-27T17:03:47.959Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2712,
+          "transferSize": 2714,
           "resourceSize": 5925
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691084,
+          "transferSize": 691086,
           "resourceSize": 1367566
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690967,
+          "transferSize": 690965,
           "resourceSize": 1367298
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5292,
+          "transferSize": 5293,
           "resourceSize": 17438
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4972,
+          "transferSize": 4967,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479340,
+          "transferSize": 479336,
           "resourceSize": 1172959
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2405,
+          "transferSize": 2407,
           "resourceSize": 5031
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690784,
+          "transferSize": 690779,
           "resourceSize": 1366672
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2580,
+          "transferSize": 2583,
           "resourceSize": 5467
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690952,
+          "transferSize": 690959,
           "resourceSize": 1367108
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2419,
+          "transferSize": 2421,
           "resourceSize": 5013
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690793,
+          "transferSize": 690792,
           "resourceSize": 1366654
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2637,
+          "transferSize": 2639,
           "resourceSize": 5577
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691010,
+          "transferSize": 691015,
           "resourceSize": 1367218
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3283,
+          "transferSize": 3287,
           "resourceSize": 7893
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691657,
+          "transferSize": 691669,
           "resourceSize": 1593540
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3287,
+          "transferSize": 3289,
           "resourceSize": 6929
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 698085,
+          "transferSize": 698091,
           "resourceSize": 1380967
         }
       },

--- a/.github/page_size_audit_results/v1.10.2.json
+++ b/.github/page_size_audit_results/v1.10.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:01.200Z"
+    "generatedAt": "2025-11-27T17:06:25.491Z"
   },
-  "timestamp": "2025-11-27T16:01:01.200Z",
+  "timestamp": "2025-11-27T17:06:25.491Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2712,
+          "transferSize": 2714,
           "resourceSize": 5925
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691086,
+          "transferSize": 691092,
           "resourceSize": 1367566
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690964,
+          "transferSize": 690971,
           "resourceSize": 1367298
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5292,
+          "transferSize": 5295,
           "resourceSize": 17450
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4962,
+          "transferSize": 4971,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479330,
+          "transferSize": 479342,
           "resourceSize": 1172971
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2405,
+          "transferSize": 2407,
           "resourceSize": 5031
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690780,
+          "transferSize": 690781,
           "resourceSize": 1366672
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2581,
+          "transferSize": 2583,
           "resourceSize": 5467
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690955,
+          "transferSize": 690957,
           "resourceSize": 1367108
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2420,
+          "transferSize": 2421,
           "resourceSize": 5013
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690796,
+          "transferSize": 690798,
           "resourceSize": 1366654
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2637,
+          "transferSize": 2639,
           "resourceSize": 5577
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691008,
+          "transferSize": 691018,
           "resourceSize": 1367218
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3283,
+          "transferSize": 3287,
           "resourceSize": 7893
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691656,
+          "transferSize": 691663,
           "resourceSize": 1593540
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3287,
+          "transferSize": 3289,
           "resourceSize": 6929
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 698091,
+          "transferSize": 698089,
           "resourceSize": 1380967
         }
       },

--- a/.github/page_size_audit_results/v1.11.0.json
+++ b/.github/page_size_audit_results/v1.11.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.11.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:03.051Z"
+    "generatedAt": "2025-11-27T17:03:52.197Z"
   },
-  "timestamp": "2025-11-27T16:01:03.052Z",
+  "timestamp": "2025-11-27T17:03:52.197Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2617,
+          "transferSize": 2616,
           "resourceSize": 5628
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690900,
+          "transferSize": 690901,
           "resourceSize": 1366976
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2592,
+          "transferSize": 2593,
           "resourceSize": 5657
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690875,
+          "transferSize": 690883,
           "resourceSize": 1367005
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5292,
+          "transferSize": 5294,
           "resourceSize": 17450
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4964,
+          "transferSize": 4970,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479240,
+          "transferSize": 479248,
           "resourceSize": 1172678
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2405,
+          "transferSize": 2407,
           "resourceSize": 5031
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690687,
+          "transferSize": 690691,
           "resourceSize": 1366379
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2581,
+          "transferSize": 2582,
           "resourceSize": 5467
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690860,
+          "transferSize": 690866,
           "resourceSize": 1366815
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2419,
+          "transferSize": 2421,
           "resourceSize": 5013
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690701,
+          "transferSize": 690704,
           "resourceSize": 1366361
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2638,
+          "transferSize": 2639,
           "resourceSize": 5577
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690917,
+          "transferSize": 690923,
           "resourceSize": 1366925
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3283,
+          "transferSize": 3287,
           "resourceSize": 7893
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691566,
+          "transferSize": 691572,
           "resourceSize": 1593247
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3287,
+          "transferSize": 3289,
           "resourceSize": 6929
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1132,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 697993,
+          "transferSize": 698006,
           "resourceSize": 1380674
         }
       },

--- a/.github/page_size_audit_results/v1.12.0.json
+++ b/.github/page_size_audit_results/v1.12.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:07.868Z"
+    "generatedAt": "2025-11-27T17:06:35.321Z"
   },
-  "timestamp": "2025-11-27T16:01:07.868Z",
+  "timestamp": "2025-11-27T17:06:35.321Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2631,
+          "transferSize": 2627,
           "resourceSize": 5669
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690963,
+          "transferSize": 690958,
           "resourceSize": 1367158
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2601,
+          "transferSize": 2598,
           "resourceSize": 5698
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5299,
+          "transferSize": 5297,
           "resourceSize": 17491
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4960,
+          "transferSize": 4966,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479287,
+          "transferSize": 479291,
           "resourceSize": 1172860
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2417,
+          "transferSize": 2415,
           "resourceSize": 5084
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690746,
+          "transferSize": 690739,
           "resourceSize": 1366573
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2591,
+          "transferSize": 2588,
           "resourceSize": 5508
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690921,
+          "transferSize": 690918,
           "resourceSize": 1366997
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2433,
+          "transferSize": 2432,
           "resourceSize": 5066
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690756,
+          "transferSize": 690755,
           "resourceSize": 1366555
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2649,
+          "transferSize": 2645,
           "resourceSize": 5618
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690971,
+          "transferSize": 690966,
           "resourceSize": 1367107
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3296,
+          "transferSize": 3292,
           "resourceSize": 7934
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691622,
+          "transferSize": 691613,
           "resourceSize": 1593429
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3302,
+          "transferSize": 3299,
           "resourceSize": 6986
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 698053,
+          "transferSize": 698051,
           "resourceSize": 1380872
         }
       },

--- a/.github/page_size_audit_results/v1.12.1.json
+++ b/.github/page_size_audit_results/v1.12.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:41.249Z"
+    "generatedAt": "2025-11-27T17:06:31.859Z"
   },
-  "timestamp": "2025-11-27T16:03:41.250Z",
+  "timestamp": "2025-11-27T17:06:31.859Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691932,
+          "transferSize": 691933,
           "resourceSize": 1369792
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5307,
+          "transferSize": 5308,
           "resourceSize": 17767
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4966,
+          "transferSize": 4968,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 480001,
+          "transferSize": 480004,
           "resourceSize": 1174188
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691723,
+          "transferSize": 691721,
           "resourceSize": 1369207
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2596,
+          "transferSize": 2595,
           "resourceSize": 5692
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691896,
+          "transferSize": 691892,
           "resourceSize": 1369631
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691742,
+          "transferSize": 691745,
           "resourceSize": 1369189
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691950,
+          "transferSize": 691952,
           "resourceSize": 1369741
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692604,
+          "transferSize": 692602,
           "resourceSize": 1596063
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 698756,
+          "transferSize": 698755,
           "resourceSize": 1382108
         }
       },

--- a/.github/page_size_audit_results/v1.12.2.json
+++ b/.github/page_size_audit_results/v1.12.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:12:03.937Z"
+    "generatedAt": "2025-11-27T17:16:07.171Z"
   },
-  "timestamp": "2025-11-27T16:12:03.938Z",
+  "timestamp": "2025-11-27T17:16:07.172Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2691,
+          "transferSize": 2688,
           "resourceSize": 6043
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693604,
+          "transferSize": 693601,
           "resourceSize": 1373033
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2663,
+          "transferSize": 2659,
           "resourceSize": 6072
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693572,
+          "transferSize": 693569,
           "resourceSize": 1373062
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5372,
+          "transferSize": 5369,
           "resourceSize": 17957
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4971,
+          "transferSize": 4970,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 481679,
+          "transferSize": 481675,
           "resourceSize": 1177429
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693390,
+          "transferSize": 693395,
           "resourceSize": 1372448
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2650,
+          "transferSize": 2647,
           "resourceSize": 5882
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693558,
+          "transferSize": 693553,
           "resourceSize": 1372872
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693399,
+          "transferSize": 693401,
           "resourceSize": 1372430
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2708,
+          "transferSize": 2705,
           "resourceSize": 5992
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 694279,
+          "transferSize": 694283,
           "resourceSize": 1599305
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 700415,
+          "transferSize": 700420,
           "resourceSize": 1385349
         }
       },

--- a/.github/page_size_audit_results/v1.12.3.json
+++ b/.github/page_size_audit_results/v1.12.3.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:40.782Z"
+    "generatedAt": "2025-11-27T17:06:28.410Z"
   },
-  "timestamp": "2025-11-27T16:03:40.782Z",
+  "timestamp": "2025-11-27T17:06:28.410Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2789,
-          "resourceSize": 6330
+          "transferSize": 2701,
+          "resourceSize": 6049
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294920,
-          "resourceSize": 939867
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318557,
-          "resourceSize": 711314
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 842253,
-          "resourceSize": 1881928
+          "transferSize": 693606,
+          "resourceSize": 1373056
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2760,
-          "resourceSize": 6359
+          "transferSize": 2673,
+          "resourceSize": 6078
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294920,
-          "resourceSize": 939867
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318557,
-          "resourceSize": 711314
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 842220,
-          "resourceSize": 1881957
+          "transferSize": 693582,
+          "resourceSize": 1373085
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5591,
-          "resourceSize": 18693
+          "transferSize": 5381,
+          "resourceSize": 17963
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 696633,
-          "resourceSize": 2096894
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 318557,
-          "resourceSize": 711314
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7792,
-          "resourceSize": 6933
+          "transferSize": 4955,
+          "resourceSize": 5685
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 1029191,
-          "resourceSize": 2834050
+          "transferSize": 481671,
+          "resourceSize": 1177452
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2586,
-          "resourceSize": 5745
+          "transferSize": 2499,
+          "resourceSize": 5464
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294920,
-          "resourceSize": 939867
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318557,
-          "resourceSize": 711314
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 842053,
-          "resourceSize": 1881343
+          "transferSize": 693407,
+          "resourceSize": 1372471
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2749,
-          "resourceSize": 6169
+          "transferSize": 2661,
+          "resourceSize": 5888
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294920,
-          "resourceSize": 939867
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318557,
-          "resourceSize": 711314
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 842214,
-          "resourceSize": 1881767
+          "transferSize": 693570,
+          "resourceSize": 1372895
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2597,
-          "resourceSize": 5727
+          "transferSize": 2508,
+          "resourceSize": 5446
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294920,
-          "resourceSize": 939867
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318557,
-          "resourceSize": 711314
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
@@ -391,12 +391,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 842060,
-          "resourceSize": 1881326
+          "transferSize": 693413,
+          "resourceSize": 1372453
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2809,
-          "resourceSize": 6279
+          "transferSize": 2720,
+          "resourceSize": 5998
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294920,
-          "resourceSize": 939867
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318557,
-          "resourceSize": 711314
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 1044,
-          "resourceSize": 217
+          "transferSize": 1043,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 842276,
-          "resourceSize": 1881878
+          "transferSize": 693625,
+          "resourceSize": 1373005
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3464,
-          "resourceSize": 8595
+          "transferSize": 3381,
+          "resourceSize": 8314
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 294920,
-          "resourceSize": 939867
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318557,
-          "resourceSize": 711314
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 842930,
-          "resourceSize": 2108200
+          "transferSize": 694287,
+          "resourceSize": 1599328
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3578,
-          "resourceSize": 8150
+          "transferSize": 3368,
+          "resourceSize": 7366
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 696633,
-          "resourceSize": 2096894
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 318557,
-          "resourceSize": 711314
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3945,
-          "resourceSize": 1443
+          "transferSize": 1121,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 1044,
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 1247932,
-          "resourceSize": 3042024
+          "transferSize": 700425,
+          "resourceSize": 1385372
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.13.0.json
+++ b/.github/page_size_audit_results/v1.13.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:27.274Z"
+    "generatedAt": "2025-11-27T17:03:56.076Z"
   },
-  "timestamp": "2025-11-27T16:01:27.274Z",
+  "timestamp": "2025-11-27T17:03:56.077Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693609,
+          "transferSize": 693608,
           "resourceSize": 1373056
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2672,
+          "transferSize": 2671,
           "resourceSize": 6078
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693582,
+          "transferSize": 693578,
           "resourceSize": 1373085
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5381,
+          "transferSize": 5382,
           "resourceSize": 17963
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4970,
+          "transferSize": 4973,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 481686,
+          "transferSize": 481690,
           "resourceSize": 1177452
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693410,
+          "transferSize": 693402,
           "resourceSize": 1372471
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2661,
+          "transferSize": 2660,
           "resourceSize": 5888
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693566,
+          "transferSize": 693568,
           "resourceSize": 1372895
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693413,
+          "transferSize": 693421,
           "resourceSize": 1372453
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 694288,
+          "transferSize": 694296,
           "resourceSize": 1599328
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 700430,
+          "transferSize": 700426,
           "resourceSize": 1385372
         }
       },

--- a/.github/page_size_audit_results/v1.13.1.json
+++ b/.github/page_size_audit_results/v1.13.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:00.050Z"
+    "generatedAt": "2025-11-27T17:03:52.263Z"
   },
-  "timestamp": "2025-11-27T16:01:00.050Z",
+  "timestamp": "2025-11-27T17:03:52.263Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693673,
+          "transferSize": 693678,
           "resourceSize": 1373727
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693643,
+          "transferSize": 693651,
           "resourceSize": 1373756
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4975,
+          "transferSize": 4978,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 481758,
+          "transferSize": 481761,
           "resourceSize": 1178123
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693471,
+          "transferSize": 693473,
           "resourceSize": 1373142
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2669,
+          "transferSize": 2668,
           "resourceSize": 5906
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693637,
+          "transferSize": 693642,
           "resourceSize": 1373566
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693482,
+          "transferSize": 693483,
           "resourceSize": 1373124
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2727,
+          "transferSize": 2726,
           "resourceSize": 6016
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693695,
+          "transferSize": 693693,
           "resourceSize": 1373676
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 700490,
+          "transferSize": 700492,
           "resourceSize": 1386043
         }
       },

--- a/.github/page_size_audit_results/v1.14.0.json
+++ b/.github/page_size_audit_results/v1.14.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.14.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:42.885Z"
+    "generatedAt": "2025-11-27T17:03:46.636Z"
   },
-  "timestamp": "2025-11-27T16:03:42.885Z",
+  "timestamp": "2025-11-27T17:03:46.636Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2679,
+          "transferSize": 2678,
           "resourceSize": 5995
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693622,
+          "transferSize": 693620,
           "resourceSize": 1373684
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4971,
+          "transferSize": 4973,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 481754,
+          "transferSize": 481756,
           "resourceSize": 1178123
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693470,
+          "transferSize": 693473,
           "resourceSize": 1373142
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2639,
+          "transferSize": 2638,
           "resourceSize": 5834
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693609,
+          "transferSize": 693603,
           "resourceSize": 1373494
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693480,
+          "transferSize": 693484,
           "resourceSize": 1373124
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2694,
+          "transferSize": 2693,
           "resourceSize": 5944
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693669,
+          "transferSize": 693658,
           "resourceSize": 1373604
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 694323,
+          "transferSize": 694320,
           "resourceSize": 1599927
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 700497,
+          "transferSize": 700493,
           "resourceSize": 1386043
         }
       },

--- a/.github/page_size_audit_results/v1.15.0.json
+++ b/.github/page_size_audit_results/v1.15.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:00.398Z"
+    "generatedAt": "2025-11-27T17:04:14.511Z"
   },
-  "timestamp": "2025-11-27T16:01:00.399Z",
+  "timestamp": "2025-11-27T17:04:14.511Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693796,
+          "transferSize": 693794,
           "resourceSize": 1374309
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2667,
+          "transferSize": 2666,
           "resourceSize": 6042
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693773,
+          "transferSize": 693767,
           "resourceSize": 1374338
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5574,
+          "transferSize": 5572,
           "resourceSize": 18285
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4970,
+          "transferSize": 4974,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 482072,
+          "transferSize": 482074,
           "resourceSize": 1179063
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693629,
+          "transferSize": 693623,
           "resourceSize": 1373796
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2655,
+          "transferSize": 2654,
           "resourceSize": 5852
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693756,
+          "transferSize": 693761,
           "resourceSize": 1374148
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693630,
+          "transferSize": 693634,
           "resourceSize": 1373778
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2710,
+          "transferSize": 2709,
           "resourceSize": 5962
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693808,
+          "transferSize": 693812,
           "resourceSize": 1374258
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 694473,
+          "transferSize": 694475,
           "resourceSize": 1600581
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 700642,
+          "transferSize": 700635,
           "resourceSize": 1386697
         }
       },

--- a/.github/page_size_audit_results/v1.15.1.json
+++ b/.github/page_size_audit_results/v1.15.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:00:58.869Z"
+    "generatedAt": "2025-11-27T17:03:53.683Z"
   },
-  "timestamp": "2025-11-27T16:00:58.869Z",
+  "timestamp": "2025-11-27T17:03:53.684Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2044,
+          "transferSize": 2047,
           "resourceSize": 4871
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692673,
+          "transferSize": 692679,
           "resourceSize": 1372193
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2018,
+          "transferSize": 2021,
           "resourceSize": 4900
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692644,
+          "transferSize": 692655,
           "resourceSize": 1372222
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5022,
+          "transferSize": 5023,
           "resourceSize": 17181
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4966,
+          "transferSize": 4958,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 481046,
+          "transferSize": 481039,
           "resourceSize": 1176985
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1890,
+          "transferSize": 1894,
           "resourceSize": 4358
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692520,
+          "transferSize": 692523,
           "resourceSize": 1371680
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2021,
+          "transferSize": 2024,
           "resourceSize": 4710
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692646,
+          "transferSize": 692656,
           "resourceSize": 1372032
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1901,
+          "transferSize": 1905,
           "resourceSize": 4340
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692532,
+          "transferSize": 692537,
           "resourceSize": 1371662
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2094,
+          "transferSize": 2098,
           "resourceSize": 4820
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692725,
+          "transferSize": 692734,
           "resourceSize": 1372142
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2743,
+          "transferSize": 2747,
           "resourceSize": 7136
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 693377,
+          "transferSize": 693379,
           "resourceSize": 1598465
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2784,
+          "transferSize": 2790,
           "resourceSize": 6242
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 699563,
+          "transferSize": 699572,
           "resourceSize": 1384563
         }
       },

--- a/.github/page_size_audit_results/v1.16.0.json
+++ b/.github/page_size_audit_results/v1.16.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:03.504Z"
+    "generatedAt": "2025-11-27T17:03:44.426Z"
   },
-  "timestamp": "2025-11-27T16:01:03.505Z",
+  "timestamp": "2025-11-27T17:03:44.426Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692776,
+          "transferSize": 692770,
           "resourceSize": 1372739
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692756,
+          "transferSize": 692747,
           "resourceSize": 1372768
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5022,
+          "transferSize": 5023,
           "resourceSize": 17191
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4983,
+          "transferSize": 4970,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 481161,
+          "transferSize": 481149,
           "resourceSize": 1177531
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692627,
+          "transferSize": 692619,
           "resourceSize": 1372226
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692752,
+          "transferSize": 692755,
           "resourceSize": 1372578
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692631,
+          "transferSize": 692635,
           "resourceSize": 1372208
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2096,
+          "transferSize": 2095,
           "resourceSize": 4830
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692825,
+          "transferSize": 692820,
           "resourceSize": 1372688
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 693475,
+          "transferSize": 693473,
           "resourceSize": 1599011
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 699668,
+          "transferSize": 699671,
           "resourceSize": 1385109
         }
       },

--- a/.github/page_size_audit_results/v1.16.1.json
+++ b/.github/page_size_audit_results/v1.16.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:34.695Z"
+    "generatedAt": "2025-11-27T17:06:41.186Z"
   },
-  "timestamp": "2025-11-27T16:03:34.696Z",
+  "timestamp": "2025-11-27T17:06:41.186Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2045,
+          "transferSize": 2048,
           "resourceSize": 4881
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692776,
+          "transferSize": 692785,
           "resourceSize": 1372739
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2019,
+          "transferSize": 2023,
           "resourceSize": 4910
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692747,
+          "transferSize": 692755,
           "resourceSize": 1372768
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5021,
+          "transferSize": 5025,
           "resourceSize": 17191
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4960,
+          "transferSize": 4984,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 481137,
+          "transferSize": 481165,
           "resourceSize": 1177531
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1891,
+          "transferSize": 1895,
           "resourceSize": 4368
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692619,
+          "transferSize": 692629,
           "resourceSize": 1372226
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2022,
+          "transferSize": 2025,
           "resourceSize": 4720
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692750,
+          "transferSize": 692757,
           "resourceSize": 1372578
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1903,
+          "transferSize": 1907,
           "resourceSize": 4350
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692631,
+          "transferSize": 692636,
           "resourceSize": 1372208
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2094,
+          "transferSize": 2097,
           "resourceSize": 4830
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692821,
+          "transferSize": 692833,
           "resourceSize": 1372688
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2745,
+          "transferSize": 2749,
           "resourceSize": 7146
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 693473,
+          "transferSize": 693480,
           "resourceSize": 1599011
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2787,
+          "transferSize": 2792,
           "resourceSize": 6252
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 699664,
+          "transferSize": 699673,
           "resourceSize": 1385109
         }
       },

--- a/.github/page_size_audit_results/v1.17.0.json
+++ b/.github/page_size_audit_results/v1.17.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.17.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:38.145Z"
+    "generatedAt": "2025-11-27T17:06:30.693Z"
   },
-  "timestamp": "2025-11-27T16:03:38.146Z",
+  "timestamp": "2025-11-27T17:06:30.693Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2139,
+          "transferSize": 2136,
           "resourceSize": 5357
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692405,
+          "transferSize": 692400,
           "resourceSize": 1373068
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2112,
+          "transferSize": 2109,
           "resourceSize": 5386
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692376,
+          "transferSize": 692382,
           "resourceSize": 1373097
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5157,
+          "transferSize": 5154,
           "resourceSize": 17739
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4989,
+          "transferSize": 4978,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 481267,
+          "transferSize": 481253,
           "resourceSize": 1177932
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692246,
+          "transferSize": 692251,
           "resourceSize": 1372555
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2118,
+          "transferSize": 2114,
           "resourceSize": 5196
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692385,
+          "transferSize": 692388,
           "resourceSize": 1372907
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692266,
+          "transferSize": 692271,
           "resourceSize": 1372537
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2190,
+          "transferSize": 2186,
           "resourceSize": 5306
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692455,
+          "transferSize": 692457,
           "resourceSize": 1373017
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693101,
+          "transferSize": 693098,
           "resourceSize": 1375333
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 699292,
+          "transferSize": 699295,
           "resourceSize": 1385437
         }
       },

--- a/.github/page_size_audit_results/v1.18.0.json
+++ b/.github/page_size_audit_results/v1.18.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.18.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:00.543Z"
+    "generatedAt": "2025-11-27T17:06:21.253Z"
   },
-  "timestamp": "2025-11-27T16:01:00.544Z",
+  "timestamp": "2025-11-27T17:06:21.253Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2103,
+          "transferSize": 2099,
           "resourceSize": 5065
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692574,
+          "transferSize": 692569,
           "resourceSize": 1376425
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2077,
+          "transferSize": 2074,
           "resourceSize": 5094
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692546,
+          "transferSize": 692543,
           "resourceSize": 1376454
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5119,
+          "transferSize": 5117,
           "resourceSize": 17447
         },
         "font": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 481402,
+          "transferSize": 481400,
           "resourceSize": 1181289
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1948,
+          "transferSize": 1946,
           "resourceSize": 4552
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692413,
+          "transferSize": 692409,
           "resourceSize": 1375912
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2082,
+          "transferSize": 2077,
           "resourceSize": 4904
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692546,
+          "transferSize": 692545,
           "resourceSize": 1376264
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1960,
+          "transferSize": 1956,
           "resourceSize": 4534
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692424,
+          "transferSize": 692429,
           "resourceSize": 1375894
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2154,
+          "transferSize": 2151,
           "resourceSize": 5014
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692614,
+          "transferSize": 692617,
           "resourceSize": 1376374
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2795,
+          "transferSize": 2791,
           "resourceSize": 7330
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693264,
+          "transferSize": 693256,
           "resourceSize": 1378690
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2837,
+          "transferSize": 2833,
           "resourceSize": 6436
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 699451,
+          "transferSize": 699450,
           "resourceSize": 1388794
         }
       },

--- a/.github/page_size_audit_results/v1.19.0.json
+++ b/.github/page_size_audit_results/v1.19.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.19.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:06.504Z"
+    "generatedAt": "2025-11-27T17:06:38.482Z"
   },
-  "timestamp": "2025-11-27T16:01:06.504Z",
+  "timestamp": "2025-11-27T17:06:38.482Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2098,
+          "transferSize": 2103,
           "resourceSize": 5065
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692563,
+          "transferSize": 692571,
           "resourceSize": 1376425
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2073,
+          "transferSize": 2077,
           "resourceSize": 5094
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692545,
+          "transferSize": 692547,
           "resourceSize": 1376454
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5370,
+          "transferSize": 5376,
           "resourceSize": 20552
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7783,
+          "transferSize": 7800,
           "resourceSize": 8841
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 484471,
+          "transferSize": 484494,
           "resourceSize": 1187550
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1947,
+          "transferSize": 1948,
           "resourceSize": 4552
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692414,
+          "transferSize": 692415,
           "resourceSize": 1375912
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2078,
+          "transferSize": 2082,
           "resourceSize": 4904
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692542,
+          "transferSize": 692546,
           "resourceSize": 1376264
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1957,
+          "transferSize": 1960,
           "resourceSize": 4534
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692422,
+          "transferSize": 692423,
           "resourceSize": 1375894
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2150,
+          "transferSize": 2155,
           "resourceSize": 5014
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692616,
+          "transferSize": 692622,
           "resourceSize": 1376374
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2792,
+          "transferSize": 2795,
           "resourceSize": 7330
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693263,
+          "transferSize": 693262,
           "resourceSize": 1378690
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2834,
+          "transferSize": 2837,
           "resourceSize": 6436
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1129,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 699456,
+          "transferSize": 699454,
           "resourceSize": 1388794
         }
       },

--- a/.github/page_size_audit_results/v1.2.0.json
+++ b/.github/page_size_audit_results/v1.2.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.2.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:00:53.599Z"
+    "generatedAt": "2025-11-27T17:04:00.287Z"
   },
-  "timestamp": "2025-11-27T16:00:53.599Z",
+  "timestamp": "2025-11-27T17:04:00.287Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2577,
+          "transferSize": 2574,
           "resourceSize": 5364
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690113,
+          "transferSize": 690109,
           "resourceSize": 1364173
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2449,
+          "transferSize": 2447,
           "resourceSize": 5080
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689989,
+          "transferSize": 689983,
           "resourceSize": 1363889
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5207,
+          "transferSize": 5205,
           "resourceSize": 16686
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4967,
+          "transferSize": 4964,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 478837,
+          "transferSize": 478832,
           "resourceSize": 1169375
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2271,
+          "transferSize": 2269,
           "resourceSize": 4464
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689812,
+          "transferSize": 689809,
           "resourceSize": 1363273
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2436,
+          "transferSize": 2433,
           "resourceSize": 4890
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689973,
+          "transferSize": 689970,
           "resourceSize": 1363699
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2293,
+          "transferSize": 2290,
           "resourceSize": 4481
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2497,
+          "transferSize": 2493,
           "resourceSize": 5000
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690034,
+          "transferSize": 690029,
           "resourceSize": 1363809
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3079,
+          "transferSize": 3076,
           "resourceSize": 7123
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690621,
+          "transferSize": 690611,
           "resourceSize": 1365932
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3118,
+          "transferSize": 3115,
           "resourceSize": 6326
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.2.1.json
+++ b/.github/page_size_audit_results/v1.2.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.2.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:00:59.158Z"
+    "generatedAt": "2025-11-27T17:03:53.781Z"
   },
-  "timestamp": "2025-11-27T16:00:59.158Z",
+  "timestamp": "2025-11-27T17:03:53.782Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2579,
+          "transferSize": 2578,
           "resourceSize": 5372
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689894,
+          "transferSize": 689887,
           "resourceSize": 1363464
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2453,
+          "transferSize": 2449,
           "resourceSize": 5088
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689767,
+          "transferSize": 689761,
           "resourceSize": 1363180
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5208,
+          "transferSize": 5205,
           "resourceSize": 16694
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4995,
+          "transferSize": 4968,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 478642,
+          "transferSize": 478612,
           "resourceSize": 1168666
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689585,
+          "transferSize": 689582,
           "resourceSize": 1362564
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2437,
+          "transferSize": 2436,
           "resourceSize": 4898
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689748,
+          "transferSize": 689746,
           "resourceSize": 1362990
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2498,
+          "transferSize": 2497,
           "resourceSize": 5008
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689811,
+          "transferSize": 689808,
           "resourceSize": 1363100
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690394,
+          "transferSize": 690400,
           "resourceSize": 1365217
         }
       },

--- a/.github/page_size_audit_results/v1.20.0.json
+++ b/.github/page_size_audit_results/v1.20.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.20.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:00:58.161Z"
+    "generatedAt": "2025-11-27T17:03:49.155Z"
   },
-  "timestamp": "2025-11-27T16:00:58.162Z",
+  "timestamp": "2025-11-27T17:03:49.155Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2104,
+          "transferSize": 2101,
           "resourceSize": 5065
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692601,
+          "transferSize": 692600,
           "resourceSize": 1376991
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2078,
+          "transferSize": 2076,
           "resourceSize": 5094
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692582,
+          "transferSize": 692573,
           "resourceSize": 1377020
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5377,
+          "transferSize": 5376,
           "resourceSize": 20552
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7781,
+          "transferSize": 7782,
           "resourceSize": 8841
         },
         "other": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692444,
+          "transferSize": 692448,
           "resourceSize": 1376478
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2083,
+          "transferSize": 2081,
           "resourceSize": 4904
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692583,
+          "transferSize": 692588,
           "resourceSize": 1376830
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692456,
+          "transferSize": 692457,
           "resourceSize": 1376460
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2155,
+          "transferSize": 2153,
           "resourceSize": 5014
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692650,
+          "transferSize": 692653,
           "resourceSize": 1376940
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693294,
+          "transferSize": 693289,
           "resourceSize": 1379256
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1128,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 699488,
+          "transferSize": 699491,
           "resourceSize": 1389360
         }
       },

--- a/.github/page_size_audit_results/v1.21.0.json
+++ b/.github/page_size_audit_results/v1.21.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.21.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:10.148Z"
+    "generatedAt": "2025-11-27T17:03:59.705Z"
   },
-  "timestamp": "2025-11-27T16:01:10.149Z",
+  "timestamp": "2025-11-27T17:03:59.705Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2161,
+          "transferSize": 2164,
           "resourceSize": 5389
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692804,
+          "transferSize": 692812,
           "resourceSize": 1378273
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2134,
+          "transferSize": 2137,
           "resourceSize": 5418
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5731,
+          "transferSize": 5735,
           "resourceSize": 23857
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9072,
+          "transferSize": 9073,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 486301,
+          "transferSize": 486306,
           "resourceSize": 1195467
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2006,
+          "transferSize": 2009,
           "resourceSize": 4876
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692658,
+          "transferSize": 692654,
           "resourceSize": 1377760
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2136,
+          "transferSize": 2140,
           "resourceSize": 5228
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692776,
+          "transferSize": 692784,
           "resourceSize": 1378112
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2018,
+          "transferSize": 2022,
           "resourceSize": 4858
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692658,
+          "transferSize": 692672,
           "resourceSize": 1377742
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2210,
+          "transferSize": 2213,
           "resourceSize": 5338
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692852,
+          "transferSize": 692857,
           "resourceSize": 1378222
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3045,
+          "transferSize": 3048,
           "resourceSize": 8814
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1318,
+          "transferSize": 1319,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 694239,
+          "transferSize": 694243,
           "resourceSize": 1382107
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2896,
+          "transferSize": 2899,
           "resourceSize": 6760
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 699692,
+          "transferSize": 699694,
           "resourceSize": 1390642
         }
       },

--- a/.github/page_size_audit_results/v1.22.0.json
+++ b/.github/page_size_audit_results/v1.22.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.22.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:26.889Z"
+    "generatedAt": "2025-11-27T17:03:52.860Z"
   },
-  "timestamp": "2025-11-27T16:01:26.890Z",
+  "timestamp": "2025-11-27T17:03:52.860Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2128,
+          "transferSize": 2127,
           "resourceSize": 5360
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2100,
+          "transferSize": 2099,
           "resourceSize": 5382
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692884,
+          "transferSize": 692887,
           "resourceSize": 1378881
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9073,
+          "transferSize": 9111,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 486408,
+          "transferSize": 486446,
           "resourceSize": 1196061
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692759,
+          "transferSize": 692760,
           "resourceSize": 1378339
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2104,
+          "transferSize": 2102,
           "resourceSize": 5192
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692894,
+          "transferSize": 692889,
           "resourceSize": 1378691
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692768,
+          "transferSize": 692774,
           "resourceSize": 1378321
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2177,
+          "transferSize": 2176,
           "resourceSize": 5302
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692956,
+          "transferSize": 692965,
           "resourceSize": 1378801
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1315,
+          "transferSize": 1319,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 694350,
+          "transferSize": 694354,
           "resourceSize": 1382738
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1129,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 699795,
+          "transferSize": 699805,
           "resourceSize": 1391221
         }
       },

--- a/.github/page_size_audit_results/v1.23.0.json
+++ b/.github/page_size_audit_results/v1.23.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.23.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:35.278Z"
+    "generatedAt": "2025-11-27T17:03:54.517Z"
   },
-  "timestamp": "2025-11-27T16:03:35.278Z",
+  "timestamp": "2025-11-27T17:03:54.517Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2126,
+          "transferSize": 2124,
           "resourceSize": 5373
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692943,
+          "transferSize": 692942,
           "resourceSize": 1378956
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2101,
+          "transferSize": 2098,
           "resourceSize": 5382
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692923,
+          "transferSize": 692916,
           "resourceSize": 1378965
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5699,
+          "transferSize": 5695,
           "resourceSize": 23836
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9056,
+          "transferSize": 9079,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 486425,
+          "transferSize": 486444,
           "resourceSize": 1196145
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1974,
+          "transferSize": 1971,
           "resourceSize": 4840
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692791,
+          "transferSize": 692788,
           "resourceSize": 1378423
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2104,
+          "transferSize": 2101,
           "resourceSize": 5192
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692918,
+          "transferSize": 692925,
           "resourceSize": 1378775
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1987,
+          "transferSize": 1984,
           "resourceSize": 4822
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692805,
+          "transferSize": 692800,
           "resourceSize": 1378405
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2177,
+          "transferSize": 2175,
           "resourceSize": 5302
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692994,
+          "transferSize": 692992,
           "resourceSize": 1378885
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3025,
+          "transferSize": 3022,
           "resourceSize": 8901
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1315,
+          "transferSize": 1324,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 694388,
+          "transferSize": 694394,
           "resourceSize": 1382893
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2864,
+          "transferSize": 2860,
           "resourceSize": 6724
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1129,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 699838,
+          "transferSize": 699828,
           "resourceSize": 1391305
         }
       },

--- a/.github/page_size_audit_results/v1.24.0.json
+++ b/.github/page_size_audit_results/v1.24.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.24.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:00:53.929Z"
+    "generatedAt": "2025-11-27T17:09:07.304Z"
   },
-  "timestamp": "2025-11-27T16:00:53.929Z",
+  "timestamp": "2025-11-27T17:09:07.304Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2127,
+          "transferSize": 2125,
           "resourceSize": 5373
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692938,
+          "transferSize": 692950,
           "resourceSize": 1378956
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2101,
+          "transferSize": 2100,
           "resourceSize": 5382
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692916,
+          "transferSize": 692917,
           "resourceSize": 1378965
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9033,
+          "transferSize": 9115,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 486400,
+          "transferSize": 486482,
           "resourceSize": 1196145
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692788,
+          "transferSize": 692793,
           "resourceSize": 1378423
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2107,
+          "transferSize": 2105,
           "resourceSize": 5233
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692804,
+          "transferSize": 692809,
           "resourceSize": 1378405
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2180,
+          "transferSize": 2178,
           "resourceSize": 5343
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 781,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693000,
+          "transferSize": 693007,
           "resourceSize": 1378926
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1317,
+          "transferSize": 1322,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 694391,
+          "transferSize": 694396,
           "resourceSize": 1382893
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1129,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 699828,
+          "transferSize": 699837,
           "resourceSize": 1391305
         }
       },

--- a/.github/page_size_audit_results/v1.25.0.json
+++ b/.github/page_size_audit_results/v1.25.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.25.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:38.689Z"
+    "generatedAt": "2025-11-27T17:06:46.110Z"
   },
-  "timestamp": "2025-11-27T16:03:38.690Z",
+  "timestamp": "2025-11-27T17:06:46.110Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2123,
+          "transferSize": 2125,
           "resourceSize": 5373
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693087,
+          "transferSize": 693096,
           "resourceSize": 1379319
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2100,
+          "transferSize": 2103,
           "resourceSize": 5401
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693065,
+          "transferSize": 693067,
           "resourceSize": 1379347
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5694,
+          "transferSize": 5697,
           "resourceSize": 23836
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9053,
+          "transferSize": 9104,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 486564,
+          "transferSize": 486618,
           "resourceSize": 1196508
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1970,
+          "transferSize": 1973,
           "resourceSize": 4840
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692937,
+          "transferSize": 692940,
           "resourceSize": 1378786
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2102,
+          "transferSize": 2106,
           "resourceSize": 5233
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693063,
+          "transferSize": 693068,
           "resourceSize": 1379179
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1983,
+          "transferSize": 1987,
           "resourceSize": 4822
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692946,
+          "transferSize": 692951,
           "resourceSize": 1378768
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2176,
+          "transferSize": 2179,
           "resourceSize": 5343
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693141,
+          "transferSize": 693150,
           "resourceSize": 1379289
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3022,
+          "transferSize": 3024,
           "resourceSize": 8901
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1322,
+          "transferSize": 1328,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 694539,
+          "transferSize": 694547,
           "resourceSize": 1383256
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2859,
+          "transferSize": 2863,
           "resourceSize": 6724
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 699973,
+          "transferSize": 699981,
           "resourceSize": 1391668
         }
       },

--- a/.github/page_size_audit_results/v1.26.0.json
+++ b/.github/page_size_audit_results/v1.26.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.26.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:02.895Z"
+    "generatedAt": "2025-11-27T17:03:54.787Z"
   },
-  "timestamp": "2025-11-27T16:01:02.895Z",
+  "timestamp": "2025-11-27T17:03:54.787Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2124,
+          "transferSize": 2123,
           "resourceSize": 5373
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693085,
+          "transferSize": 693090,
           "resourceSize": 1379319
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693066,
+          "transferSize": 693068,
           "resourceSize": 1379347
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5696,
+          "transferSize": 5695,
           "resourceSize": 23836
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9088,
+          "transferSize": 9101,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 486601,
+          "transferSize": 486613,
           "resourceSize": 1196508
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692935,
+          "transferSize": 692939,
           "resourceSize": 1378786
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2104,
+          "transferSize": 2102,
           "resourceSize": 5233
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693075,
+          "transferSize": 693067,
           "resourceSize": 1379179
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692946,
+          "transferSize": 692949,
           "resourceSize": 1378768
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2177,
+          "transferSize": 2176,
           "resourceSize": 5343
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693141,
+          "transferSize": 693143,
           "resourceSize": 1379289
         }
       },

--- a/.github/page_size_audit_results/v1.27.0.json
+++ b/.github/page_size_audit_results/v1.27.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.27.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:10.451Z"
+    "generatedAt": "2025-11-27T17:03:49.995Z"
   },
-  "timestamp": "2025-11-27T16:01:10.451Z",
+  "timestamp": "2025-11-27T17:03:49.996Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2137,
+          "transferSize": 2138,
           "resourceSize": 5533
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693628,
+          "transferSize": 693632,
           "resourceSize": 1379054
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693605,
+          "transferSize": 693612,
           "resourceSize": 1379082
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5706,
+          "transferSize": 5707,
           "resourceSize": 23996
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9094,
+          "transferSize": 9108,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 487142,
+          "transferSize": 487157,
           "resourceSize": 1196243
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693475,
+          "transferSize": 693467,
           "resourceSize": 1378521
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693606,
+          "transferSize": 693605,
           "resourceSize": 1378914
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693483,
+          "transferSize": 693485,
           "resourceSize": 1378503
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693680,
+          "transferSize": 693679,
           "resourceSize": 1379024
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1312,
+          "transferSize": 1320,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 695063,
+          "transferSize": 695071,
           "resourceSize": 1383004
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1129,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 700509,
+          "transferSize": 700514,
           "resourceSize": 1391403
         }
       },

--- a/.github/page_size_audit_results/v1.28.0.json
+++ b/.github/page_size_audit_results/v1.28.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.28.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:04:12.530Z"
+    "generatedAt": "2025-11-27T17:08:56.733Z"
   },
-  "timestamp": "2025-11-27T16:04:12.530Z",
+  "timestamp": "2025-11-27T17:08:56.733Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2135,
-          "resourceSize": 5540
+          "transferSize": 2226,
+          "resourceSize": 5821
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 292591,
+          "resourceSize": 909862
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 318745,
+          "resourceSize": 717271
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690475,
-          "resourceSize": 1348499
+          "transferSize": 839122,
+          "resourceSize": 1857371
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2111,
-          "resourceSize": 5561
+          "transferSize": 2201,
+          "resourceSize": 5842
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 292591,
+          "resourceSize": 909862
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 318745,
+          "resourceSize": 717271
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690448,
-          "resourceSize": 1348520
+          "transferSize": 839095,
+          "resourceSize": 1857392
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5703,
-          "resourceSize": 23998
+          "transferSize": 5921,
+          "resourceSize": 24728
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 151283,
-          "resourceSize": 413555
+          "transferSize": 694304,
+          "resourceSize": 2066889
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 318745,
+          "resourceSize": 717271
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9053,
-          "resourceSize": 11929
+          "transferSize": 11915,
+          "resourceSize": 13177
         },
         "other": {
           "transferSize": 618,
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 483950,
-          "resourceSize": 1165683
+          "transferSize": 1031503,
+          "resourceSize": 2822281
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1980,
-          "resourceSize": 5000
+          "transferSize": 2072,
+          "resourceSize": 5281
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 292591,
+          "resourceSize": 909862
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 318745,
+          "resourceSize": 717271
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690323,
-          "resourceSize": 1347959
+          "transferSize": 838970,
+          "resourceSize": 1856831
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2112,
-          "resourceSize": 5393
+          "transferSize": 2204,
+          "resourceSize": 5674
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 292591,
+          "resourceSize": 909862
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 318745,
+          "resourceSize": 717271
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 762,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690446,
-          "resourceSize": 1348352
+          "transferSize": 839107,
+          "resourceSize": 1857224
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1991,
-          "resourceSize": 4982
+          "transferSize": 2085,
+          "resourceSize": 5263
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 292591,
+          "resourceSize": 909862
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 318745,
+          "resourceSize": 717271
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690330,
-          "resourceSize": 1347941
+          "transferSize": 838983,
+          "resourceSize": 1856813
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2185,
-          "resourceSize": 5503
+          "transferSize": 2279,
+          "resourceSize": 5784
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 292591,
+          "resourceSize": 909862
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 318745,
+          "resourceSize": 717271
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 618,
-          "resourceSize": 216
+          "transferSize": 619,
+          "resourceSize": 217
         },
         "total": {
-          "transferSize": 690522,
-          "resourceSize": 1348462
+          "transferSize": 839179,
+          "resourceSize": 1857335
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3030,
-          "resourceSize": 9074
+          "transferSize": 3124,
+          "resourceSize": 9355
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 292591,
+          "resourceSize": 909862
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 318745,
+          "resourceSize": 717271
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1314,
+          "transferSize": 1318,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 618,
-          "resourceSize": 216
+          "transferSize": 619,
+          "resourceSize": 217
         },
         "total": {
-          "transferSize": 691916,
-          "resourceSize": 1352442
+          "transferSize": 840572,
+          "resourceSize": 1861315
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2867,
-          "resourceSize": 6886
+          "transferSize": 3082,
+          "resourceSize": 7670
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 151283,
-          "resourceSize": 413555
+          "transferSize": 694304,
+          "resourceSize": 2066889
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 318745,
+          "resourceSize": 717271
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
-          "resourceSize": 195
+          "transferSize": 3948,
+          "resourceSize": 1443
         },
         "other": {
-          "transferSize": 618,
-          "resourceSize": 216
+          "transferSize": 619,
+          "resourceSize": 217
         },
         "total": {
-          "transferSize": 697356,
-          "resourceSize": 1360843
+          "transferSize": 1244873,
+          "resourceSize": 3017496
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.29.0.json
+++ b/.github/page_size_audit_results/v1.29.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.29.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:07.684Z"
+    "generatedAt": "2025-11-27T17:03:47.466Z"
   },
-  "timestamp": "2025-11-27T16:01:07.685Z",
+  "timestamp": "2025-11-27T17:03:47.467Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2134,
+          "transferSize": 2135,
           "resourceSize": 5545
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690478,
+          "transferSize": 690481,
           "resourceSize": 1348504
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2110,
+          "transferSize": 2111,
           "resourceSize": 5566
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690454,
+          "transferSize": 690453,
           "resourceSize": 1348525
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9086,
+          "transferSize": 9428,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 483985,
+          "transferSize": 484327,
           "resourceSize": 1165688
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690327,
+          "transferSize": 690322,
           "resourceSize": 1347964
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690453,
+          "transferSize": 690456,
           "resourceSize": 1348357
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690331,
+          "transferSize": 690341,
           "resourceSize": 1347946
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690529,
+          "transferSize": 690528,
           "resourceSize": 1348467
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697362,
+          "transferSize": 697361,
           "resourceSize": 1360848
         }
       },

--- a/.github/page_size_audit_results/v1.29.1.json
+++ b/.github/page_size_audit_results/v1.29.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.29.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:42.824Z"
+    "generatedAt": "2025-11-27T17:06:34.114Z"
   },
-  "timestamp": "2025-11-27T16:03:42.825Z",
+  "timestamp": "2025-11-27T17:06:34.115Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2135,
+          "transferSize": 2132,
           "resourceSize": 5545
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690477,
+          "transferSize": 690473,
           "resourceSize": 1348522
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2111,
+          "transferSize": 2108,
           "resourceSize": 5566
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690457,
+          "transferSize": 690451,
           "resourceSize": 1348543
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5706,
+          "transferSize": 5702,
           "resourceSize": 24003
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9045,
+          "transferSize": 9049,
           "resourceSize": 11929
         },
         "other": {
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1981,
+          "transferSize": 1976,
           "resourceSize": 5005
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2112,
+          "transferSize": 2109,
           "resourceSize": 5398
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690460,
+          "transferSize": 690454,
           "resourceSize": 1348375
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1992,
+          "transferSize": 1989,
           "resourceSize": 4987
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690338,
+          "transferSize": 690334,
           "resourceSize": 1347964
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2185,
+          "transferSize": 2182,
           "resourceSize": 5508
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690529,
+          "transferSize": 690528,
           "resourceSize": 1348485
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3030,
+          "transferSize": 3026,
           "resourceSize": 9079
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1313,
+          "transferSize": 1309,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691920,
+          "transferSize": 691912,
           "resourceSize": 1352465
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2866,
+          "transferSize": 2863,
           "resourceSize": 6891
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697363,
+          "transferSize": 697360,
           "resourceSize": 1360866
         }
       },

--- a/.github/page_size_audit_results/v1.3.0.json
+++ b/.github/page_size_audit_results/v1.3.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.3.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:34.316Z"
+    "generatedAt": "2025-11-27T17:03:56.087Z"
   },
-  "timestamp": "2025-11-27T16:03:34.317Z",
+  "timestamp": "2025-11-27T17:03:56.087Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2582,
+          "transferSize": 2578,
           "resourceSize": 5372
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690515,
+          "transferSize": 690509,
           "resourceSize": 1366978
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2450,
+          "transferSize": 2447,
           "resourceSize": 5088
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690383,
+          "transferSize": 690382,
           "resourceSize": 1366694
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5213,
+          "transferSize": 5210,
           "resourceSize": 16726
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4978,
+          "transferSize": 4983,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479251,
+          "transferSize": 479253,
           "resourceSize": 1172212
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2275,
+          "transferSize": 2273,
           "resourceSize": 4472
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690206,
+          "transferSize": 690207,
           "resourceSize": 1366078
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2440,
+          "transferSize": 2437,
           "resourceSize": 4898
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690376,
+          "transferSize": 690369,
           "resourceSize": 1366504
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2299,
+          "transferSize": 2296,
           "resourceSize": 4489
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690233,
+          "transferSize": 690239,
           "resourceSize": 1366095
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2501,
+          "transferSize": 2498,
           "resourceSize": 5008
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690436,
+          "transferSize": 690432,
           "resourceSize": 1366614
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3088,
+          "transferSize": 3084,
           "resourceSize": 7125
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691029,
+          "transferSize": 691024,
           "resourceSize": 1368731
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3147,
+          "transferSize": 3143,
           "resourceSize": 6404
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697502,
+          "transferSize": 697504,
           "resourceSize": 1380406
         }
       },

--- a/.github/page_size_audit_results/v1.30.0.json
+++ b/.github/page_size_audit_results/v1.30.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.30.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:06.864Z"
+    "generatedAt": "2025-11-27T17:09:01.933Z"
   },
-  "timestamp": "2025-11-27T16:01:06.864Z",
+  "timestamp": "2025-11-27T17:09:01.933Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690495,
+          "transferSize": 690487,
           "resourceSize": 1348552
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2109,
+          "transferSize": 2110,
           "resourceSize": 5645
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690470,
+          "transferSize": 690467,
           "resourceSize": 1348573
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5705,
+          "transferSize": 5704,
           "resourceSize": 24098
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9057,
+          "transferSize": 9060,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 483970,
+          "transferSize": 483972,
           "resourceSize": 1165752
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690337,
+          "transferSize": 690333,
           "resourceSize": 1348012
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2112,
+          "transferSize": 2113,
           "resourceSize": 5477
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690471,
+          "transferSize": 690468,
           "resourceSize": 1348405
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690349,
+          "transferSize": 690345,
           "resourceSize": 1347994
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2186,
+          "transferSize": 2188,
           "resourceSize": 5587
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690537,
+          "transferSize": 690546,
           "resourceSize": 1348515
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1324,
+          "transferSize": 1319,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691939,
+          "transferSize": 691934,
           "resourceSize": 1352495
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697378,
+          "transferSize": 697374,
           "resourceSize": 1360918
         }
       },

--- a/.github/page_size_audit_results/v1.31.0.json
+++ b/.github/page_size_audit_results/v1.31.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.31.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:14.409Z"
+    "generatedAt": "2025-11-27T17:09:04.100Z"
   },
-  "timestamp": "2025-11-27T16:01:14.409Z",
+  "timestamp": "2025-11-27T17:09:04.101Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2137,
+          "transferSize": 2135,
           "resourceSize": 5628
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690491,
+          "transferSize": 690492,
           "resourceSize": 1348556
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2111,
+          "transferSize": 2110,
           "resourceSize": 5649
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690468,
+          "transferSize": 690467,
           "resourceSize": 1348577
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5707,
+          "transferSize": 5706,
           "resourceSize": 24106
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9095,
+          "transferSize": 9050,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 484010,
+          "transferSize": 483964,
           "resourceSize": 1165760
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690329,
+          "transferSize": 690334,
           "resourceSize": 1348016
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2112,
+          "transferSize": 2111,
           "resourceSize": 5481
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690470,
+          "transferSize": 690466,
           "resourceSize": 1348409
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690349,
+          "transferSize": 690346,
           "resourceSize": 1347998
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2187,
+          "transferSize": 2184,
           "resourceSize": 5591
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690540,
+          "transferSize": 690538,
           "resourceSize": 1348519
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1312,
+          "transferSize": 1317,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691928,
+          "transferSize": 691933,
           "resourceSize": 1352499
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697383,
+          "transferSize": 697379,
           "resourceSize": 1360922
         }
       },

--- a/.github/page_size_audit_results/v1.32.0.json
+++ b/.github/page_size_audit_results/v1.32.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.32.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:16.221Z"
+    "generatedAt": "2025-11-27T17:06:32.945Z"
   },
-  "timestamp": "2025-11-27T16:01:16.221Z",
+  "timestamp": "2025-11-27T17:06:32.945Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2136,
+          "transferSize": 2133,
           "resourceSize": 5628
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690520,
+          "transferSize": 690512,
           "resourceSize": 1348669
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2110,
+          "transferSize": 2107,
           "resourceSize": 5649
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690494,
+          "transferSize": 690483,
           "resourceSize": 1348690
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5723,
+          "transferSize": 5721,
           "resourceSize": 24180
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9417,
+          "transferSize": 9056,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 484371,
+          "transferSize": 484008,
           "resourceSize": 1165947
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1975,
+          "transferSize": 1972,
           "resourceSize": 5088
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690361,
+          "transferSize": 690348,
           "resourceSize": 1348129
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2112,
+          "transferSize": 2108,
           "resourceSize": 5481
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690492,
+          "transferSize": 690488,
           "resourceSize": 1348522
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1988,
+          "transferSize": 1986,
           "resourceSize": 5070
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690367,
+          "transferSize": 690369,
           "resourceSize": 1348111
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2185,
+          "transferSize": 2181,
           "resourceSize": 5591
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690561,
+          "transferSize": 690559,
           "resourceSize": 1348632
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3028,
+          "transferSize": 3025,
           "resourceSize": 9162
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1314,
+          "transferSize": 1315,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691951,
+          "transferSize": 691949,
           "resourceSize": 1352612
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2874,
+          "transferSize": 2870,
           "resourceSize": 6996
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1118,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697406,
+          "transferSize": 697394,
           "resourceSize": 1361035
         }
       },

--- a/.github/page_size_audit_results/v1.32.1.json
+++ b/.github/page_size_audit_results/v1.32.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.32.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:00:54.802Z"
+    "generatedAt": "2025-11-27T17:03:59.128Z"
   },
-  "timestamp": "2025-11-27T16:00:54.803Z",
+  "timestamp": "2025-11-27T17:03:59.128Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2134,
+          "transferSize": 2135,
           "resourceSize": 5628
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690526,
+          "transferSize": 690525,
           "resourceSize": 1348827
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9032,
+          "transferSize": 9077,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 484016,
+          "transferSize": 484061,
           "resourceSize": 1166130
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690387,
+          "transferSize": 690390,
           "resourceSize": 1348266
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690523,
+          "transferSize": 690530,
           "resourceSize": 1348659
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690402,
+          "transferSize": 690400,
           "resourceSize": 1348248
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690595,
+          "transferSize": 690599,
           "resourceSize": 1348769
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1314,
+          "transferSize": 1319,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691988,
+          "transferSize": 691993,
           "resourceSize": 1352749
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1118,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697431,
+          "transferSize": 697440,
           "resourceSize": 1361172
         }
       },

--- a/.github/page_size_audit_results/v1.33.0.json
+++ b/.github/page_size_audit_results/v1.33.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.33.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:21.402Z"
+    "generatedAt": "2025-11-27T17:03:50.270Z"
   },
-  "timestamp": "2025-11-27T16:06:21.402Z",
+  "timestamp": "2025-11-27T17:03:50.271Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2133,
+          "transferSize": 2134,
           "resourceSize": 5628
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690523,
+          "transferSize": 690526,
           "resourceSize": 1348827
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9074,
+          "transferSize": 9049,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 484064,
+          "transferSize": 484039,
           "resourceSize": 1166135
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690393,
+          "transferSize": 690390,
           "resourceSize": 1348266
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690528,
+          "transferSize": 690520,
           "resourceSize": 1348659
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690403,
+          "transferSize": 690400,
           "resourceSize": 1348248
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2182,
+          "transferSize": 2185,
           "resourceSize": 5591
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690597,
+          "transferSize": 690605,
           "resourceSize": 1348769
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1321,
+          "transferSize": 1322,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691995,
+          "transferSize": 691996,
           "resourceSize": 1352749
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697436,
+          "transferSize": 697438,
           "resourceSize": 1361172
         }
       },

--- a/.github/page_size_audit_results/v1.34.0.json
+++ b/.github/page_size_audit_results/v1.34.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.34.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:34.907Z"
+    "generatedAt": "2025-11-27T17:03:56.865Z"
   },
-  "timestamp": "2025-11-27T16:03:34.907Z",
+  "timestamp": "2025-11-27T17:03:56.866Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2132,
+          "transferSize": 2136,
           "resourceSize": 5628
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690548,
+          "transferSize": 690552,
           "resourceSize": 1348806
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2106,
+          "transferSize": 2109,
           "resourceSize": 5649
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690517,
+          "transferSize": 690528,
           "resourceSize": 1348827
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5434,
+          "transferSize": 5435,
           "resourceSize": 23810
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9075,
+          "transferSize": 9072,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 483777,
+          "transferSize": 483775,
           "resourceSize": 1165714
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690393,
+          "transferSize": 690392,
           "resourceSize": 1348266
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2109,
+          "transferSize": 2111,
           "resourceSize": 5481
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690523,
+          "transferSize": 690527,
           "resourceSize": 1348659
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690399,
+          "transferSize": 690400,
           "resourceSize": 1348248
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2181,
+          "transferSize": 2186,
           "resourceSize": 5591
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690593,
+          "transferSize": 690603,
           "resourceSize": 1348769
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697425,
+          "transferSize": 697422,
           "resourceSize": 1361170
         }
       },

--- a/.github/page_size_audit_results/v1.34.1.json
+++ b/.github/page_size_audit_results/v1.34.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.34.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:01.768Z"
+    "generatedAt": "2025-11-27T17:07:06.075Z"
   },
-  "timestamp": "2025-11-27T16:01:01.769Z",
+  "timestamp": "2025-11-27T17:07:06.076Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2149,
+          "transferSize": 2147,
           "resourceSize": 5682
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690693,
+          "transferSize": 690691,
           "resourceSize": 1350592
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690654,
+          "transferSize": 690660,
           "resourceSize": 1350613
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9121,
+          "transferSize": 9098,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 483950,
+          "transferSize": 483927,
           "resourceSize": 1167500
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690528,
+          "transferSize": 690527,
           "resourceSize": 1350052
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2123,
+          "transferSize": 2121,
           "resourceSize": 5535
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690657,
+          "transferSize": 690661,
           "resourceSize": 1350445
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690542,
+          "transferSize": 690538,
           "resourceSize": 1350034
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2197,
+          "transferSize": 2196,
           "resourceSize": 5645
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690736,
+          "transferSize": 690734,
           "resourceSize": 1350555
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1317,
+          "transferSize": 1334,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692144,
+          "transferSize": 692161,
           "resourceSize": 1354527
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697564,
+          "transferSize": 697566,
           "resourceSize": 1362956
         }
       },

--- a/.github/page_size_audit_results/v1.35.0.json
+++ b/.github/page_size_audit_results/v1.35.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.35.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:04.137Z"
+    "generatedAt": "2025-11-27T17:06:29.269Z"
   },
-  "timestamp": "2025-11-27T16:01:04.138Z",
+  "timestamp": "2025-11-27T17:06:29.270Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2149,
+          "transferSize": 2150,
           "resourceSize": 5695
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689657,
+          "transferSize": 689662,
           "resourceSize": 1345526
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689629,
+          "transferSize": 689632,
           "resourceSize": 1345543
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5229,
+          "transferSize": 5230,
           "resourceSize": 23724
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9051,
+          "transferSize": 9073,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 478857,
+          "transferSize": 478880,
           "resourceSize": 1153121
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689506,
+          "transferSize": 689498,
           "resourceSize": 1344982
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689633,
+          "transferSize": 689634,
           "resourceSize": 1345375
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689514,
+          "transferSize": 689513,
           "resourceSize": 1344964
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1284,
+          "transferSize": 1274,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691096,
+          "transferSize": 691086,
           "resourceSize": 1349442
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1117,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692224,
+          "transferSize": 692227,
           "resourceSize": 1347589
         }
       },

--- a/.github/page_size_audit_results/v1.36.0.json
+++ b/.github/page_size_audit_results/v1.36.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.36.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:47.547Z"
+    "generatedAt": "2025-11-27T17:08:53.832Z"
   },
-  "timestamp": "2025-11-27T16:03:47.547Z",
+  "timestamp": "2025-11-27T17:08:53.833Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2153,
+          "transferSize": 2149,
           "resourceSize": 5700
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689511,
+          "transferSize": 689506,
           "resourceSize": 1345112
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2124,
+          "transferSize": 2120,
           "resourceSize": 5712
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689478,
+          "transferSize": 689474,
           "resourceSize": 1345124
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5234,
+          "transferSize": 5229,
           "resourceSize": 23724
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9045,
+          "transferSize": 9040,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 478700,
+          "transferSize": 478690,
           "resourceSize": 1152702
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1992,
+          "transferSize": 1989,
           "resourceSize": 5151
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689343,
+          "transferSize": 689344,
           "resourceSize": 1344563
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2129,
+          "transferSize": 2124,
           "resourceSize": 5544
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689483,
+          "transferSize": 689482,
           "resourceSize": 1344956
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2005,
+          "transferSize": 2003,
           "resourceSize": 5133
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2201,
+          "transferSize": 2196,
           "resourceSize": 5654
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 689550,
+          "transferSize": 689546,
           "resourceSize": 1345066
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3075,
+          "transferSize": 3071,
           "resourceSize": 9249
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1285,
+          "transferSize": 1280,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690945,
+          "transferSize": 690936,
           "resourceSize": 1349023
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2359,
+          "transferSize": 2355,
           "resourceSize": 5920
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.37.0.json
+++ b/.github/page_size_audit_results/v1.37.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.37.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:29.563Z"
+    "generatedAt": "2025-11-27T17:06:36.750Z"
   },
-  "timestamp": "2025-11-27T16:03:29.564Z",
+  "timestamp": "2025-11-27T17:06:36.751Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2154,
+          "transferSize": 2150,
           "resourceSize": 5700
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690208,
+          "transferSize": 690204,
           "resourceSize": 1362903
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2125,
+          "transferSize": 2121,
           "resourceSize": 5712
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690180,
+          "transferSize": 690175,
           "resourceSize": 1362915
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5234,
+          "transferSize": 5230,
           "resourceSize": 23724
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9090,
+          "transferSize": 9077,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479443,
+          "transferSize": 479426,
           "resourceSize": 1170493
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1992,
+          "transferSize": 1989,
           "resourceSize": 5151
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690047,
+          "transferSize": 690039,
           "resourceSize": 1362354
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2128,
+          "transferSize": 2126,
           "resourceSize": 5544
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690178,
+          "transferSize": 690179,
           "resourceSize": 1362747
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2005,
+          "transferSize": 2003,
           "resourceSize": 5133
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690055,
+          "transferSize": 690056,
           "resourceSize": 1362336
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2202,
+          "transferSize": 2199,
           "resourceSize": 5654
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690257,
+          "transferSize": 690251,
           "resourceSize": 1362857
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3143,
+          "transferSize": 3139,
           "resourceSize": 9580
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1279,
+          "transferSize": 1271,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691705,
+          "transferSize": 691693,
           "resourceSize": 1367145
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2359,
+          "transferSize": 2356,
           "resourceSize": 5920
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692776,
+          "transferSize": 692770,
           "resourceSize": 1364961
         }
       },

--- a/.github/page_size_audit_results/v1.38.0.json
+++ b/.github/page_size_audit_results/v1.38.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.38.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:37.469Z"
+    "generatedAt": "2025-11-27T17:06:28.913Z"
   },
-  "timestamp": "2025-11-27T16:03:37.469Z",
+  "timestamp": "2025-11-27T17:06:28.914Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2153,
+          "transferSize": 2151,
           "resourceSize": 5700
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690379,
+          "transferSize": 690380,
           "resourceSize": 1363196
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2123,
+          "transferSize": 2121,
           "resourceSize": 5712
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690350,
+          "transferSize": 690344,
           "resourceSize": 1363208
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5233,
+          "transferSize": 5230,
           "resourceSize": 23724
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9099,
+          "transferSize": 9061,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479624,
+          "transferSize": 479583,
           "resourceSize": 1170786
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2004,
+          "transferSize": 2001,
           "resourceSize": 5206
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2134,
+          "transferSize": 2132,
           "resourceSize": 5582
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690363,
+          "transferSize": 690359,
           "resourceSize": 1363078
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2005,
+          "transferSize": 2002,
           "resourceSize": 5133
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690233,
+          "transferSize": 690235,
           "resourceSize": 1362629
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2209,
+          "transferSize": 2206,
           "resourceSize": 5692
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690436,
+          "transferSize": 690432,
           "resourceSize": 1363188
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3159,
+          "transferSize": 3155,
           "resourceSize": 9648
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1278,
+          "transferSize": 1287,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691893,
+          "transferSize": 691898,
           "resourceSize": 1367506
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2359,
+          "transferSize": 2355,
           "resourceSize": 5920
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692946,
+          "transferSize": 692944,
           "resourceSize": 1365254
         }
       },

--- a/.github/page_size_audit_results/v1.39.0.json
+++ b/.github/page_size_audit_results/v1.39.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.39.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:50.751Z"
+    "generatedAt": "2025-11-27T17:08:55.927Z"
   },
-  "timestamp": "2025-11-27T16:03:50.752Z",
+  "timestamp": "2025-11-27T17:08:55.927Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690401,
+          "transferSize": 690400,
           "resourceSize": 1363221
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690366,
+          "transferSize": 690374,
           "resourceSize": 1363233
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9081,
+          "transferSize": 9038,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479635,
+          "transferSize": 479592,
           "resourceSize": 1170811
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690258,
+          "transferSize": 690256,
           "resourceSize": 1362727
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2157,
+          "transferSize": 2156,
           "resourceSize": 5667
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690383,
+          "transferSize": 690387,
           "resourceSize": 1363103
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690251,
+          "transferSize": 690253,
           "resourceSize": 1362654
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690455,
+          "transferSize": 690460,
           "resourceSize": 1363213
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1287,
+          "transferSize": 1279,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691929,
+          "transferSize": 691921,
           "resourceSize": 1367531
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692969,
+          "transferSize": 692972,
           "resourceSize": 1365279
         }
       },

--- a/.github/page_size_audit_results/v1.4.0.json
+++ b/.github/page_size_audit_results/v1.4.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.4.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:00:59.640Z"
+    "generatedAt": "2025-11-27T17:03:48.784Z"
   },
-  "timestamp": "2025-11-27T16:00:59.641Z",
+  "timestamp": "2025-11-27T17:03:48.784Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2584,
+          "transferSize": 2581,
           "resourceSize": 5377
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690517,
+          "transferSize": 690518,
           "resourceSize": 1366983
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2452,
+          "transferSize": 2449,
           "resourceSize": 5093
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690388,
+          "transferSize": 690386,
           "resourceSize": 1366699
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5217,
+          "transferSize": 5215,
           "resourceSize": 16731
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4957,
+          "transferSize": 4970,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479234,
+          "transferSize": 479245,
           "resourceSize": 1172217
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2278,
+          "transferSize": 2275,
           "resourceSize": 4477
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690215,
+          "transferSize": 690211,
           "resourceSize": 1366083
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2442,
+          "transferSize": 2440,
           "resourceSize": 4903
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690372,
+          "transferSize": 690368,
           "resourceSize": 1366509
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2301,
+          "transferSize": 2298,
           "resourceSize": 4494
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690238,
+          "transferSize": 690229,
           "resourceSize": 1366100
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2505,
+          "transferSize": 2501,
           "resourceSize": 5013
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 762,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690431,
+          "transferSize": 690435,
           "resourceSize": 1366619
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3091,
+          "transferSize": 3088,
           "resourceSize": 7130
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691021,
+          "transferSize": 691019,
           "resourceSize": 1368736
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3147,
+          "transferSize": 3145,
           "resourceSize": 6409
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1117,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697499,
+          "transferSize": 697505,
           "resourceSize": 1380411
         }
       },

--- a/.github/page_size_audit_results/v1.40.0.json
+++ b/.github/page_size_audit_results/v1.40.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.40.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:06.376Z"
+    "generatedAt": "2025-11-27T17:06:33.390Z"
   },
-  "timestamp": "2025-11-27T16:01:06.376Z",
+  "timestamp": "2025-11-27T17:06:33.391Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2192,
+          "transferSize": 2190,
           "resourceSize": 5834
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 780,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691098,
+          "transferSize": 691108,
           "resourceSize": 1365735
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2163,
+          "transferSize": 2160,
           "resourceSize": 5846
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691070,
+          "transferSize": 691069,
           "resourceSize": 1365747
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5243,
+          "transferSize": 5240,
           "resourceSize": 23830
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9063,
+          "transferSize": 9097,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 480280,
+          "transferSize": 480311,
           "resourceSize": 1173297
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2043,
+          "transferSize": 2040,
           "resourceSize": 5340
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690953,
+          "transferSize": 690951,
           "resourceSize": 1365241
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2174,
+          "transferSize": 2171,
           "resourceSize": 5716
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2043,
+          "transferSize": 2041,
           "resourceSize": 5267
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690945,
+          "transferSize": 690946,
           "resourceSize": 1365168
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2248,
+          "transferSize": 2245,
           "resourceSize": 5826
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691153,
+          "transferSize": 691152,
           "resourceSize": 1365727
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1275,
+          "transferSize": 1279,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 692614,
+          "transferSize": 692618,
           "resourceSize": 1370045
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2399,
+          "transferSize": 2396,
           "resourceSize": 6064
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 693672,
+          "transferSize": 693667,
           "resourceSize": 1367803
         }
       },

--- a/.github/page_size_audit_results/v1.40.1.json
+++ b/.github/page_size_audit_results/v1.40.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.40.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:59.099Z"
+    "generatedAt": "2025-11-27T17:09:27.856Z"
   },
-  "timestamp": "2025-11-27T16:03:59.100Z",
+  "timestamp": "2025-11-27T17:09:27.856Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2173,
+          "transferSize": 2175,
           "resourceSize": 5722
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657121,
+          "transferSize": 657126,
           "resourceSize": 1279934
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2143,
+          "transferSize": 2145,
           "resourceSize": 5734
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 782,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657093,
+          "transferSize": 657108,
           "resourceSize": 1279946
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5219,
+          "transferSize": 5222,
           "resourceSize": 23718
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9079,
+          "transferSize": 9047,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 446315,
+          "transferSize": 446286,
           "resourceSize": 1087496
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2023,
+          "transferSize": 2027,
           "resourceSize": 5228
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 656972,
+          "transferSize": 656980,
           "resourceSize": 1279440
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2154,
+          "transferSize": 2156,
           "resourceSize": 5604
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657105,
+          "transferSize": 657108,
           "resourceSize": 1279816
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2023,
+          "transferSize": 2027,
           "resourceSize": 5155
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 656972,
+          "transferSize": 656974,
           "resourceSize": 1279367
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2228,
+          "transferSize": 2230,
           "resourceSize": 5714
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657182,
+          "transferSize": 657179,
           "resourceSize": 1279926
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3178,
+          "transferSize": 3182,
           "resourceSize": 9670
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1279,
+          "transferSize": 1285,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 658638,
+          "transferSize": 658648,
           "resourceSize": 1284244
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2379,
+          "transferSize": 2382,
           "resourceSize": 5952
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1129,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 659700,
+          "transferSize": 659701,
           "resourceSize": 1282002
         }
       },

--- a/.github/page_size_audit_results/v1.41.0.json
+++ b/.github/page_size_audit_results/v1.41.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:10.312Z"
+    "generatedAt": "2025-11-27T17:09:08.839Z"
   },
-  "timestamp": "2025-11-27T16:06:10.312Z",
+  "timestamp": "2025-11-27T17:09:08.839Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2175,
+          "transferSize": 2173,
           "resourceSize": 5728
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657128,
+          "transferSize": 657122,
           "resourceSize": 1279940
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2144,
+          "transferSize": 2142,
           "resourceSize": 5740
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657092,
+          "transferSize": 657093,
           "resourceSize": 1279952
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5225,
+          "transferSize": 5224,
           "resourceSize": 23724
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9043,
+          "transferSize": 9108,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 446285,
+          "transferSize": 446349,
           "resourceSize": 1087502
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 656975,
+          "transferSize": 656974,
           "resourceSize": 1279446
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2155,
+          "transferSize": 2153,
           "resourceSize": 5610
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657101,
+          "transferSize": 657104,
           "resourceSize": 1279822
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 656978,
+          "transferSize": 656977,
           "resourceSize": 1279373
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2229,
+          "transferSize": 2227,
           "resourceSize": 5720
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1280,
+          "transferSize": 1282,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 658639,
+          "transferSize": 658641,
           "resourceSize": 1284250
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 659692,
+          "transferSize": 659696,
           "resourceSize": 1282008
         }
       },

--- a/.github/page_size_audit_results/v1.41.1.json
+++ b/.github/page_size_audit_results/v1.41.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:43.573Z"
+    "generatedAt": "2025-11-27T17:06:22.909Z"
   },
-  "timestamp": "2025-11-27T16:03:43.574Z",
+  "timestamp": "2025-11-27T17:06:22.909Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2175,
+          "transferSize": 2177,
           "resourceSize": 5728
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657123,
+          "transferSize": 657125,
           "resourceSize": 1279940
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2144,
+          "transferSize": 2147,
           "resourceSize": 5740
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657095,
+          "transferSize": 657101,
           "resourceSize": 1279952
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5225,
+          "transferSize": 5229,
           "resourceSize": 23724
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9036,
+          "transferSize": 9415,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 446278,
+          "transferSize": 446661,
           "resourceSize": 1087502
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2025,
+          "transferSize": 2029,
           "resourceSize": 5234
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 656973,
+          "transferSize": 656979,
           "resourceSize": 1279446
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2155,
+          "transferSize": 2157,
           "resourceSize": 5610
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657101,
+          "transferSize": 657108,
           "resourceSize": 1279822
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2026,
+          "transferSize": 2029,
           "resourceSize": 5161
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 656976,
+          "transferSize": 656983,
           "resourceSize": 1279373
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2229,
+          "transferSize": 2232,
           "resourceSize": 5720
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657178,
+          "transferSize": 657183,
           "resourceSize": 1279932
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3178,
+          "transferSize": 3182,
           "resourceSize": 9676
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1280,
+          "transferSize": 1281,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 658639,
+          "transferSize": 658644,
           "resourceSize": 1284250
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2381,
+          "transferSize": 2383,
           "resourceSize": 5958
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 659699,
+          "transferSize": 659695,
           "resourceSize": 1282008
         }
       },

--- a/.github/page_size_audit_results/v1.41.2.json
+++ b/.github/page_size_audit_results/v1.41.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:36.559Z"
+    "generatedAt": "2025-11-27T17:04:07.001Z"
   },
-  "timestamp": "2025-11-27T16:03:36.560Z",
+  "timestamp": "2025-11-27T17:04:07.001Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2177,
+          "transferSize": 2176,
           "resourceSize": 5728
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 655118,
+          "transferSize": 655128,
           "resourceSize": 1275483
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2147,
+          "transferSize": 2146,
           "resourceSize": 5740
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 655094,
+          "transferSize": 655088,
           "resourceSize": 1275495
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5223,
+          "transferSize": 5222,
           "resourceSize": 23729
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9112,
+          "transferSize": 9074,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 444347,
+          "transferSize": 444308,
           "resourceSize": 1083050
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 654978,
+          "transferSize": 654983,
           "resourceSize": 1274989
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2159,
+          "transferSize": 2157,
           "resourceSize": 5610
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 654975,
+          "transferSize": 654981,
           "resourceSize": 1274916
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2233,
+          "transferSize": 2232,
           "resourceSize": 5720
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 655182,
+          "transferSize": 655180,
           "resourceSize": 1275475
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1284,
+          "transferSize": 1282,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 656643,
+          "transferSize": 656641,
           "resourceSize": 1279793
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 657692,
+          "transferSize": 657698,
           "resourceSize": 1277556
         }
       },

--- a/.github/page_size_audit_results/v1.42.0.json
+++ b/.github/page_size_audit_results/v1.42.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:21.861Z"
+    "generatedAt": "2025-11-27T17:06:42.712Z"
   },
-  "timestamp": "2025-11-27T16:06:21.861Z",
+  "timestamp": "2025-11-27T17:06:42.712Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2314,
+          "transferSize": 2315,
           "resourceSize": 6221
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408359,
+          "transferSize": 408361,
           "resourceSize": 477317
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2263,
+          "transferSize": 2264,
           "resourceSize": 6135
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407754,
+          "transferSize": 407759,
           "resourceSize": 476853
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5360,
+          "transferSize": 5361,
           "resourceSize": 24231
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10195,
+          "transferSize": 10186,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 277829,
+          "transferSize": 277821,
           "resourceSize": 524554
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405851,
+          "transferSize": 405857,
           "resourceSize": 472924
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2255,
+          "transferSize": 2257,
           "resourceSize": 5898
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405982,
+          "transferSize": 405984,
           "resourceSize": 473300
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405859,
+          "transferSize": 405854,
           "resourceSize": 472851
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2330,
+          "transferSize": 2331,
           "resourceSize": 6008
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406053,
+          "transferSize": 406059,
           "resourceSize": 473410
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1944,
+          "transferSize": 1948,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408907,
+          "transferSize": 408911,
           "resourceSize": 479118
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1129,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 490100,
+          "transferSize": 490091,
           "resourceSize": 718034
         }
       },

--- a/.github/page_size_audit_results/v1.42.1.json
+++ b/.github/page_size_audit_results/v1.42.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:46.224Z"
+    "generatedAt": "2025-11-27T17:08:55.366Z"
   },
-  "timestamp": "2025-11-27T16:03:46.224Z",
+  "timestamp": "2025-11-27T17:08:55.367Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2819,
+          "transferSize": 2821,
           "resourceSize": 7493
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408487,
+          "transferSize": 408492,
           "resourceSize": 476642
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2794,
           "resourceSize": 7511
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408145,
+          "transferSize": 408144,
           "resourceSize": 476343
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10183,
+          "transferSize": 10217,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 277991,
+          "transferSize": 278025,
           "resourceSize": 523595
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2655,
+          "transferSize": 2656,
           "resourceSize": 6891
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406237,
+          "transferSize": 406244,
           "resourceSize": 472405
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2791,
+          "transferSize": 2793,
           "resourceSize": 7265
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2655,
+          "transferSize": 2657,
           "resourceSize": 6830
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406234,
+          "transferSize": 406242,
           "resourceSize": 472344
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2871,
+          "transferSize": 2873,
           "resourceSize": 7385
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406453,
+          "transferSize": 406455,
           "resourceSize": 472899
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1924,
+          "transferSize": 1937,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 409243,
+          "transferSize": 409256,
           "resourceSize": 478543
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3045,
+          "transferSize": 3047,
           "resourceSize": 7827
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 490252,
+          "transferSize": 490260,
           "resourceSize": 717075
         }
       },

--- a/.github/page_size_audit_results/v1.42.10.json
+++ b/.github/page_size_audit_results/v1.42.10.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.10",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:04:01.758Z"
+    "generatedAt": "2025-11-27T17:08:57.996Z"
   },
-  "timestamp": "2025-11-27T16:04:01.758Z",
+  "timestamp": "2025-11-27T17:08:57.996Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2837,
+          "transferSize": 2840,
           "resourceSize": 7602
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408290,
+          "transferSize": 408294,
           "resourceSize": 476193
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2798,
+          "transferSize": 2800,
           "resourceSize": 7518
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5624,
+          "transferSize": 5630,
           "resourceSize": 24850
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10197,
+          "transferSize": 10206,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 201590,
+          "transferSize": 201605,
           "resourceSize": 294380
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2657,
+          "transferSize": 2660,
           "resourceSize": 6898
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405799,
+          "transferSize": 405807,
           "resourceSize": 471678
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2792,
+          "transferSize": 2795,
           "resourceSize": 7272
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405935,
+          "transferSize": 405942,
           "resourceSize": 472052
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2658,
+          "transferSize": 2661,
           "resourceSize": 6837
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405802,
+          "transferSize": 405807,
           "resourceSize": 471617
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2874,
+          "transferSize": 2876,
           "resourceSize": 7392
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406015,
+          "transferSize": 406019,
           "resourceSize": 472172
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3859,
+          "transferSize": 3862,
           "resourceSize": 11341
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1937,
+          "transferSize": 1941,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 408818,
+          "transferSize": 408825,
           "resourceSize": 477816
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3080,
+          "transferSize": 3084,
           "resourceSize": 8035
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 414662,
+          "transferSize": 414668,
           "resourceSize": 489158
         }
       },

--- a/.github/page_size_audit_results/v1.42.11.json
+++ b/.github/page_size_audit_results/v1.42.11.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.11",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:49.209Z"
+    "generatedAt": "2025-11-27T17:09:00.143Z"
   },
-  "timestamp": "2025-11-27T16:03:49.209Z",
+  "timestamp": "2025-11-27T17:09:00.144Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2839,
+          "transferSize": 2838,
           "resourceSize": 7602
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408295,
+          "transferSize": 408290,
           "resourceSize": 476193
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2799,
+          "transferSize": 2797,
           "resourceSize": 7518
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407738,
+          "transferSize": 407737,
           "resourceSize": 475764
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5627,
+          "transferSize": 5626,
           "resourceSize": 24850
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10183,
+          "transferSize": 10184,
           "resourceSize": 12954
         },
         "other": {
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2659,
+          "transferSize": 2658,
           "resourceSize": 6898
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405812,
+          "transferSize": 405803,
           "resourceSize": 471678
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2794,
+          "transferSize": 2792,
           "resourceSize": 7272
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405938,
+          "transferSize": 405933,
           "resourceSize": 472052
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2659,
+          "transferSize": 2660,
           "resourceSize": 6837
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405801,
+          "transferSize": 405808,
           "resourceSize": 471617
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2876,
+          "transferSize": 2871,
           "resourceSize": 7392
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406019,
+          "transferSize": 406017,
           "resourceSize": 472172
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1937,
+          "transferSize": 1943,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 408818,
+          "transferSize": 408824,
           "resourceSize": 477816
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 414662,
+          "transferSize": 414664,
           "resourceSize": 489158
         }
       },

--- a/.github/page_size_audit_results/v1.42.12.json
+++ b/.github/page_size_audit_results/v1.42.12.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.12",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:04:02.386Z"
+    "generatedAt": "2025-11-27T17:06:45.800Z"
   },
-  "timestamp": "2025-11-27T16:04:02.386Z",
+  "timestamp": "2025-11-27T17:06:45.801Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2817,
+          "transferSize": 2815,
           "resourceSize": 7403
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407214,
+          "transferSize": 407219,
           "resourceSize": 475992
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2787,
+          "transferSize": 2785,
           "resourceSize": 7421
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407188,
+          "transferSize": 407182,
           "resourceSize": 476010
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5604,
+          "transferSize": 5600,
           "resourceSize": 24642
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10181,
+          "transferSize": 10203,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200491,
+          "transferSize": 200509,
           "resourceSize": 294161
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2664,
+          "transferSize": 2661,
           "resourceSize": 6907
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407063,
+          "transferSize": 407065,
           "resourceSize": 475496
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2799,
+          "transferSize": 2796,
           "resourceSize": 7281
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407198,
+          "transferSize": 407202,
           "resourceSize": 475870
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2663,
+          "transferSize": 2660,
           "resourceSize": 6846
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407061,
+          "transferSize": 407059,
           "resourceSize": 475435
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2878,
+          "transferSize": 2876,
           "resourceSize": 7401
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407275,
+          "transferSize": 407276,
           "resourceSize": 475990
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3865,
+          "transferSize": 3863,
           "resourceSize": 11454
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1930,
+          "transferSize": 1938,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 410270,
+          "transferSize": 410276,
           "resourceSize": 481767
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3058,
+          "transferSize": 3054,
           "resourceSize": 7836
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413589,
+          "transferSize": 413588,
           "resourceSize": 488957
         }
       },

--- a/.github/page_size_audit_results/v1.42.13.json
+++ b/.github/page_size_audit_results/v1.42.13.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.13",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:14.614Z"
+    "generatedAt": "2025-11-27T17:06:19.198Z"
   },
-  "timestamp": "2025-11-27T16:06:14.614Z",
+  "timestamp": "2025-11-27T17:06:19.198Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2835,
+          "transferSize": 2834,
           "resourceSize": 7599
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407832,
+          "transferSize": 407831,
           "resourceSize": 476253
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2811,
+          "transferSize": 2810,
           "resourceSize": 7619
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407812,
+          "transferSize": 407811,
           "resourceSize": 476273
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5546,
+          "transferSize": 5545,
           "resourceSize": 24667
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10167,
+          "transferSize": 10191,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 201020,
+          "transferSize": 201043,
           "resourceSize": 294251
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2688,
+          "transferSize": 2687,
           "resourceSize": 7110
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407685,
+          "transferSize": 407691,
           "resourceSize": 475764
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407822,
+          "transferSize": 407825,
           "resourceSize": 476138
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2688,
+          "transferSize": 2689,
           "resourceSize": 7049
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407683,
+          "transferSize": 407690,
           "resourceSize": 475703
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2906,
+          "transferSize": 2905,
           "resourceSize": 7604
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407906,
+          "transferSize": 407908,
           "resourceSize": 476258
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3760,
+          "transferSize": 3758,
           "resourceSize": 11416
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1943,
+          "transferSize": 1940,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 410780,
+          "transferSize": 410775,
           "resourceSize": 481795
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3077,
+          "transferSize": 3076,
           "resourceSize": 8059
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 414209,
+          "transferSize": 414207,
           "resourceSize": 489245
         }
       },

--- a/.github/page_size_audit_results/v1.42.14.json
+++ b/.github/page_size_audit_results/v1.42.14.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.14",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:18.305Z"
+    "generatedAt": "2025-11-27T17:06:38.337Z"
   },
-  "timestamp": "2025-11-27T16:06:18.305Z",
+  "timestamp": "2025-11-27T17:06:38.338Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2862,
+          "transferSize": 2865,
           "resourceSize": 7598
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406898,
+          "transferSize": 406905,
           "resourceSize": 475312
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2836,
+          "transferSize": 2839,
           "resourceSize": 7618
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406880,
+          "transferSize": 406881,
           "resourceSize": 475332
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5679,
+          "transferSize": 5685,
           "resourceSize": 25373
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10197,
+          "transferSize": 10175,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200219,
+          "transferSize": 200203,
           "resourceSize": 294000
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2714,
+          "transferSize": 2717,
           "resourceSize": 7109
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406752,
+          "transferSize": 406757,
           "resourceSize": 474823
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2880,
+          "transferSize": 2883,
           "resourceSize": 7620
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 779,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406931,
+          "transferSize": 406925,
           "resourceSize": 475334
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2714,
+          "transferSize": 2718,
           "resourceSize": 7048
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406761,
+          "transferSize": 406760,
           "resourceSize": 474762
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2970,
+          "transferSize": 2974,
           "resourceSize": 7762
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407011,
+          "transferSize": 407017,
           "resourceSize": 475476
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1939,
+          "transferSize": 1936,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 409877,
+          "transferSize": 409874,
           "resourceSize": 481006
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3102,
+          "transferSize": 3108,
           "resourceSize": 8058
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413273,
+          "transferSize": 413276,
           "resourceSize": 488287
         }
       },

--- a/.github/page_size_audit_results/v1.42.2.json
+++ b/.github/page_size_audit_results/v1.42.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:10.816Z"
+    "generatedAt": "2025-11-27T17:06:30.155Z"
   },
-  "timestamp": "2025-11-27T16:06:10.817Z",
+  "timestamp": "2025-11-27T17:06:30.155Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2821,
+          "transferSize": 2822,
           "resourceSize": 7493
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408511,
+          "transferSize": 408512,
           "resourceSize": 476691
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2795,
+          "transferSize": 2796,
           "resourceSize": 7511
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408164,
+          "transferSize": 408168,
           "resourceSize": 476392
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5584,
+          "transferSize": 5587,
           "resourceSize": 24599
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10166,
+          "transferSize": 10188,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200241,
+          "transferSize": 200266,
           "resourceSize": 288606
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2653,
+          "transferSize": 2656,
           "resourceSize": 6891
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406262,
+          "transferSize": 406266,
           "resourceSize": 472454
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406398,
+          "transferSize": 406397,
           "resourceSize": 472828
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2654,
+          "transferSize": 2655,
           "resourceSize": 6830
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406265,
+          "transferSize": 406263,
           "resourceSize": 472393
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406477,
+          "transferSize": 406480,
           "resourceSize": 472948
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3857,
+          "transferSize": 3859,
           "resourceSize": 11334
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1954,
+          "transferSize": 1941,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 409293,
+          "transferSize": 409282,
           "resourceSize": 478592
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3045,
+          "transferSize": 3046,
           "resourceSize": 7827
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 412835,
+          "transferSize": 412837,
           "resourceSize": 483082
         }
       },

--- a/.github/page_size_audit_results/v1.42.3.json
+++ b/.github/page_size_audit_results/v1.42.3.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:22.201Z"
+    "generatedAt": "2025-11-27T17:06:33.561Z"
   },
-  "timestamp": "2025-11-27T16:06:22.201Z",
+  "timestamp": "2025-11-27T17:06:33.562Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408513,
+          "transferSize": 408514,
           "resourceSize": 476691
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2799,
+          "transferSize": 2798,
           "resourceSize": 7511
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408176,
+          "transferSize": 408168,
           "resourceSize": 476392
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5588,
+          "transferSize": 5587,
           "resourceSize": 24599
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10219,
+          "transferSize": 10166,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200282,
+          "transferSize": 200228,
           "resourceSize": 288577
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406257,
+          "transferSize": 406264,
           "resourceSize": 472454
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2792,
+          "transferSize": 2793,
           "resourceSize": 7265
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406398,
+          "transferSize": 406399,
           "resourceSize": 472828
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406261,
+          "transferSize": 406265,
           "resourceSize": 472393
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1936,
+          "transferSize": 1938,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 409279,
+          "transferSize": 409281,
           "resourceSize": 478592
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1116,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 412819,
+          "transferSize": 412816,
           "resourceSize": 483053
         }
       },

--- a/.github/page_size_audit_results/v1.42.4.json
+++ b/.github/page_size_audit_results/v1.42.4.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:42.454Z"
+    "generatedAt": "2025-11-27T17:06:33.561Z"
   },
-  "timestamp": "2025-11-27T16:03:42.454Z",
+  "timestamp": "2025-11-27T17:06:33.561Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2822,
+          "transferSize": 2821,
           "resourceSize": 7493
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2795,
           "resourceSize": 7511
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408171,
+          "transferSize": 408170,
           "resourceSize": 476392
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5588,
+          "transferSize": 5582,
           "resourceSize": 24599
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10200,
+          "transferSize": 10172,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200263,
+          "transferSize": 200229,
           "resourceSize": 288577
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2658,
+          "transferSize": 2654,
           "resourceSize": 6891
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406264,
+          "transferSize": 406253,
           "resourceSize": 472454
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2792,
+          "transferSize": 2789,
           "resourceSize": 7265
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406392,
+          "transferSize": 406396,
           "resourceSize": 472828
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2656,
+          "transferSize": 2653,
           "resourceSize": 6830
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406260,
+          "transferSize": 406257,
           "resourceSize": 472393
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2872,
+          "transferSize": 2871,
           "resourceSize": 7385
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406476,
+          "transferSize": 406472,
           "resourceSize": 472948
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3860,
+          "transferSize": 3856,
           "resourceSize": 11334
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1937,
+          "transferSize": 1932,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 409279,
+          "transferSize": 409270,
           "resourceSize": 478592
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3050,
+          "transferSize": 3045,
           "resourceSize": 7827
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 412829,
+          "transferSize": 412817,
           "resourceSize": 483053
         }
       },

--- a/.github/page_size_audit_results/v1.42.5.json
+++ b/.github/page_size_audit_results/v1.42.5.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.5",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:42.441Z"
+    "generatedAt": "2025-11-27T17:06:35.652Z"
   },
-  "timestamp": "2025-11-27T16:03:42.441Z",
+  "timestamp": "2025-11-27T17:06:35.652Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2832,
+          "transferSize": 2830,
           "resourceSize": 7595
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408724,
+          "transferSize": 408722,
           "resourceSize": 476823
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2794,
+          "transferSize": 2793,
           "resourceSize": 7511
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5580,
+          "transferSize": 5578,
           "resourceSize": 24599
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10186,
+          "transferSize": 10179,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200243,
+          "transferSize": 200234,
           "resourceSize": 288579
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2655,
+          "transferSize": 2653,
           "resourceSize": 6891
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406261,
+          "transferSize": 406262,
           "resourceSize": 472456
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2790,
+          "transferSize": 2788,
           "resourceSize": 7265
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406391,
+          "transferSize": 406396,
           "resourceSize": 472830
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2653,
+          "transferSize": 2651,
           "resourceSize": 6830
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406256,
+          "transferSize": 406262,
           "resourceSize": 472395
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2870,
+          "transferSize": 2869,
           "resourceSize": 7385
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406474,
+          "transferSize": 406478,
           "resourceSize": 472950
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3854,
+          "transferSize": 3855,
           "resourceSize": 11334
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1946,
+          "transferSize": 1934,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 409284,
+          "transferSize": 409273,
           "resourceSize": 478594
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3057,
+          "transferSize": 3059,
           "resourceSize": 7929
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1116,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413343,
+          "transferSize": 413355,
           "resourceSize": 483502
         }
       },

--- a/.github/page_size_audit_results/v1.42.6.json
+++ b/.github/page_size_audit_results/v1.42.6.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.6",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:02.934Z"
+    "generatedAt": "2025-11-27T17:03:47.377Z"
   },
-  "timestamp": "2025-11-27T16:06:02.934Z",
+  "timestamp": "2025-11-27T17:03:47.377Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2840,
+          "transferSize": 2837,
           "resourceSize": 7595
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408779,
+          "transferSize": 408777,
           "resourceSize": 476873
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2800,
+          "transferSize": 2797,
           "resourceSize": 7511
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408223,
+          "transferSize": 408218,
           "resourceSize": 476444
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5588,
+          "transferSize": 5584,
           "resourceSize": 24599
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10201,
+          "transferSize": 10188,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200313,
+          "transferSize": 200296,
           "resourceSize": 288629
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2662,
+          "transferSize": 2656,
           "resourceSize": 6891
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406318,
+          "transferSize": 406312,
           "resourceSize": 472506
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2795,
+          "transferSize": 2793,
           "resourceSize": 7265
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406448,
+          "transferSize": 406443,
           "resourceSize": 472880
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2660,
+          "transferSize": 2658,
           "resourceSize": 6830
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406319,
+          "transferSize": 406312,
           "resourceSize": 472445
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2875,
+          "transferSize": 2871,
           "resourceSize": 7385
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406527,
+          "transferSize": 406525,
           "resourceSize": 473000
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3862,
+          "transferSize": 3858,
           "resourceSize": 11334
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1935,
+          "transferSize": 1937,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 409329,
+          "transferSize": 409327,
           "resourceSize": 478644
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3068,
+          "transferSize": 3064,
           "resourceSize": 7929
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413404,
+          "transferSize": 413408,
           "resourceSize": 483552
         }
       },

--- a/.github/page_size_audit_results/v1.42.7.json
+++ b/.github/page_size_audit_results/v1.42.7.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.7",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:53.554Z"
+    "generatedAt": "2025-11-27T17:03:54.895Z"
   },
-  "timestamp": "2025-11-27T16:03:53.554Z",
+  "timestamp": "2025-11-27T17:03:54.896Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408109,
+          "transferSize": 408121,
           "resourceSize": 471871
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407551,
+          "transferSize": 407553,
           "resourceSize": 471442
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10194,
+          "transferSize": 10199,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 201287,
+          "transferSize": 201292,
           "resourceSize": 289888
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405628,
+          "transferSize": 405625,
           "resourceSize": 467356
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2800,
+          "transferSize": 2799,
           "resourceSize": 7271
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405759,
+          "transferSize": 405765,
           "resourceSize": 467730
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405630,
+          "transferSize": 405623,
           "resourceSize": 467295
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2881,
+          "transferSize": 2880,
           "resourceSize": 7391
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405847,
+          "transferSize": 405841,
           "resourceSize": 467850
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1934,
+          "transferSize": 1942,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 408634,
+          "transferSize": 408642,
           "resourceSize": 473494
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 414366,
+          "transferSize": 414359,
           "resourceSize": 484666
         }
       },

--- a/.github/page_size_audit_results/v1.42.8.json
+++ b/.github/page_size_audit_results/v1.42.8.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.8",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:36.808Z"
+    "generatedAt": "2025-11-27T17:08:59.195Z"
   },
-  "timestamp": "2025-11-27T16:03:36.808Z",
+  "timestamp": "2025-11-27T17:08:59.195Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408296,
+          "transferSize": 408297,
           "resourceSize": 476236
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2798,
+          "transferSize": 2797,
           "resourceSize": 7517
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407738,
+          "transferSize": 407739,
           "resourceSize": 475807
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10153,
+          "transferSize": 10200,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 201429,
+          "transferSize": 201476,
           "resourceSize": 294253
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405806,
+          "transferSize": 405812,
           "resourceSize": 471721
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2794,
+          "transferSize": 2793,
           "resourceSize": 7271
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405943,
+          "transferSize": 405942,
           "resourceSize": 472095
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405808,
+          "transferSize": 405814,
           "resourceSize": 471660
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406023,
+          "transferSize": 406024,
           "resourceSize": 472215
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1941,
+          "transferSize": 1939,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 408824,
+          "transferSize": 408822,
           "resourceSize": 477859
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3080,
+          "transferSize": 3082,
           "resourceSize": 8034
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1128,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 414544,
+          "transferSize": 414552,
           "resourceSize": 489031
         }
       },

--- a/.github/page_size_audit_results/v1.42.9.json
+++ b/.github/page_size_audit_results/v1.42.9.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.9",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:46.222Z"
+    "generatedAt": "2025-11-27T17:03:50.027Z"
   },
-  "timestamp": "2025-11-27T16:03:46.223Z",
+  "timestamp": "2025-11-27T17:03:50.027Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408293,
+          "transferSize": 408295,
           "resourceSize": 476192
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2798,
+          "transferSize": 2799,
           "resourceSize": 7517
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407734,
+          "transferSize": 407735,
           "resourceSize": 475763
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10207,
+          "transferSize": 10159,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 201582,
+          "transferSize": 201534,
           "resourceSize": 294494
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2659,
+          "transferSize": 2658,
           "resourceSize": 6897
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405935,
+          "transferSize": 405940,
           "resourceSize": 472051
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405803,
+          "transferSize": 405801,
           "resourceSize": 471616
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406027,
+          "transferSize": 406018,
           "resourceSize": 472171
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3857,
+          "transferSize": 3858,
           "resourceSize": 11340
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1934,
+          "transferSize": 1937,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 408813,
+          "transferSize": 408817,
           "resourceSize": 477815
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 414641,
+          "transferSize": 414642,
           "resourceSize": 489272
         }
       },

--- a/.github/page_size_audit_results/v1.43.0.json
+++ b/.github/page_size_audit_results/v1.43.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.43.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:04:04.303Z"
+    "generatedAt": "2025-11-27T17:06:36.258Z"
   },
-  "timestamp": "2025-11-27T16:04:04.303Z",
+  "timestamp": "2025-11-27T17:06:36.258Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2864,
-          "resourceSize": 7597
+          "transferSize": 3004,
+          "resourceSize": 7992
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 14110,
-          "resourceSize": 32203
+          "transferSize": 50668,
+          "resourceSize": 139755
         },
         "stylesheet": {
-          "transferSize": 8528,
-          "resourceSize": 55445
+          "transferSize": 9698,
+          "resourceSize": 56449
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406916,
-          "resourceSize": 475342
+          "transferSize": 444787,
+          "resourceSize": 584293
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2837,
-          "resourceSize": 7617
+          "transferSize": 2981,
+          "resourceSize": 8012
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 14110,
-          "resourceSize": 32203
+          "transferSize": 50668,
+          "resourceSize": 139755
         },
         "stylesheet": {
-          "transferSize": 8528,
-          "resourceSize": 55445
+          "transferSize": 9698,
+          "resourceSize": 56449
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406887,
-          "resourceSize": 475362
+          "transferSize": 444761,
+          "resourceSize": 584313
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5685,
-          "resourceSize": 25372
+          "transferSize": 5808,
+          "resourceSize": 25889
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 17760,
-          "resourceSize": 38511
+          "transferSize": 54318,
+          "resourceSize": 146063
         },
         "stylesheet": {
-          "transferSize": 10124,
-          "resourceSize": 61297
+          "transferSize": 11294,
+          "resourceSize": 62301
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10180,
+          "transferSize": 10162,
           "resourceSize": 12954
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200217,
-          "resourceSize": 294030
+          "transferSize": 238050,
+          "resourceSize": 403103
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2717,
-          "resourceSize": 7108
+          "transferSize": 2854,
+          "resourceSize": 7503
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 14110,
-          "resourceSize": 32203
+          "transferSize": 50668,
+          "resourceSize": 139755
         },
         "stylesheet": {
-          "transferSize": 8528,
-          "resourceSize": 55445
+          "transferSize": 9698,
+          "resourceSize": 56449
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406767,
-          "resourceSize": 474853
+          "transferSize": 444637,
+          "resourceSize": 583804
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2882,
-          "resourceSize": 7619
+          "transferSize": 3021,
+          "resourceSize": 8014
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 14110,
-          "resourceSize": 32203
+          "transferSize": 50668,
+          "resourceSize": 139755
         },
         "stylesheet": {
-          "transferSize": 8528,
-          "resourceSize": 55445
+          "transferSize": 9698,
+          "resourceSize": 56449
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406933,
-          "resourceSize": 475364
+          "transferSize": 444796,
+          "resourceSize": 584315
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2718,
-          "resourceSize": 7047
+          "transferSize": 2852,
+          "resourceSize": 7442
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 14110,
-          "resourceSize": 32203
+          "transferSize": 50668,
+          "resourceSize": 139755
         },
         "stylesheet": {
-          "transferSize": 8528,
-          "resourceSize": 55445
+          "transferSize": 9698,
+          "resourceSize": 56449
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406772,
-          "resourceSize": 474792
+          "transferSize": 444631,
+          "resourceSize": 583743
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2974,
-          "resourceSize": 7761
+          "transferSize": 3110,
+          "resourceSize": 8156
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 14110,
-          "resourceSize": 32203
+          "transferSize": 50668,
+          "resourceSize": 139755
         },
         "stylesheet": {
-          "transferSize": 8528,
-          "resourceSize": 55445
+          "transferSize": 9698,
+          "resourceSize": 56449
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 618,
-          "resourceSize": 216
+          "transferSize": 619,
+          "resourceSize": 217
         },
         "total": {
-          "transferSize": 407024,
-          "resourceSize": 475506
+          "transferSize": 444894,
+          "resourceSize": 584458
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3825,
-          "resourceSize": 11567
+          "transferSize": 3951,
+          "resourceSize": 11962
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 14110,
-          "resourceSize": 32203
+          "transferSize": 50668,
+          "resourceSize": 139755
         },
         "stylesheet": {
-          "transferSize": 9373,
-          "resourceSize": 56125
+          "transferSize": 10543,
+          "resourceSize": 57129
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1940,
+          "transferSize": 1952,
           "resourceSize": 1239
         },
         "other": {
-          "transferSize": 618,
-          "resourceSize": 216
+          "transferSize": 619,
+          "resourceSize": 217
         },
         "total": {
-          "transferSize": 409891,
-          "resourceSize": 481036
+          "transferSize": 447758,
+          "resourceSize": 589988
         }
       },
       "themeResources": {
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3107,
-          "resourceSize": 8057
+          "transferSize": 3257,
+          "resourceSize": 8452
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 18286,
-          "resourceSize": 38865
+          "transferSize": 54844,
+          "resourceSize": 146417
         },
         "stylesheet": {
-          "transferSize": 10124,
-          "resourceSize": 61297
+          "transferSize": 11294,
+          "resourceSize": 62301
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413284,
-          "resourceSize": 488317
+          "transferSize": 451159,
+          "resourceSize": 597268
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.43.1.json
+++ b/.github/page_size_audit_results/v1.43.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.43.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:45.631Z"
+    "generatedAt": "2025-11-27T17:06:32.426Z"
   },
-  "timestamp": "2025-11-27T16:03:45.632Z",
+  "timestamp": "2025-11-27T17:06:32.426Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2857,
+          "transferSize": 2862,
           "resourceSize": 7491
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406907,
+          "transferSize": 406911,
           "resourceSize": 475236
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2830,
+          "transferSize": 2835,
           "resourceSize": 7511
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406876,
+          "transferSize": 406887,
           "resourceSize": 475256
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5673,
+          "transferSize": 5678,
           "resourceSize": 25213
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10163,
+          "transferSize": 10206,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200188,
+          "transferSize": 200236,
           "resourceSize": 293871
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2710,
+          "transferSize": 2716,
           "resourceSize": 7002
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406759,
+          "transferSize": 406763,
           "resourceSize": 474747
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2874,
+          "transferSize": 2879,
           "resourceSize": 7513
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406923,
+          "transferSize": 406934,
           "resourceSize": 475258
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2708,
+          "transferSize": 2713,
           "resourceSize": 6941
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406757,
+          "transferSize": 406764,
           "resourceSize": 474686
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2964,
+          "transferSize": 2968,
           "resourceSize": 7655
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407018,
+          "transferSize": 407020,
           "resourceSize": 475400
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3816,
+          "transferSize": 3820,
           "resourceSize": 11461
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1939,
+          "transferSize": 1933,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 409881,
+          "transferSize": 409879,
           "resourceSize": 480930
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3098,
+          "transferSize": 3103,
           "resourceSize": 7951
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413271,
+          "transferSize": 413279,
           "resourceSize": 488211
         }
       },

--- a/.github/page_size_audit_results/v1.44.0.json
+++ b/.github/page_size_audit_results/v1.44.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.44.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:54.322Z"
+    "generatedAt": "2025-11-27T17:06:32.179Z"
   },
-  "timestamp": "2025-11-27T16:03:54.323Z",
+  "timestamp": "2025-11-27T17:06:32.180Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2860,
+          "transferSize": 2856,
           "resourceSize": 7491
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406913,
+          "transferSize": 406908,
           "resourceSize": 475216
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2834,
+          "transferSize": 2831,
           "resourceSize": 7511
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406883,
+          "transferSize": 406885,
           "resourceSize": 475236
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5681,
+          "transferSize": 5676,
           "resourceSize": 25235
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10178,
+          "transferSize": 10166,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200214,
+          "transferSize": 200197,
           "resourceSize": 293873
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2714,
+          "transferSize": 2710,
           "resourceSize": 7002
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406768,
+          "transferSize": 406763,
           "resourceSize": 474727
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2879,
+          "transferSize": 2875,
           "resourceSize": 7513
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406931,
+          "transferSize": 406927,
           "resourceSize": 475238
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2711,
+          "transferSize": 2709,
           "resourceSize": 6941
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406770,
+          "transferSize": 406761,
           "resourceSize": 474666
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2966,
+          "transferSize": 2962,
           "resourceSize": 7655
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407014,
+          "transferSize": 407013,
           "resourceSize": 475380
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1939,
+          "transferSize": 1930,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 409886,
+          "transferSize": 409877,
           "resourceSize": 480923
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3123,
+          "transferSize": 3120,
           "resourceSize": 8075
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413304,
+          "transferSize": 413301,
           "resourceSize": 488315
         }
       },

--- a/.github/page_size_audit_results/v1.45.0.json
+++ b/.github/page_size_audit_results/v1.45.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:19.573Z"
+    "generatedAt": "2025-11-27T17:06:33.662Z"
   },
-  "timestamp": "2025-11-27T16:06:19.573Z",
+  "timestamp": "2025-11-27T17:06:33.663Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406917,
+          "transferSize": 406918,
           "resourceSize": 475258
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2862,
+          "transferSize": 2864,
           "resourceSize": 7560
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406910,
+          "transferSize": 406920,
           "resourceSize": 475285
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5678,
+          "transferSize": 5680,
           "resourceSize": 25235
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10181,
+          "transferSize": 10202,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200214,
+          "transferSize": 200237,
           "resourceSize": 293873
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2714,
+          "transferSize": 2712,
           "resourceSize": 7002
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406769,
+          "transferSize": 406771,
           "resourceSize": 474727
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2882,
+          "transferSize": 2883,
           "resourceSize": 7601
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406936,
+          "transferSize": 406938,
           "resourceSize": 475326
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2711,
+          "transferSize": 2710,
           "resourceSize": 6941
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406765,
+          "transferSize": 406764,
           "resourceSize": 474666
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2975,
+          "transferSize": 2978,
           "resourceSize": 7743
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407032,
+          "transferSize": 407036,
           "resourceSize": 475468
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3151,
+          "transferSize": 3153,
           "resourceSize": 8712
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408050,
+          "transferSize": 408053,
           "resourceSize": 477117
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413303,
+          "transferSize": 413305,
           "resourceSize": 488315
         }
       },

--- a/.github/page_size_audit_results/v1.45.1.json
+++ b/.github/page_size_audit_results/v1.45.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:38.629Z"
+    "generatedAt": "2025-11-27T17:09:11.283Z"
   },
-  "timestamp": "2025-11-27T16:06:38.629Z",
+  "timestamp": "2025-11-27T17:09:11.283Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406915,
+          "transferSize": 406905,
           "resourceSize": 475271
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406905,
+          "transferSize": 406908,
           "resourceSize": 475298
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5682,
+          "transferSize": 5679,
           "resourceSize": 25235
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10215,
+          "transferSize": 10164,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200287,
+          "transferSize": 200233,
           "resourceSize": 294007
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2714,
+          "transferSize": 2712,
           "resourceSize": 7002
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406763,
+          "transferSize": 406754,
           "resourceSize": 474740
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406928,
+          "transferSize": 406925,
           "resourceSize": 475339
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406755,
+          "transferSize": 406756,
           "resourceSize": 474679
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407019,
+          "transferSize": 407021,
           "resourceSize": 475481
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3148,
+          "transferSize": 3149,
           "resourceSize": 8712
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408037,
+          "transferSize": 408038,
           "resourceSize": 477130
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3121,
+          "transferSize": 3119,
           "resourceSize": 8075
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413345,
+          "transferSize": 413338,
           "resourceSize": 488457
         }
       },

--- a/.github/page_size_audit_results/v1.45.2.json
+++ b/.github/page_size_audit_results/v1.45.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:48.481Z"
+    "generatedAt": "2025-11-27T17:06:25.576Z"
   },
-  "timestamp": "2025-11-27T16:03:48.481Z",
+  "timestamp": "2025-11-27T17:06:25.577Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2860,
+          "transferSize": 2857,
           "resourceSize": 7533
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406906,
+          "transferSize": 406905,
           "resourceSize": 475271
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2861,
+          "transferSize": 2859,
           "resourceSize": 7560
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406909,
+          "transferSize": 406905,
           "resourceSize": 475298
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5679,
+          "transferSize": 5676,
           "resourceSize": 25235
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10184,
+          "transferSize": 10161,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200253,
+          "transferSize": 200227,
           "resourceSize": 294007
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2712,
+          "transferSize": 2709,
           "resourceSize": 7002
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406755,
+          "transferSize": 406758,
           "resourceSize": 474740
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2881,
+          "transferSize": 2879,
           "resourceSize": 7601
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406928,
+          "transferSize": 406922,
           "resourceSize": 475339
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2708,
+          "transferSize": 2704,
           "resourceSize": 6941
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406754,
+          "transferSize": 406752,
           "resourceSize": 474679
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2973,
+          "transferSize": 2971,
           "resourceSize": 7743
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407020,
+          "transferSize": 407025,
           "resourceSize": 475481
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3148,
+          "transferSize": 3147,
           "resourceSize": 8712
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 408042,
+          "transferSize": 408037,
           "resourceSize": 477130
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3117,
+          "transferSize": 3115,
           "resourceSize": 8075
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413340,
+          "transferSize": 413335,
           "resourceSize": 488457
         }
       },

--- a/.github/page_size_audit_results/v1.45.3.json
+++ b/.github/page_size_audit_results/v1.45.3.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:04:07.919Z"
+    "generatedAt": "2025-11-27T17:06:18.962Z"
   },
-  "timestamp": "2025-11-27T16:04:07.919Z",
+  "timestamp": "2025-11-27T17:06:18.962Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2862,
+          "transferSize": 2860,
           "resourceSize": 7533
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406932,
+          "transferSize": 406934,
           "resourceSize": 475312
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2862,
+          "transferSize": 2859,
           "resourceSize": 7560
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406930,
+          "transferSize": 406929,
           "resourceSize": 475339
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5685,
+          "transferSize": 5681,
           "resourceSize": 25288
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10163,
+          "transferSize": 10199,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200260,
+          "transferSize": 200292,
           "resourceSize": 294101
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2727,
+          "transferSize": 2725,
           "resourceSize": 7112
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407072,
+          "transferSize": 407076,
           "resourceSize": 475005
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2883,
+          "transferSize": 2880,
           "resourceSize": 7697
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407188,
+          "transferSize": 407193,
           "resourceSize": 475549
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2708,
+          "transferSize": 2706,
           "resourceSize": 6941
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406773,
+          "transferSize": 406776,
           "resourceSize": 474720
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2974,
+          "transferSize": 2973,
           "resourceSize": 7743
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407048,
+          "transferSize": 407044,
           "resourceSize": 475522
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3150,
+          "transferSize": 3149,
           "resourceSize": 8712
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 408060,
+          "transferSize": 408066,
           "resourceSize": 477172
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3119,
+          "transferSize": 3118,
           "resourceSize": 8075
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413364,
+          "transferSize": 413367,
           "resourceSize": 488498
         }
       },

--- a/.github/page_size_audit_results/v1.45.4.json
+++ b/.github/page_size_audit_results/v1.45.4.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:10.730Z"
+    "generatedAt": "2025-11-27T17:06:38.162Z"
   },
-  "timestamp": "2025-11-27T16:06:10.730Z",
+  "timestamp": "2025-11-27T17:06:38.163Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2860,
+          "transferSize": 2863,
           "resourceSize": 7533
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406925,
+          "transferSize": 406932,
           "resourceSize": 475312
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2860,
+          "transferSize": 2863,
           "resourceSize": 7560
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406927,
+          "transferSize": 406935,
           "resourceSize": 475339
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10196,
+          "transferSize": 10209,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 200292,
+          "transferSize": 200305,
           "resourceSize": 294101
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2727,
+          "transferSize": 2729,
           "resourceSize": 7112
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407076,
+          "transferSize": 407072,
           "resourceSize": 475005
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2882,
+          "transferSize": 2883,
           "resourceSize": 7697
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407189,
+          "transferSize": 407190,
           "resourceSize": 475549
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2708,
+          "transferSize": 2710,
           "resourceSize": 6941
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406771,
+          "transferSize": 406776,
           "resourceSize": 474720
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2974,
+          "transferSize": 2977,
           "resourceSize": 7743
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407039,
+          "transferSize": 407046,
           "resourceSize": 475522
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3149,
+          "transferSize": 3151,
           "resourceSize": 8712
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 408057,
+          "transferSize": 408061,
           "resourceSize": 477172
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3120,
+          "transferSize": 3122,
           "resourceSize": 8075
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 413365,
+          "transferSize": 413370,
           "resourceSize": 488498
         }
       },

--- a/.github/page_size_audit_results/v1.46.0.json
+++ b/.github/page_size_audit_results/v1.46.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.46.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:55.181Z"
+    "generatedAt": "2025-11-27T17:06:47.128Z"
   },
-  "timestamp": "2025-11-27T16:03:55.181Z",
+  "timestamp": "2025-11-27T17:06:47.128Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2881,
+          "transferSize": 2883,
           "resourceSize": 7719
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407523,
+          "transferSize": 407529,
           "resourceSize": 474479
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407080,
+          "transferSize": 407076,
           "resourceSize": 474144
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5680,
+          "transferSize": 5685,
           "resourceSize": 25239
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10158,
+          "transferSize": 10204,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 199774,
+          "transferSize": 199825,
           "resourceSize": 292320
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2703,
+          "transferSize": 2707,
           "resourceSize": 7063
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406570,
+          "transferSize": 406577,
           "resourceSize": 473214
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2870,
+          "transferSize": 2873,
           "resourceSize": 7672
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406694,
+          "transferSize": 406699,
           "resourceSize": 473782
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2685,
+          "transferSize": 2690,
           "resourceSize": 6892
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406274,
+          "transferSize": 406280,
           "resourceSize": 472929
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2962,
+          "transferSize": 2965,
           "resourceSize": 7718
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406549,
+          "transferSize": 406553,
           "resourceSize": 473755
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3140,
+          "transferSize": 3143,
           "resourceSize": 8687
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 407575,
+          "transferSize": 407578,
           "resourceSize": 475405
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3101,
+          "transferSize": 3105,
           "resourceSize": 8026
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.47.0.json
+++ b/.github/page_size_audit_results/v1.47.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.47.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:50.991Z"
+    "generatedAt": "2025-11-27T17:06:40.269Z"
   },
-  "timestamp": "2025-11-27T16:03:50.992Z",
+  "timestamp": "2025-11-27T17:06:40.269Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2881,
+          "transferSize": 2882,
           "resourceSize": 7714
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407525,
+          "transferSize": 407530,
           "resourceSize": 474474
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2866,
+          "transferSize": 2868,
           "resourceSize": 7641
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 407086,
+          "transferSize": 407083,
           "resourceSize": 474139
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10186,
+          "transferSize": 10183,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 199804,
+          "transferSize": 199801,
           "resourceSize": 292310
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2705,
+          "transferSize": 2707,
           "resourceSize": 7058
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406574,
+          "transferSize": 406582,
           "resourceSize": 473209
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2873,
+          "transferSize": 2875,
           "resourceSize": 7667
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406698,
+          "transferSize": 406703,
           "resourceSize": 473777
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2686,
+          "transferSize": 2687,
           "resourceSize": 6887
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406272,
+          "transferSize": 406276,
           "resourceSize": 472924
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2963,
+          "transferSize": 2964,
           "resourceSize": 7713
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406552,
+          "transferSize": 406558,
           "resourceSize": 473750
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3144,
+          "transferSize": 3148,
           "resourceSize": 8682
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 407578,
+          "transferSize": 407579,
           "resourceSize": 475400
         }
       },

--- a/.github/page_size_audit_results/v1.48.0.json
+++ b/.github/page_size_audit_results/v1.48.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:05:57.929Z"
+    "generatedAt": "2025-11-27T17:06:31.545Z"
   },
-  "timestamp": "2025-11-27T16:05:57.930Z",
+  "timestamp": "2025-11-27T17:06:31.545Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2848,
+          "transferSize": 2843,
           "resourceSize": 7694
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406477,
+          "transferSize": 406475,
           "resourceSize": 471404
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2835,
+          "transferSize": 2830,
           "resourceSize": 7621
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 406036,
+          "transferSize": 406032,
           "resourceSize": 471069
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5647,
+          "transferSize": 5639,
           "resourceSize": 25100
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10209,
+          "transferSize": 10179,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 197757,
+          "transferSize": 197719,
           "resourceSize": 287033
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2672,
+          "transferSize": 2668,
           "resourceSize": 7038
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405532,
+          "transferSize": 405530,
           "resourceSize": 470139
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2840,
+          "transferSize": 2834,
           "resourceSize": 7647
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405664,
+          "transferSize": 405645,
           "resourceSize": 470707
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2651,
+          "transferSize": 2647,
           "resourceSize": 6867
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405232,
+          "transferSize": 405230,
           "resourceSize": 469854
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2929,
+          "transferSize": 2927,
           "resourceSize": 7693
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 405505,
+          "transferSize": 405510,
           "resourceSize": 470680
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3111,
+          "transferSize": 3107,
           "resourceSize": 8662
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 406541,
+          "transferSize": 406533,
           "resourceSize": 472330
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3037,
+          "transferSize": 3033,
           "resourceSize": 7781
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 407983,
+          "transferSize": 407974,
           "resourceSize": 472607
         }
       },

--- a/.github/page_size_audit_results/v1.48.1.json
+++ b/.github/page_size_audit_results/v1.48.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:40.787Z"
+    "generatedAt": "2025-11-27T17:03:52.685Z"
   },
-  "timestamp": "2025-11-27T16:03:40.787Z",
+  "timestamp": "2025-11-27T17:03:52.686Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2823,
+          "transferSize": 2822,
           "resourceSize": 7918
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 74630,
+          "transferSize": 74631,
           "resourceSize": 148282
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2816,
+          "transferSize": 2817,
           "resourceSize": 7846
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 74194,
+          "transferSize": 74191,
           "resourceSize": 147948
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5528,
+          "transferSize": 5527,
           "resourceSize": 24554
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10205,
+          "transferSize": 10202,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 76109,
+          "transferSize": 76105,
           "resourceSize": 173443
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2651,
+          "transferSize": 2650,
           "resourceSize": 7267
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 73682,
+          "transferSize": 73679,
           "resourceSize": 147022
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2814,
+          "transferSize": 2816,
           "resourceSize": 7872
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 73801,
+          "transferSize": 73808,
           "resourceSize": 147586
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2630,
+          "transferSize": 2627,
           "resourceSize": 7096
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 73378,
+          "transferSize": 73379,
           "resourceSize": 146737
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2904,
+          "transferSize": 2905,
           "resourceSize": 7918
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 73658,
+          "transferSize": 73659,
           "resourceSize": 147559
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3138,
+          "transferSize": 3137,
           "resourceSize": 9332
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 781,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 74736,
+          "transferSize": 74746,
           "resourceSize": 149654
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3012,
+          "transferSize": 3011,
           "resourceSize": 7981
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 1130,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 76136,
+          "transferSize": 76127,
           "resourceSize": 149461
         }
       },

--- a/.github/page_size_audit_results/v1.48.2.json
+++ b/.github/page_size_audit_results/v1.48.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:17.427Z"
+    "generatedAt": "2025-11-27T17:09:03.402Z"
   },
-  "timestamp": "2025-11-27T16:06:17.428Z",
+  "timestamp": "2025-11-27T17:09:03.402Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2841,
+          "transferSize": 2844,
           "resourceSize": 7951
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 73940,
+          "transferSize": 73934,
           "resourceSize": 144568
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2862,
+          "transferSize": 2866,
           "resourceSize": 8181
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 74206,
+          "transferSize": 74205,
           "resourceSize": 144880
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5546,
+          "transferSize": 5550,
           "resourceSize": 24656
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10199,
+          "transferSize": 10174,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 76383,
+          "transferSize": 76362,
           "resourceSize": 172339
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2648,
+          "transferSize": 2652,
           "resourceSize": 7267
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 72846,
+          "transferSize": 72849,
           "resourceSize": 143153
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2898,
+          "transferSize": 2903,
           "resourceSize": 8205
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 74472,
+          "transferSize": 74479,
           "resourceSize": 144977
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2629,
+          "transferSize": 2633,
           "resourceSize": 7096
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 72550,
+          "transferSize": 72548,
           "resourceSize": 142868
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2987,
+          "transferSize": 2991,
           "resourceSize": 8251
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 74330,
+          "transferSize": 74335,
           "resourceSize": 144951
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3209,
+          "transferSize": 3213,
           "resourceSize": 9656
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 76162,
+          "transferSize": 76158,
           "resourceSize": 149274
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3020,
+          "transferSize": 3027,
           "resourceSize": 8083
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1118,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 76313,
+          "transferSize": 76315,
           "resourceSize": 148014
         }
       },

--- a/.github/page_size_audit_results/v1.48.3.json
+++ b/.github/page_size_audit_results/v1.48.3.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:06:32.197Z"
+    "generatedAt": "2025-11-27T17:06:55.059Z"
   },
-  "timestamp": "2025-11-27T16:06:32.197Z",
+  "timestamp": "2025-11-27T17:06:55.059Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2798,
+          "transferSize": 2801,
           "resourceSize": 7944
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 74385,
+          "transferSize": 74392,
           "resourceSize": 144475
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2817,
+          "transferSize": 2818,
           "resourceSize": 8042
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 74651,
+          "transferSize": 74652,
           "resourceSize": 144655
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5541,
+          "transferSize": 5547,
           "resourceSize": 24786
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10168,
+          "transferSize": 10210,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 77285,
+          "transferSize": 77333,
           "resourceSize": 172404
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2625,
+          "transferSize": 2626,
           "resourceSize": 7287
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 73325,
+          "transferSize": 73327,
           "resourceSize": 143097
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2830,
+          "transferSize": 2833,
           "resourceSize": 8185
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 74906,
+          "transferSize": 74904,
           "resourceSize": 144871
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2612,
+          "transferSize": 2615,
           "resourceSize": 7110
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 73044,
+          "transferSize": 73037,
           "resourceSize": 142806
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2944,
+          "transferSize": 2945,
           "resourceSize": 8226
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 74777,
+          "transferSize": 74784,
           "resourceSize": 144840
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3160,
+          "transferSize": 3163,
           "resourceSize": 9630
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 76599,
+          "transferSize": 76609,
           "resourceSize": 149162
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2999,
+          "transferSize": 3003,
           "resourceSize": 8100
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 1117,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 76791,
+          "transferSize": 76803,
           "resourceSize": 147955
         }
       },

--- a/.github/page_size_audit_results/v1.5.0.json
+++ b/.github/page_size_audit_results/v1.5.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.5.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:12.985Z"
+    "generatedAt": "2025-11-27T17:03:55.231Z"
   },
-  "timestamp": "2025-11-27T16:01:12.985Z",
+  "timestamp": "2025-11-27T17:03:55.231Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2581,
+          "transferSize": 2583,
           "resourceSize": 5377
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2449,
+          "transferSize": 2452,
           "resourceSize": 5093
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690382,
+          "transferSize": 690389,
           "resourceSize": 1366699
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5213,
+          "transferSize": 5217,
           "resourceSize": 16731
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4973,
+          "transferSize": 4983,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479246,
+          "transferSize": 479260,
           "resourceSize": 1172217
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2275,
+          "transferSize": 2278,
           "resourceSize": 4477
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690206,
+          "transferSize": 690208,
           "resourceSize": 1366083
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2439,
+          "transferSize": 2443,
           "resourceSize": 4903
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690376,
+          "transferSize": 690373,
           "resourceSize": 1366509
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2289,
+          "transferSize": 2292,
           "resourceSize": 4459
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690223,
+          "transferSize": 690226,
           "resourceSize": 1366065
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2502,
+          "transferSize": 2504,
           "resourceSize": 5013
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690432,
+          "transferSize": 690440,
           "resourceSize": 1366619
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3088,
+          "transferSize": 3091,
           "resourceSize": 7130
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691020,
+          "transferSize": 691025,
           "resourceSize": 1368736
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3145,
+          "transferSize": 3147,
           "resourceSize": 6409
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1129,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697505,
+          "transferSize": 697511,
           "resourceSize": 1380411
         }
       },

--- a/.github/page_size_audit_results/v1.6.0.json
+++ b/.github/page_size_audit_results/v1.6.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.6.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:03.380Z"
+    "generatedAt": "2025-11-27T17:03:54.681Z"
   },
-  "timestamp": "2025-11-27T16:01:03.380Z",
+  "timestamp": "2025-11-27T17:03:54.682Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2582,
+          "transferSize": 2581,
           "resourceSize": 5388
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690529,
+          "transferSize": 690525,
           "resourceSize": 1367017
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2452,
+          "transferSize": 2451,
           "resourceSize": 5104
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690399,
+          "transferSize": 690400,
           "resourceSize": 1366733
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5216,
+          "transferSize": 5215,
           "resourceSize": 16742
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4968,
+          "transferSize": 4973,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479257,
+          "transferSize": 479261,
           "resourceSize": 1172251
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2280,
+          "transferSize": 2276,
           "resourceSize": 4488
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690224,
+          "transferSize": 690220,
           "resourceSize": 1366117
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2443,
+          "transferSize": 2441,
           "resourceSize": 4914
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 762,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690388,
+          "transferSize": 690380,
           "resourceSize": 1366543
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2293,
+          "transferSize": 2291,
           "resourceSize": 4470
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690243,
+          "transferSize": 690231,
           "resourceSize": 1366099
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2505,
+          "transferSize": 2504,
           "resourceSize": 5024
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690452,
+          "transferSize": 690449,
           "resourceSize": 1366653
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3094,
+          "transferSize": 3090,
           "resourceSize": 7141
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691037,
+          "transferSize": 691038,
           "resourceSize": 1368770
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3149,
+          "transferSize": 3146,
           "resourceSize": 6420
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 697516,
+          "transferSize": 697518,
           "resourceSize": 1380445
         }
       },

--- a/.github/page_size_audit_results/v1.6.1.json
+++ b/.github/page_size_audit_results/v1.6.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.6.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:05.912Z"
+    "generatedAt": "2025-11-27T17:03:54.298Z"
   },
-  "timestamp": "2025-11-27T16:01:05.912Z",
+  "timestamp": "2025-11-27T17:03:54.298Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2699,
-          "resourceSize": 5763
+          "transferSize": 2584,
+          "resourceSize": 5389
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 181924,
-          "resourceSize": 534981
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318191,
-          "resourceSize": 710799
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 728381,
-          "resourceSize": 1475960
+          "transferSize": 690527,
+          "resourceSize": 1367030
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2574,
-          "resourceSize": 5479
+          "transferSize": 2462,
+          "resourceSize": 5105
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 181924,
-          "resourceSize": 534981
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318191,
-          "resourceSize": 710799
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 728251,
-          "resourceSize": 1475676
+          "transferSize": 690409,
+          "resourceSize": 1366746
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5329,
-          "resourceSize": 17218
+          "transferSize": 5220,
+          "resourceSize": 16743
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 187995,
-          "resourceSize": 547377
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 318191,
-          "resourceSize": 710799
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4965,
+          "transferSize": 4967,
           "resourceSize": 5685
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 517098,
-          "resourceSize": 1281295
+          "transferSize": 479263,
+          "resourceSize": 1172264
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2397,
-          "resourceSize": 4863
+          "transferSize": 2280,
+          "resourceSize": 4489
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 181924,
-          "resourceSize": 534981
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318191,
-          "resourceSize": 710799
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 728077,
-          "resourceSize": 1475060
+          "transferSize": 690230,
+          "resourceSize": 1366130
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2564,
-          "resourceSize": 5289
+          "transferSize": 2444,
+          "resourceSize": 4915
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 181924,
-          "resourceSize": 534981
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318191,
-          "resourceSize": 710799
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 728237,
-          "resourceSize": 1475486
+          "transferSize": 690390,
+          "resourceSize": 1366556
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2411,
-          "resourceSize": 4845
+          "transferSize": 2295,
+          "resourceSize": 4471
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 181924,
-          "resourceSize": 534981
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318191,
-          "resourceSize": 710799
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 728087,
-          "resourceSize": 1475042
+          "transferSize": 690244,
+          "resourceSize": 1366112
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2626,
-          "resourceSize": 5399
+          "transferSize": 2507,
+          "resourceSize": 5025
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 181924,
-          "resourceSize": 534981
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318191,
-          "resourceSize": 710799
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 728302,
-          "resourceSize": 1475596
+          "transferSize": 690453,
+          "resourceSize": 1366666
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3207,
-          "resourceSize": 7516
+          "transferSize": 3095,
+          "resourceSize": 7142
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 181924,
-          "resourceSize": 534981
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318191,
-          "resourceSize": 710799
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 728885,
-          "resourceSize": 1477713
+          "transferSize": 691043,
+          "resourceSize": 1368783
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3262,
-          "resourceSize": 6795
+          "transferSize": 3151,
+          "resourceSize": 6421
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 187995,
-          "resourceSize": 547377
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 318191,
-          "resourceSize": 710799
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 619,
-          "resourceSize": 217
+          "transferSize": 618,
+          "resourceSize": 216
         },
         "total": {
-          "transferSize": 735368,
-          "resourceSize": 1489389
+          "transferSize": 697529,
+          "resourceSize": 1380458
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.7.0.json
+++ b/.github/page_size_audit_results/v1.7.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.7.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:25.928Z"
+    "generatedAt": "2025-11-27T17:04:18.552Z"
   },
-  "timestamp": "2025-11-27T16:03:25.929Z",
+  "timestamp": "2025-11-27T17:04:18.552Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2631,
+          "transferSize": 2628,
           "resourceSize": 5461
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2507,
+          "transferSize": 2505,
           "resourceSize": 5177
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690882,
+          "transferSize": 690876,
           "resourceSize": 1366818
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5220,
+          "transferSize": 5218,
           "resourceSize": 16743
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4968,
+          "transferSize": 4967,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479264,
+          "transferSize": 479261,
           "resourceSize": 1172264
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2327,
+          "transferSize": 2325,
           "resourceSize": 4561
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690697,
+          "transferSize": 690701,
           "resourceSize": 1366202
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2496,
+          "transferSize": 2493,
           "resourceSize": 4987
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690869,
+          "transferSize": 690870,
           "resourceSize": 1366628
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2342,
+          "transferSize": 2339,
           "resourceSize": 4543
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690720,
+          "transferSize": 690713,
           "resourceSize": 1366184
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2554,
+          "transferSize": 2551,
           "resourceSize": 5097
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690934,
+          "transferSize": 690924,
           "resourceSize": 1366738
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3191,
+          "transferSize": 3188,
           "resourceSize": 7414
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691565,
+          "transferSize": 691559,
           "resourceSize": 1593061
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3194,
+          "transferSize": 3193,
           "resourceSize": 6493
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 697992,
+          "transferSize": 697996,
           "resourceSize": 1380531
         }
       },

--- a/.github/page_size_audit_results/v1.8.0.json
+++ b/.github/page_size_audit_results/v1.8.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:00:57.235Z"
+    "generatedAt": "2025-11-27T17:03:57.947Z"
   },
-  "timestamp": "2025-11-27T16:00:57.235Z",
+  "timestamp": "2025-11-27T17:03:57.947Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691004,
+          "transferSize": 691009,
           "resourceSize": 1367107
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2509,
+          "transferSize": 2508,
           "resourceSize": 5182
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690881,
+          "transferSize": 690878,
           "resourceSize": 1366823
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4996,
+          "transferSize": 4963,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479289,
+          "transferSize": 479256,
           "resourceSize": 1172269
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690702,
+          "transferSize": 690707,
           "resourceSize": 1366207
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2498,
+          "transferSize": 2496,
           "resourceSize": 4992
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690868,
+          "transferSize": 690872,
           "resourceSize": 1366633
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690722,
+          "transferSize": 690720,
           "resourceSize": 1366189
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690931,
+          "transferSize": 690934,
           "resourceSize": 1366743
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691569,
+          "transferSize": 691574,
           "resourceSize": 1593066
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1130,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 698000,
+          "transferSize": 698005,
           "resourceSize": 1380536
         }
       },

--- a/.github/page_size_audit_results/v1.8.1.json
+++ b/.github/page_size_audit_results/v1.8.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:03:33.056Z"
+    "generatedAt": "2025-11-27T17:03:48.770Z"
   },
-  "timestamp": "2025-11-27T16:03:33.057Z",
+  "timestamp": "2025-11-27T17:03:48.771Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691000,
+          "transferSize": 690999,
           "resourceSize": 1367107
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690882,
+          "transferSize": 690879,
           "resourceSize": 1366823
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4962,
+          "transferSize": 4971,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479253,
+          "transferSize": 479262,
           "resourceSize": 1172269
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690698,
+          "transferSize": 690699,
           "resourceSize": 1366207
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2495,
+          "transferSize": 2493,
           "resourceSize": 4992
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690871,
+          "transferSize": 690866,
           "resourceSize": 1366633
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690715,
+          "transferSize": 690714,
           "resourceSize": 1366189
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2552,
+          "transferSize": 2551,
           "resourceSize": 5102
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690929,
+          "transferSize": 690931,
           "resourceSize": 1366743
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691566,
+          "transferSize": 691564,
           "resourceSize": 1593066
         }
       },

--- a/.github/page_size_audit_results/v1.9.0.json
+++ b/.github/page_size_audit_results/v1.9.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.9.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-11-27T16:01:03.833Z"
+    "generatedAt": "2025-11-27T17:03:55.560Z"
   },
-  "timestamp": "2025-11-27T16:01:03.833Z",
+  "timestamp": "2025-11-27T17:03:55.560Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2639,
+          "transferSize": 2637,
           "resourceSize": 5505
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 781,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691013,
+          "transferSize": 691023,
           "resourceSize": 1367146
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2515,
+          "transferSize": 2513,
           "resourceSize": 5221
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690893,
+          "transferSize": 690890,
           "resourceSize": 1366862
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5233,
+          "transferSize": 5232,
           "resourceSize": 16787
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4955,
+          "transferSize": 4974,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 479264,
+          "transferSize": 479282,
           "resourceSize": 1172308
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2337,
+          "transferSize": 2335,
           "resourceSize": 4605
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690712,
+          "transferSize": 690707,
           "resourceSize": 1366246
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2506,
+          "transferSize": 2504,
           "resourceSize": 5031
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690877,
+          "transferSize": 690873,
           "resourceSize": 1366672
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2350,
+          "transferSize": 2348,
           "resourceSize": 4587
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690723,
+          "transferSize": 690719,
           "resourceSize": 1366228
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2562,
+          "transferSize": 2560,
           "resourceSize": 5141
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 690933,
+          "transferSize": 690932,
           "resourceSize": 1366782
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3195,
+          "transferSize": 3197,
           "resourceSize": 7458
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 216
         },
         "total": {
-          "transferSize": 691564,
+          "transferSize": 691568,
           "resourceSize": 1593105
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3207,
+          "transferSize": 3203,
           "resourceSize": 6537
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 217
         },
         "total": {
-          "transferSize": 698005,
+          "transferSize": 698001,
           "resourceSize": 1380575
         }
       },


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.0.0
- **End Version:** latest

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Size Audit workflow*