### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.0.0.json
+++ b/.github/page_size_audit_results/v1.0.0.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.0.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:38.524Z"
+    "generatedAt": "2025-12-24T18:59:13.905Z"
   },
-  "timestamp": "2025-12-24T18:08:38.525Z",
+  "timestamp": "2025-12-24T18:59:13.905Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693918,
+          "transferSize": 693913,
           "resourceSize": 1371358
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 3350,
+          "transferSize": 3408,
           "resourceSize": 3746
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480910,
+          "transferSize": 480968,
           "resourceSize": 1173873
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2182,
+          "transferSize": 2183,
           "resourceSize": 4664
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693585,
+          "transferSize": 693583,
           "resourceSize": 1370340
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693744,
+          "transferSize": 693745,
           "resourceSize": 1370766
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2207,
+          "transferSize": 2208,
           "resourceSize": 4681
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693610,
+          "transferSize": 693607,
           "resourceSize": 1370357
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2403,
+          "transferSize": 2404,
           "resourceSize": 5200
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693810,
+          "transferSize": 693804,
           "resourceSize": 1370876
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3102,
+          "transferSize": 3103,
           "resourceSize": 7641
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918679,
+          "transferSize": 918680,
           "resourceSize": 1597323
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3017,
+          "transferSize": 3018,
           "resourceSize": 6526
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 700842,
+          "transferSize": 700844,
           "resourceSize": 1384598
         }
       },

--- a/.github/page_size_audit_results/v1.0.1.json
+++ b/.github/page_size_audit_results/v1.0.1.json
@@ -1,38 +1,38 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.0.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:42.180Z"
+    "generatedAt": "2025-12-24T18:56:57.050Z"
   },
-  "timestamp": "2025-12-24T18:08:42.181Z",
+  "timestamp": "2025-12-24T18:56:57.051Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2208,
-          "resourceSize": 4726
+          "transferSize": 2300,
+          "resourceSize": 5007
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 150042,
-          "resourceSize": 438367
+          "transferSize": 297147,
+          "resourceSize": 945672
         },
         "stylesheet": {
-          "transferSize": 316171,
-          "resourceSize": 704671
+          "transferSize": 317623,
+          "resourceSize": 705957
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693728,
-          "resourceSize": 1372240
+          "transferSize": 842379,
+          "resourceSize": 1881112
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2047,
-          "resourceSize": 4235
+          "transferSize": 2134,
+          "resourceSize": 4516
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 150042,
-          "resourceSize": 438367
+          "transferSize": 297147,
+          "resourceSize": 945672
         },
         "stylesheet": {
-          "transferSize": 316171,
-          "resourceSize": 704671
+          "transferSize": 317623,
+          "resourceSize": 705957
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693563,
-          "resourceSize": 1371749
+          "transferSize": 842209,
+          "resourceSize": 1880621
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 4749,
-          "resourceSize": 15300
+          "transferSize": 4948,
+          "resourceSize": 16014
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 156113,
-          "resourceSize": 450763
+          "transferSize": 699134,
+          "resourceSize": 2104097
         },
         "stylesheet": {
-          "transferSize": 316171,
-          "resourceSize": 704671
+          "transferSize": 317623,
+          "resourceSize": 705957
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 3419,
-          "resourceSize": 3746
+          "transferSize": 6277,
+          "resourceSize": 5044
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480814,
-          "resourceSize": 1174755
+          "transferSize": 1028344,
+          "resourceSize": 2831387
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1885,
-          "resourceSize": 3708
+          "transferSize": 1972,
+          "resourceSize": 3989
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 150042,
-          "resourceSize": 438367
+          "transferSize": 297147,
+          "resourceSize": 945672
         },
         "stylesheet": {
-          "transferSize": 316171,
-          "resourceSize": 704671
+          "transferSize": 317623,
+          "resourceSize": 705957
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693403,
-          "resourceSize": 1371222
+          "transferSize": 842048,
+          "resourceSize": 1880094
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2043,
-          "resourceSize": 4134
+          "transferSize": 2131,
+          "resourceSize": 4415
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 150042,
-          "resourceSize": 438367
+          "transferSize": 297147,
+          "resourceSize": 945672
         },
         "stylesheet": {
-          "transferSize": 316171,
-          "resourceSize": 704671
+          "transferSize": 317623,
+          "resourceSize": 705957
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693563,
-          "resourceSize": 1371648
+          "transferSize": 842204,
+          "resourceSize": 1880520
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1908,
-          "resourceSize": 3725
+          "transferSize": 1996,
+          "resourceSize": 4006
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 150042,
-          "resourceSize": 438367
+          "transferSize": 297147,
+          "resourceSize": 945672
         },
         "stylesheet": {
-          "transferSize": 316171,
-          "resourceSize": 704671
+          "transferSize": 317623,
+          "resourceSize": 705957
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693424,
-          "resourceSize": 1371239
+          "transferSize": 842074,
+          "resourceSize": 1880111
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2117,
-          "resourceSize": 4244
+          "transferSize": 2203,
+          "resourceSize": 4525
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 150042,
-          "resourceSize": 438367
+          "transferSize": 297147,
+          "resourceSize": 945672
         },
         "stylesheet": {
-          "transferSize": 316171,
-          "resourceSize": 704671
+          "transferSize": 317623,
+          "resourceSize": 705957
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 693639,
-          "resourceSize": 1371758
+          "transferSize": 842281,
+          "resourceSize": 1880631
         }
       },
       "themeResources": {
@@ -496,12 +496,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 690750,
-          "resourceSize": 1367319
+          "transferSize": 690751,
+          "resourceSize": 1367320
         }
       }
     },
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2811,
-          "resourceSize": 6685
+          "transferSize": 2898,
+          "resourceSize": 6966
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 150042,
-          "resourceSize": 438367
+          "transferSize": 297147,
+          "resourceSize": 945672
         },
         "stylesheet": {
-          "transferSize": 316171,
-          "resourceSize": 704671
+          "transferSize": 317623,
+          "resourceSize": 705957
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 918501,
-          "resourceSize": 1598205
+          "transferSize": 1067149,
+          "resourceSize": 2107078
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 914925,
-          "resourceSize": 1591325
+          "transferSize": 914926,
+          "resourceSize": 1591326
         }
       }
     },
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2730,
-          "resourceSize": 5570
+          "transferSize": 2930,
+          "resourceSize": 6302
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 156113,
-          "resourceSize": 450763
+          "transferSize": 699134,
+          "resourceSize": 2104097
         },
         "stylesheet": {
-          "transferSize": 316171,
-          "resourceSize": 704671
+          "transferSize": 317623,
+          "resourceSize": 705957
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
-          "resourceSize": 195
+          "transferSize": 3996,
+          "resourceSize": 1493
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 700676,
-          "resourceSize": 1385480
+          "transferSize": 1248221,
+          "resourceSize": 3042131
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 694810,
-          "resourceSize": 1377877
+          "transferSize": 694811,
+          "resourceSize": 1377878
         }
       }
     }

--- a/.github/page_size_audit_results/v1.1.0.json
+++ b/.github/page_size_audit_results/v1.1.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:42.556Z"
+    "generatedAt": "2025-12-24T18:53:58.147Z"
   },
-  "timestamp": "2025-12-24T18:08:42.556Z",
+  "timestamp": "2025-12-24T18:53:58.147Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2182,
+          "transferSize": 2180,
           "resourceSize": 4642
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693697,
+          "transferSize": 693695,
           "resourceSize": 1372156
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2040,
+          "transferSize": 2037,
           "resourceSize": 4219
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693564,
+          "transferSize": 693560,
           "resourceSize": 1371733
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 4744,
+          "transferSize": 4742,
           "resourceSize": 15284
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 3414,
+          "transferSize": 3413,
           "resourceSize": 3746
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480804,
+          "transferSize": 480801,
           "resourceSize": 1174739
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1879,
+          "transferSize": 1876,
           "resourceSize": 3692
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693398,
+          "transferSize": 693400,
           "resourceSize": 1371206
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2036,
+          "transferSize": 2035,
           "resourceSize": 4118
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693560,
+          "transferSize": 693554,
           "resourceSize": 1371632
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1903,
+          "transferSize": 1902,
           "resourceSize": 3709
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693417,
+          "transferSize": 693426,
           "resourceSize": 1371223
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2108,
+          "transferSize": 2106,
           "resourceSize": 4228
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693626,
+          "transferSize": 693622,
           "resourceSize": 1371742
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2805,
+          "transferSize": 2804,
           "resourceSize": 6669
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918502,
+          "transferSize": 918501,
           "resourceSize": 1598189
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2729,
+          "transferSize": 2725,
           "resourceSize": 5554
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.1.1.json
+++ b/.github/page_size_audit_results/v1.1.1.json
@@ -1,38 +1,38 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:09:04.668Z"
+    "generatedAt": "2025-12-24T18:56:51.482Z"
   },
-  "timestamp": "2025-12-24T18:09:04.668Z",
+  "timestamp": "2025-12-24T18:56:51.482Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2267,
-          "resourceSize": 4923
+          "transferSize": 2182,
+          "resourceSize": 4642
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297107,
-          "resourceSize": 945687
+          "transferSize": 150002,
+          "resourceSize": 438382
         },
         "stylesheet": {
-          "transferSize": 317608,
-          "resourceSize": 705909
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842297,
-          "resourceSize": 1880995
+          "transferSize": 693646,
+          "resourceSize": 1372123
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2123,
-          "resourceSize": 4500
+          "transferSize": 2040,
+          "resourceSize": 4219
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297107,
-          "resourceSize": 945687
+          "transferSize": 150002,
+          "resourceSize": 438382
         },
         "stylesheet": {
-          "transferSize": 317608,
-          "resourceSize": 705909
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842148,
-          "resourceSize": 1880572
+          "transferSize": 693507,
+          "resourceSize": 1371700
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5011,
-          "resourceSize": 16526
+          "transferSize": 4804,
+          "resourceSize": 15812
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 699094,
-          "resourceSize": 2104112
+          "transferSize": 156073,
+          "resourceSize": 450778
         },
         "stylesheet": {
-          "transferSize": 317608,
-          "resourceSize": 705909
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7266,
-          "resourceSize": 6411
+          "transferSize": 4400,
+          "resourceSize": 5113
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 1029341,
-          "resourceSize": 2833233
+          "transferSize": 481795,
+          "resourceSize": 1176601
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1960,
-          "resourceSize": 3973
+          "transferSize": 1879,
+          "resourceSize": 3692
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297107,
-          "resourceSize": 945687
+          "transferSize": 150002,
+          "resourceSize": 438382
         },
         "stylesheet": {
-          "transferSize": 317608,
-          "resourceSize": 705909
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841986,
-          "resourceSize": 1880045
+          "transferSize": 693343,
+          "resourceSize": 1371173
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2119,
-          "resourceSize": 4399
+          "transferSize": 2036,
+          "resourceSize": 4118
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297107,
-          "resourceSize": 945687
+          "transferSize": 150002,
+          "resourceSize": 438382
         },
         "stylesheet": {
-          "transferSize": 317608,
-          "resourceSize": 705909
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842142,
-          "resourceSize": 1880471
+          "transferSize": 693505,
+          "resourceSize": 1371599
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1985,
-          "resourceSize": 3990
+          "transferSize": 1900,
+          "resourceSize": 3709
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297107,
-          "resourceSize": 945687
+          "transferSize": 150002,
+          "resourceSize": 438382
         },
         "stylesheet": {
-          "transferSize": 317608,
-          "resourceSize": 705909
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842010,
-          "resourceSize": 1880062
+          "transferSize": 693366,
+          "resourceSize": 1371190
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2192,
-          "resourceSize": 4509
+          "transferSize": 2109,
+          "resourceSize": 4228
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297107,
-          "resourceSize": 945687
+          "transferSize": 150002,
+          "resourceSize": 438382
         },
         "stylesheet": {
-          "transferSize": 317608,
-          "resourceSize": 705909
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 842213,
-          "resourceSize": 1880582
+          "transferSize": 693574,
+          "resourceSize": 1371709
         }
       },
       "themeResources": {
@@ -496,12 +496,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 690696,
-          "resourceSize": 1367287
+          "transferSize": 690695,
+          "resourceSize": 1367286
         }
       }
     },
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2888,
-          "resourceSize": 6950
+          "transferSize": 2804,
+          "resourceSize": 6669
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297107,
-          "resourceSize": 945687
+          "transferSize": 150002,
+          "resourceSize": 438382
         },
         "stylesheet": {
-          "transferSize": 317608,
-          "resourceSize": 705909
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 1067084,
-          "resourceSize": 2107029
+          "transferSize": 918448,
+          "resourceSize": 1598156
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 914871,
-          "resourceSize": 1591293
+          "transferSize": 914870,
+          "resourceSize": 1591292
         }
       }
     },
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2920,
-          "resourceSize": 6286
+          "transferSize": 2731,
+          "resourceSize": 5554
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 699094,
-          "resourceSize": 2104112
+          "transferSize": 156073,
+          "resourceSize": 450778
         },
         "stylesheet": {
-          "transferSize": 317608,
-          "resourceSize": 705909
+          "transferSize": 316156,
+          "resourceSize": 704623
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3997,
-          "resourceSize": 1493
+          "transferSize": 1129,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 1248157,
-          "resourceSize": 3042082
+          "transferSize": 700626,
+          "resourceSize": 1385431
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 694756,
-          "resourceSize": 1377845
+          "transferSize": 694755,
+          "resourceSize": 1377844
         }
       }
     }

--- a/.github/page_size_audit_results/v1.1.2.json
+++ b/.github/page_size_audit_results/v1.1.2.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:45.380Z"
+    "generatedAt": "2025-12-24T18:54:01.720Z"
   },
-  "timestamp": "2025-12-24T18:08:45.381Z",
+  "timestamp": "2025-12-24T18:54:01.721Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2843,
+          "transferSize": 2844,
           "resourceSize": 6018
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 780,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692029,
+          "transferSize": 692040,
           "resourceSize": 1370026
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2709,
+          "transferSize": 2711,
           "resourceSize": 5743
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691897,
+          "transferSize": 691898,
           "resourceSize": 1369751
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5468,
+          "transferSize": 5466,
           "resourceSize": 17357
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4961,
+          "transferSize": 4967,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480741,
+          "transferSize": 480745,
           "resourceSize": 1175245
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691725,
+          "transferSize": 691727,
           "resourceSize": 1369135
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2698,
+          "transferSize": 2700,
           "resourceSize": 5553
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691889,
+          "transferSize": 691886,
           "resourceSize": 1369561
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2559,
+          "transferSize": 2560,
           "resourceSize": 5144
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691745,
+          "transferSize": 691743,
           "resourceSize": 1369152
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2757,
+          "transferSize": 2758,
           "resourceSize": 5663
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691946,
+          "transferSize": 691941,
           "resourceSize": 1369671
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3435,
+          "transferSize": 3436,
           "resourceSize": 8107
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 916794,
+          "transferSize": 916796,
           "resourceSize": 1596121
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1118,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 698986,
+          "transferSize": 698980,
           "resourceSize": 1383393
         }
       },

--- a/.github/page_size_audit_results/v1.1.3.json
+++ b/.github/page_size_audit_results/v1.1.3.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:51.982Z"
+    "generatedAt": "2025-12-24T18:54:01.792Z"
   },
-  "timestamp": "2025-12-24T18:05:51.982Z",
+  "timestamp": "2025-12-24T18:54:01.792Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2813,
+          "transferSize": 2816,
           "resourceSize": 5971
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691997,
+          "transferSize": 691998,
           "resourceSize": 1369979
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2683,
+          "transferSize": 2686,
           "resourceSize": 5683
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691865,
+          "transferSize": 691879,
           "resourceSize": 1369691
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5438,
+          "transferSize": 5441,
           "resourceSize": 17297
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4974,
+          "transferSize": 4968,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480724,
+          "transferSize": 480721,
           "resourceSize": 1175185
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2507,
+          "transferSize": 2510,
           "resourceSize": 5067
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691690,
+          "transferSize": 691696,
           "resourceSize": 1369075
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2671,
+          "transferSize": 2674,
           "resourceSize": 5493
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691858,
+          "transferSize": 691857,
           "resourceSize": 1369501
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2527,
+          "transferSize": 2531,
           "resourceSize": 5084
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691718,
+          "transferSize": 691714,
           "resourceSize": 1369092
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2730,
+          "transferSize": 2731,
           "resourceSize": 5603
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691918,
+          "transferSize": 691915,
           "resourceSize": 1369611
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3413,
+          "transferSize": 3414,
           "resourceSize": 8062
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3348,
+          "transferSize": 3353,
           "resourceSize": 6929
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 698957,
+          "transferSize": 698964,
           "resourceSize": 1383333
         }
       },

--- a/.github/page_size_audit_results/v1.1.4.json
+++ b/.github/page_size_audit_results/v1.1.4.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:50.162Z"
+    "generatedAt": "2025-12-24T18:56:41.568Z"
   },
-  "timestamp": "2025-12-24T18:05:50.162Z",
+  "timestamp": "2025-12-24T18:56:41.568Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2818,
+          "transferSize": 2814,
           "resourceSize": 5977
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692003,
+          "transferSize": 692001,
           "resourceSize": 1369985
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2688,
+          "transferSize": 2686,
           "resourceSize": 5689
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691874,
+          "transferSize": 691869,
           "resourceSize": 1369697
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5440,
+          "transferSize": 5437,
           "resourceSize": 17303
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4974,
+          "transferSize": 4992,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480726,
+          "transferSize": 480741,
           "resourceSize": 1175191
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2512,
+          "transferSize": 2509,
           "resourceSize": 5073
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2675,
+          "transferSize": 2673,
           "resourceSize": 5499
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691864,
+          "transferSize": 691856,
           "resourceSize": 1369507
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2532,
+          "transferSize": 2529,
           "resourceSize": 5090
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691721,
+          "transferSize": 691709,
           "resourceSize": 1369098
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2734,
+          "transferSize": 2731,
           "resourceSize": 5609
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691919,
+          "transferSize": 691913,
           "resourceSize": 1369617
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3418,
+          "transferSize": 3415,
           "resourceSize": 8068
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 916783,
+          "transferSize": 916775,
           "resourceSize": 1596082
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3354,
+          "transferSize": 3350,
           "resourceSize": 6935
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 698965,
+          "transferSize": 698958,
           "resourceSize": 1383339
         }
       },

--- a/.github/page_size_audit_results/v1.10.0.json
+++ b/.github/page_size_audit_results/v1.10.0.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:37.843Z"
+    "generatedAt": "2025-12-24T18:59:54.968Z"
   },
-  "timestamp": "2025-12-24T18:11:37.843Z",
+  "timestamp": "2025-12-24T18:59:54.968Z",
   "results": [
     {
       "url": "/",
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2600,
+          "transferSize": 2598,
           "resourceSize": 5713
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690716,
+          "transferSize": 690712,
           "resourceSize": 1367413
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5303,
+          "transferSize": 5304,
           "resourceSize": 17502
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4969,
+          "transferSize": 4993,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479092,
+          "transferSize": 479117,
           "resourceSize": 1173082
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2415,
+          "transferSize": 2412,
           "resourceSize": 5087
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690531,
+          "transferSize": 690527,
           "resourceSize": 1366787
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690702,
+          "transferSize": 690704,
           "resourceSize": 1367223
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2430,
+          "transferSize": 2428,
           "resourceSize": 5069
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690760,
+          "transferSize": 690761,
           "resourceSize": 1367333
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3261,
+          "transferSize": 3258,
           "resourceSize": 7788
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 762,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691377,
+          "transferSize": 691366,
           "resourceSize": 1593494
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3299,
+          "transferSize": 3297,
           "resourceSize": 6985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697841,
+          "transferSize": 697833,
           "resourceSize": 1381081
         }
       },

--- a/.github/page_size_audit_results/v1.10.1.json
+++ b/.github/page_size_audit_results/v1.10.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:40.736Z"
+    "generatedAt": "2025-12-24T18:56:49.940Z"
   },
-  "timestamp": "2025-12-24T18:08:40.736Z",
+  "timestamp": "2025-12-24T18:56:49.940Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2733,
+          "transferSize": 2734,
           "resourceSize": 6013
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690851,
+          "transferSize": 690847,
           "resourceSize": 1367713
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2599,
+          "transferSize": 2600,
           "resourceSize": 5713
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690719,
+          "transferSize": 690717,
           "resourceSize": 1367413
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5305,
+          "transferSize": 5304,
           "resourceSize": 17502
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4967,
+          "transferSize": 4958,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479092,
+          "transferSize": 479082,
           "resourceSize": 1173082
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690527,
+          "transferSize": 690532,
           "resourceSize": 1366787
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2589,
+          "transferSize": 2591,
           "resourceSize": 5523
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690704,
+          "transferSize": 690713,
           "resourceSize": 1367223
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690761,
+          "transferSize": 690763,
           "resourceSize": 1367333
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3296,
+          "transferSize": 3295,
           "resourceSize": 7951
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691415,
+          "transferSize": 691410,
           "resourceSize": 1593657
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3299,
+          "transferSize": 3298,
           "resourceSize": 6985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.10.2.json
+++ b/.github/page_size_audit_results/v1.10.2.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:48.040Z"
+    "generatedAt": "2025-12-24T18:56:46.634Z"
   },
-  "timestamp": "2025-12-24T18:05:48.040Z",
+  "timestamp": "2025-12-24T18:56:46.634Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2730,
+          "transferSize": 2734,
           "resourceSize": 6013
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690841,
+          "transferSize": 690851,
           "resourceSize": 1367713
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2599,
+          "transferSize": 2602,
           "resourceSize": 5713
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5305,
+          "transferSize": 5307,
           "resourceSize": 17514
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4980,
+          "transferSize": 4964,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479105,
+          "transferSize": 479091,
           "resourceSize": 1173094
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2415,
+          "transferSize": 2416,
           "resourceSize": 5087
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690526,
+          "transferSize": 690534,
           "resourceSize": 1366787
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2587,
+          "transferSize": 2591,
           "resourceSize": 5523
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690704,
+          "transferSize": 690705,
           "resourceSize": 1367223
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2430,
+          "transferSize": 2431,
           "resourceSize": 5069
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2645,
+          "transferSize": 2647,
           "resourceSize": 5633
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690758,
+          "transferSize": 690760,
           "resourceSize": 1367333
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691411,
+          "transferSize": 691412,
           "resourceSize": 1593657
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697843,
+          "transferSize": 697839,
           "resourceSize": 1381081
         }
       },

--- a/.github/page_size_audit_results/v1.11.0.json
+++ b/.github/page_size_audit_results/v1.11.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.11.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:42.699Z"
+    "generatedAt": "2025-12-24T18:53:53.620Z"
   },
-  "timestamp": "2025-12-24T18:08:42.699Z",
+  "timestamp": "2025-12-24T18:53:53.620Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2636,
+          "transferSize": 2634,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690658,
+          "transferSize": 690659,
           "resourceSize": 1367123
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2600,
+          "transferSize": 2596,
           "resourceSize": 5713
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690622,
+          "transferSize": 690619,
           "resourceSize": 1367120
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5306,
+          "transferSize": 5307,
           "resourceSize": 17514
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4968,
+          "transferSize": 4992,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479002,
+          "transferSize": 479027,
           "resourceSize": 1172801
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2414,
+          "transferSize": 2411,
           "resourceSize": 5087
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2588,
+          "transferSize": 2586,
           "resourceSize": 5523
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690613,
+          "transferSize": 690608,
           "resourceSize": 1366930
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2429,
+          "transferSize": 2426,
           "resourceSize": 5069
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690455,
+          "transferSize": 690450,
           "resourceSize": 1366476
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2645,
+          "transferSize": 2644,
           "resourceSize": 5633
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690672,
+          "transferSize": 690671,
           "resourceSize": 1367040
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3295,
+          "transferSize": 3293,
           "resourceSize": 7951
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3298,
+          "transferSize": 3296,
           "resourceSize": 6985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697743,
+          "transferSize": 697742,
           "resourceSize": 1380788
         }
       },

--- a/.github/page_size_audit_results/v1.12.0.json
+++ b/.github/page_size_audit_results/v1.12.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:09:17.774Z"
+    "generatedAt": "2025-12-24T18:59:59.692Z"
   },
-  "timestamp": "2025-12-24T18:09:17.775Z",
+  "timestamp": "2025-12-24T18:59:59.693Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2644,
+          "transferSize": 2649,
           "resourceSize": 5757
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690708,
+          "transferSize": 690716,
           "resourceSize": 1367305
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2604,
+          "transferSize": 2609,
           "resourceSize": 5754
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690675,
+          "transferSize": 690677,
           "resourceSize": 1367302
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2422,
+          "transferSize": 2427,
           "resourceSize": 5140
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690490,
+          "transferSize": 690497,
           "resourceSize": 1366688
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2594,
+          "transferSize": 2599,
           "resourceSize": 5564
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2437,
+          "transferSize": 2440,
           "resourceSize": 5122
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690509,
+          "transferSize": 690506,
           "resourceSize": 1366670
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2653,
+          "transferSize": 2657,
           "resourceSize": 5674
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690721,
+          "transferSize": 690726,
           "resourceSize": 1367222
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3302,
+          "transferSize": 3309,
           "resourceSize": 7992
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691371,
+          "transferSize": 691378,
           "resourceSize": 1593546
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3305,
+          "transferSize": 3309,
           "resourceSize": 7042
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697798,
+          "transferSize": 697802,
           "resourceSize": 1380986
         }
       },

--- a/.github/page_size_audit_results/v1.12.1.json
+++ b/.github/page_size_audit_results/v1.12.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:39.019Z"
+    "generatedAt": "2025-12-24T18:59:37.579Z"
   },
-  "timestamp": "2025-12-24T18:08:39.019Z",
+  "timestamp": "2025-12-24T18:59:37.579Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2652,
+          "transferSize": 2653,
           "resourceSize": 5941
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691689,
+          "transferSize": 691696,
           "resourceSize": 1369939
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2615,
+          "transferSize": 2616,
           "resourceSize": 5938
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691654,
+          "transferSize": 691659,
           "resourceSize": 1369936
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5323,
+          "transferSize": 5321,
           "resourceSize": 17831
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4976,
+          "transferSize": 4973,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479771,
+          "transferSize": 479766,
           "resourceSize": 1174311
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2434,
+          "transferSize": 2435,
           "resourceSize": 5324
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691474,
+          "transferSize": 691482,
           "resourceSize": 1369322
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2603,
+          "transferSize": 2604,
           "resourceSize": 5748
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691642,
+          "transferSize": 691643,
           "resourceSize": 1369746
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2445,
+          "transferSize": 2446,
           "resourceSize": 5306
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691485,
+          "transferSize": 691489,
           "resourceSize": 1369304
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691705,
+          "transferSize": 691703,
           "resourceSize": 1369856
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3311,
+          "transferSize": 3313,
           "resourceSize": 8176
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692348,
+          "transferSize": 692361,
           "resourceSize": 1596180
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3311,
+          "transferSize": 3314,
           "resourceSize": 7226
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 698505,
+          "transferSize": 698508,
           "resourceSize": 1382222
         }
       },

--- a/.github/page_size_audit_results/v1.12.2.json
+++ b/.github/page_size_audit_results/v1.12.2.json
@@ -1,38 +1,38 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:41.912Z"
+    "generatedAt": "2025-12-24T18:59:31.055Z"
   },
-  "timestamp": "2025-12-24T18:05:41.912Z",
+  "timestamp": "2025-12-24T18:59:31.056Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2786,
-          "resourceSize": 6423
+          "transferSize": 2704,
+          "resourceSize": 6131
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161495,
-          "resourceSize": 501502
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319020,
-          "resourceSize": 711759
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 709032,
-          "resourceSize": 1444160
+          "transferSize": 693350,
+          "resourceSize": 1373180
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2746,
-          "resourceSize": 6420
+          "transferSize": 2666,
+          "resourceSize": 6128
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161495,
-          "resourceSize": 501502
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319020,
-          "resourceSize": 711759
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 708992,
-          "resourceSize": 1444157
+          "transferSize": 693315,
+          "resourceSize": 1373177
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5453,
-          "resourceSize": 18313
+          "transferSize": 5379,
+          "resourceSize": 18021
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 167292,
-          "resourceSize": 512500
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 319020,
-          "resourceSize": 711759
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4960,
+          "transferSize": 4976,
           "resourceSize": 5685
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 497087,
-          "resourceSize": 1248532
+          "transferSize": 481435,
+          "resourceSize": 1177552
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2572,
-          "resourceSize": 5806
+          "transferSize": 2492,
+          "resourceSize": 5514
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161495,
-          "resourceSize": 501502
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319020,
-          "resourceSize": 711759
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 708815,
-          "resourceSize": 1443543
+          "transferSize": 693143,
+          "resourceSize": 1372563
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2735,
-          "resourceSize": 6230
+          "transferSize": 2654,
+          "resourceSize": 5938
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161495,
-          "resourceSize": 501502
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319020,
-          "resourceSize": 711759
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 708982,
-          "resourceSize": 1443967
+          "transferSize": 693305,
+          "resourceSize": 1372987
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2581,
-          "resourceSize": 5788
+          "transferSize": 2495,
+          "resourceSize": 5496
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161495,
-          "resourceSize": 501502
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319020,
-          "resourceSize": 711759
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 708827,
-          "resourceSize": 1443525
+          "transferSize": 693148,
+          "resourceSize": 1372545
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2795,
-          "resourceSize": 6340
+          "transferSize": 2713,
+          "resourceSize": 6048
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161495,
-          "resourceSize": 501502
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319020,
-          "resourceSize": 711759
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 709041,
-          "resourceSize": 1444078
+          "transferSize": 693363,
+          "resourceSize": 1373097
         }
       },
       "themeResources": {
@@ -496,12 +496,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 689881,
-          "resourceSize": 1366855
+          "transferSize": 689880,
+          "resourceSize": 1366854
         }
       }
     },
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3451,
-          "resourceSize": 8658
+          "transferSize": 3377,
+          "resourceSize": 8366
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161495,
-          "resourceSize": 501502
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 319020,
-          "resourceSize": 711759
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 709695,
-          "resourceSize": 1670402
+          "transferSize": 694027,
+          "resourceSize": 1599421
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 689881,
-          "resourceSize": 1590861
+          "transferSize": 689880,
+          "resourceSize": 1590860
         }
       }
     },
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3436,
-          "resourceSize": 7708
+          "transferSize": 3358,
+          "resourceSize": 7416
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 167292,
-          "resourceSize": 512500
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 319020,
-          "resourceSize": 711759
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 715828,
-          "resourceSize": 1456444
+          "transferSize": 700160,
+          "resourceSize": 1385464
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.12.3.json
+++ b/.github/page_size_audit_results/v1.12.3.json
@@ -1,38 +1,38 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:56.344Z"
+    "generatedAt": "2025-12-24T18:56:54.452Z"
   },
-  "timestamp": "2025-12-24T18:08:56.344Z",
+  "timestamp": "2025-12-24T18:56:54.452Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2840,
-          "resourceSize": 6532
+          "transferSize": 2719,
+          "resourceSize": 6137
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318275,
-          "resourceSize": 711032
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 731217,
-          "resourceSize": 1482154
+          "transferSize": 693370,
+          "resourceSize": 1373203
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2801,
-          "resourceSize": 6529
+          "transferSize": 2681,
+          "resourceSize": 6134
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318275,
-          "resourceSize": 711032
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 731183,
-          "resourceSize": 1482151
+          "transferSize": 693334,
+          "resourceSize": 1373200
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5518,
-          "resourceSize": 18544
+          "transferSize": 5390,
+          "resourceSize": 18027
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 190170,
-          "resourceSize": 551112
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 318275,
-          "resourceSize": 711032
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4969,
+          "transferSize": 4967,
           "resourceSize": 5685
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 519294,
-          "resourceSize": 1286648
+          "transferSize": 481436,
+          "resourceSize": 1177575
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2625,
-          "resourceSize": 5915
+          "transferSize": 2507,
+          "resourceSize": 5520
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318275,
-          "resourceSize": 711032
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 731006,
-          "resourceSize": 1481537
+          "transferSize": 693157,
+          "resourceSize": 1372586
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2789,
-          "resourceSize": 6339
+          "transferSize": 2669,
+          "resourceSize": 5944
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318275,
-          "resourceSize": 711032
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 731163,
-          "resourceSize": 1481961
+          "transferSize": 693318,
+          "resourceSize": 1373010
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2636,
-          "resourceSize": 5897
+          "transferSize": 2515,
+          "resourceSize": 5502
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318275,
-          "resourceSize": 711032
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 731016,
-          "resourceSize": 1481519
+          "transferSize": 693164,
+          "resourceSize": 1372568
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2850,
-          "resourceSize": 6449
+          "transferSize": 2728,
+          "resourceSize": 6054
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318275,
-          "resourceSize": 711032
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 731227,
-          "resourceSize": 1482072
+          "transferSize": 693375,
+          "resourceSize": 1373120
         }
       },
       "themeResources": {
@@ -496,12 +496,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 689880,
-          "resourceSize": 1366872
+          "transferSize": 689879,
+          "resourceSize": 1366871
         }
       }
     },
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3508,
-          "resourceSize": 8767
+          "transferSize": 3395,
+          "resourceSize": 8372
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318275,
-          "resourceSize": 711032
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 731884,
-          "resourceSize": 1708396
+          "transferSize": 694046,
+          "resourceSize": 1599444
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 689880,
-          "resourceSize": 1590878
+          "transferSize": 689879,
+          "resourceSize": 1590877
         }
       }
     },
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3488,
-          "resourceSize": 7817
+          "transferSize": 3375,
+          "resourceSize": 7422
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 190170,
-          "resourceSize": 551112
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 318275,
-          "resourceSize": 711032
+          "transferSize": 317105,
+          "resourceSize": 710028
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 738021,
-          "resourceSize": 1494438
+          "transferSize": 700179,
+          "resourceSize": 1385487
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.13.0.json
+++ b/.github/page_size_audit_results/v1.13.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:42.347Z"
+    "generatedAt": "2025-12-24T18:56:46.234Z"
   },
-  "timestamp": "2025-12-24T18:05:42.347Z",
+  "timestamp": "2025-12-24T18:56:46.234Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2718,
+          "transferSize": 2719,
           "resourceSize": 6137
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693365,
+          "transferSize": 693369,
           "resourceSize": 1373203
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693329,
+          "transferSize": 693328,
           "resourceSize": 1373200
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5388,
+          "transferSize": 5391,
           "resourceSize": 18027
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4957,
+          "transferSize": 4973,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481424,
+          "transferSize": 481443,
           "resourceSize": 1177575
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2505,
+          "transferSize": 2506,
           "resourceSize": 5520
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693158,
+          "transferSize": 693159,
           "resourceSize": 1372586
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2669,
+          "transferSize": 2670,
           "resourceSize": 5944
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693316,
+          "transferSize": 693320,
           "resourceSize": 1373010
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693167,
+          "transferSize": 693162,
           "resourceSize": 1372568
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693379,
+          "transferSize": 693381,
           "resourceSize": 1373120
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694048,
+          "transferSize": 694043,
           "resourceSize": 1599444
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1117,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700175,
+          "transferSize": 700169,
           "resourceSize": 1385487
         }
       },

--- a/.github/page_size_audit_results/v1.13.1.json
+++ b/.github/page_size_audit_results/v1.13.1.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:41.837Z"
+    "generatedAt": "2025-12-24T18:53:45.727Z"
   },
-  "timestamp": "2025-12-24T18:05:41.838Z",
+  "timestamp": "2025-12-24T18:53:45.728Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693438,
+          "transferSize": 693433,
           "resourceSize": 1373874
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693402,
+          "transferSize": 693399,
           "resourceSize": 1373871
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5399,
+          "transferSize": 5398,
           "resourceSize": 18045
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4966,
+          "transferSize": 4991,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481505,
+          "transferSize": 481529,
           "resourceSize": 1178246
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2517,
+          "transferSize": 2516,
           "resourceSize": 5538
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693230,
+          "transferSize": 693231,
           "resourceSize": 1373257
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2680,
+          "transferSize": 2681,
           "resourceSize": 5962
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693389,
+          "transferSize": 693390,
           "resourceSize": 1373681
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2526,
+          "transferSize": 2525,
           "resourceSize": 5520
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693233,
+          "transferSize": 693236,
           "resourceSize": 1373239
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693445,
+          "transferSize": 693446,
           "resourceSize": 1373791
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694107,
+          "transferSize": 694114,
           "resourceSize": 1600115
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3385,
+          "transferSize": 3384,
           "resourceSize": 7440
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1130,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700243,
+          "transferSize": 700252,
           "resourceSize": 1386158
         }
       },

--- a/.github/page_size_audit_results/v1.14.0.json
+++ b/.github/page_size_audit_results/v1.14.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.14.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:49.934Z"
+    "generatedAt": "2025-12-24T18:59:32.766Z"
   },
-  "timestamp": "2025-12-24T18:05:49.934Z",
+  "timestamp": "2025-12-24T18:59:32.767Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2692,
+          "transferSize": 2693,
           "resourceSize": 6083
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693406,
+          "transferSize": 693397,
           "resourceSize": 1373802
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2657,
+          "transferSize": 2658,
           "resourceSize": 6080
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693364,
+          "transferSize": 693365,
           "resourceSize": 1373799
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4969,
+          "transferSize": 4986,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481508,
+          "transferSize": 481525,
           "resourceSize": 1178246
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2513,
+          "transferSize": 2512,
           "resourceSize": 5538
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693226,
+          "transferSize": 693224,
           "resourceSize": 1373257
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2646,
+          "transferSize": 2648,
           "resourceSize": 5890
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693361,
+          "transferSize": 693360,
           "resourceSize": 1373609
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2524,
+          "transferSize": 2523,
           "resourceSize": 5520
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693230,
+          "transferSize": 693237,
           "resourceSize": 1373239
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2702,
+          "transferSize": 2703,
           "resourceSize": 6000
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693415,
+          "transferSize": 693409,
           "resourceSize": 1373719
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3362,
+          "transferSize": 3363,
           "resourceSize": 8318
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694075,
+          "transferSize": 694070,
           "resourceSize": 1600043
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3380,
+          "transferSize": 3381,
           "resourceSize": 7440
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700241,
+          "transferSize": 700239,
           "resourceSize": 1386158
         }
       },

--- a/.github/page_size_audit_results/v1.15.0.json
+++ b/.github/page_size_audit_results/v1.15.0.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:59.465Z"
+    "generatedAt": "2025-12-24T18:56:52.981Z"
   },
-  "timestamp": "2025-12-24T18:08:59.465Z",
+  "timestamp": "2025-12-24T18:56:52.982Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693554,
+          "transferSize": 693546,
           "resourceSize": 1374456
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693514,
+          "transferSize": 693510,
           "resourceSize": 1374453
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4968,
+          "transferSize": 4967,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481822,
+          "transferSize": 481821,
           "resourceSize": 1179186
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2526,
+          "transferSize": 2527,
           "resourceSize": 5556
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693505,
+          "transferSize": 693503,
           "resourceSize": 1374263
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2537,
+          "transferSize": 2538,
           "resourceSize": 5538
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693384,
+          "transferSize": 693378,
           "resourceSize": 1373893
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693560,
+          "transferSize": 693559,
           "resourceSize": 1374373
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3373,
+          "transferSize": 3374,
           "resourceSize": 8336
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694214,
+          "transferSize": 694215,
           "resourceSize": 1600697
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3391,
+          "transferSize": 3394,
           "resourceSize": 7458
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.15.1.json
+++ b/.github/page_size_audit_results/v1.15.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:51.127Z"
+    "generatedAt": "2025-12-24T19:00:05.106Z"
   },
-  "timestamp": "2025-12-24T18:05:51.127Z",
+  "timestamp": "2025-12-24T19:00:05.106Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2057,
+          "transferSize": 2061,
           "resourceSize": 4959
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692429,
+          "transferSize": 692437,
           "resourceSize": 1372340
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2025,
+          "transferSize": 2026,
           "resourceSize": 4956
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692398,
+          "transferSize": 692402,
           "resourceSize": 1372337
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5031,
+          "transferSize": 5032,
           "resourceSize": 17245
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4964,
+          "transferSize": 4960,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480797,
+          "transferSize": 480794,
           "resourceSize": 1177108
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1894,
+          "transferSize": 1897,
           "resourceSize": 4414
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692267,
+          "transferSize": 692266,
           "resourceSize": 1371795
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2026,
+          "transferSize": 2031,
           "resourceSize": 4766
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692402,
+          "transferSize": 692400,
           "resourceSize": 1372147
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1909,
+          "transferSize": 1912,
           "resourceSize": 4396
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2101,
+          "transferSize": 2104,
           "resourceSize": 4876
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692471,
+          "transferSize": 692477,
           "resourceSize": 1372257
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2751,
+          "transferSize": 2755,
           "resourceSize": 7194
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693123,
+          "transferSize": 693130,
           "resourceSize": 1598581
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2788,
+          "transferSize": 2795,
           "resourceSize": 6298
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699308,
+          "transferSize": 699318,
           "resourceSize": 1384678
         }
       },

--- a/.github/page_size_audit_results/v1.16.0.json
+++ b/.github/page_size_audit_results/v1.16.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:27.228Z"
+    "generatedAt": "2025-12-24T18:56:54.031Z"
   },
-  "timestamp": "2025-12-24T18:11:27.228Z",
+  "timestamp": "2025-12-24T18:56:54.031Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2059,
+          "transferSize": 2063,
           "resourceSize": 4969
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692531,
+          "transferSize": 692529,
           "resourceSize": 1372886
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2026,
+          "transferSize": 2029,
           "resourceSize": 4966
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5031,
+          "transferSize": 5034,
           "resourceSize": 17255
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4970,
+          "transferSize": 4963,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480901,
+          "transferSize": 480897,
           "resourceSize": 1177654
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1896,
+          "transferSize": 1900,
           "resourceSize": 4424
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692367,
+          "transferSize": 692368,
           "resourceSize": 1372341
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2027,
+          "transferSize": 2030,
           "resourceSize": 4776
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692494,
+          "transferSize": 692495,
           "resourceSize": 1372693
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1910,
+          "transferSize": 1913,
           "resourceSize": 4406
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692378,
+          "transferSize": 692386,
           "resourceSize": 1372323
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2103,
+          "transferSize": 2106,
           "resourceSize": 4886
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692577,
+          "transferSize": 692576,
           "resourceSize": 1372803
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2753,
+          "transferSize": 2757,
           "resourceSize": 7204
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693225,
+          "transferSize": 693231,
           "resourceSize": 1599127
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2791,
+          "transferSize": 2798,
           "resourceSize": 6308
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699410,
+          "transferSize": 699419,
           "resourceSize": 1385224
         }
       },

--- a/.github/page_size_audit_results/v1.16.1.json
+++ b/.github/page_size_audit_results/v1.16.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:46.057Z"
+    "generatedAt": "2025-12-24T18:56:46.720Z"
   },
-  "timestamp": "2025-12-24T18:05:46.057Z",
+  "timestamp": "2025-12-24T18:56:46.720Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2058,
+          "transferSize": 2060,
           "resourceSize": 4969
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692531,
+          "transferSize": 692532,
           "resourceSize": 1372886
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2024,
+          "transferSize": 2027,
           "resourceSize": 4966
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692495,
+          "transferSize": 692492,
           "resourceSize": 1372883
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5001,
+          "transferSize": 4971,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480932,
+          "transferSize": 480902,
           "resourceSize": 1177654
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692369,
+          "transferSize": 692366,
           "resourceSize": 1372341
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2027,
+          "transferSize": 2029,
           "resourceSize": 4776
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692491,
+          "transferSize": 692496,
           "resourceSize": 1372693
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692379,
+          "transferSize": 692376,
           "resourceSize": 1372323
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2102,
+          "transferSize": 2104,
           "resourceSize": 4886
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692571,
+          "transferSize": 692570,
           "resourceSize": 1372803
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693217,
+          "transferSize": 693220,
           "resourceSize": 1599127
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699412,
+          "transferSize": 699408,
           "resourceSize": 1385224
         }
       },

--- a/.github/page_size_audit_results/v1.17.0.json
+++ b/.github/page_size_audit_results/v1.17.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.17.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:53.062Z"
+    "generatedAt": "2025-12-24T18:59:45.392Z"
   },
-  "timestamp": "2025-12-24T18:05:53.062Z",
+  "timestamp": "2025-12-24T18:59:45.393Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2154,
+          "transferSize": 2155,
           "resourceSize": 5445
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692166,
+          "transferSize": 692171,
           "resourceSize": 1373215
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692131,
+          "transferSize": 692139,
           "resourceSize": 1373212
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5173,
+          "transferSize": 5174,
           "resourceSize": 17803
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4972,
+          "transferSize": 4987,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481010,
+          "transferSize": 481026,
           "resourceSize": 1178055
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1992,
+          "transferSize": 1993,
           "resourceSize": 4900
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692005,
+          "transferSize": 692000,
           "resourceSize": 1372670
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2124,
+          "transferSize": 2125,
           "resourceSize": 5252
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692135,
+          "transferSize": 692139,
           "resourceSize": 1373022
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2003,
+          "transferSize": 2004,
           "resourceSize": 4882
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692013,
+          "transferSize": 692017,
           "resourceSize": 1372652
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2198,
+          "transferSize": 2199,
           "resourceSize": 5362
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2844,
+          "transferSize": 2845,
           "resourceSize": 7680
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917031,
+          "transferSize": 917032,
           "resourceSize": 1599456
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699048,
+          "transferSize": 699044,
           "resourceSize": 1385553
         }
       },

--- a/.github/page_size_audit_results/v1.18.0.json
+++ b/.github/page_size_audit_results/v1.18.0.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.18.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:42.515Z"
+    "generatedAt": "2025-12-24T18:53:46.783Z"
   },
-  "timestamp": "2025-12-24T18:05:42.515Z",
+  "timestamp": "2025-12-24T18:53:46.784Z",
   "results": [
     {
       "url": "/",
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692290,
+          "transferSize": 692291,
           "resourceSize": 1376569
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4973,
+          "transferSize": 4964,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481153,
+          "transferSize": 481144,
           "resourceSize": 1181412
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692165,
+          "transferSize": 692166,
           "resourceSize": 1376027
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692298,
+          "transferSize": 692292,
           "resourceSize": 1376379
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1964,
+          "transferSize": 1965,
           "resourceSize": 4590
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692366,
+          "transferSize": 692369,
           "resourceSize": 1376489
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2800,
+          "transferSize": 2801,
           "resourceSize": 7388
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699194,
+          "transferSize": 699200,
           "resourceSize": 1388910
         }
       },

--- a/.github/page_size_audit_results/v1.19.0.json
+++ b/.github/page_size_audit_results/v1.19.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.19.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:26.928Z"
+    "generatedAt": "2025-12-24T18:56:12.297Z"
   },
-  "timestamp": "2025-12-24T18:11:26.929Z",
+  "timestamp": "2025-12-24T18:56:12.297Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2112,
+          "transferSize": 2118,
           "resourceSize": 5153
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692323,
+          "transferSize": 692332,
           "resourceSize": 1376572
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2079,
+          "transferSize": 2083,
           "resourceSize": 5150
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692285,
+          "transferSize": 692297,
           "resourceSize": 1376569
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5378,
+          "transferSize": 5382,
           "resourceSize": 20616
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7818,
+          "transferSize": 7775,
           "resourceSize": 8841
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484258,
+          "transferSize": 484219,
           "resourceSize": 1187673
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1953,
+          "transferSize": 1956,
           "resourceSize": 4608
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692166,
+          "transferSize": 692170,
           "resourceSize": 1376027
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2081,
+          "transferSize": 2088,
           "resourceSize": 4960
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1964,
+          "transferSize": 1968,
           "resourceSize": 4590
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692172,
+          "transferSize": 692175,
           "resourceSize": 1376009
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2156,
+          "transferSize": 2162,
           "resourceSize": 5070
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692363,
+          "transferSize": 692375,
           "resourceSize": 1376489
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2800,
+          "transferSize": 2804,
           "resourceSize": 7388
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917186,
+          "transferSize": 917188,
           "resourceSize": 1602813
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2837,
+          "transferSize": 2841,
           "resourceSize": 6492
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699203,
+          "transferSize": 699202,
           "resourceSize": 1388910
         }
       },

--- a/.github/page_size_audit_results/v1.2.0.json
+++ b/.github/page_size_audit_results/v1.2.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.2.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:40.647Z"
+    "generatedAt": "2025-12-24T18:59:38.166Z"
   },
-  "timestamp": "2025-12-24T18:08:40.647Z",
+  "timestamp": "2025-12-24T18:59:38.166Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2591,
+          "transferSize": 2588,
           "resourceSize": 5452
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2457,
+          "transferSize": 2454,
           "resourceSize": 5136
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5210,
+          "transferSize": 5209,
           "resourceSize": 16750
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4975,
+          "transferSize": 4963,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478592,
+          "transferSize": 478579,
           "resourceSize": 1169498
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2279,
+          "transferSize": 2278,
           "resourceSize": 4520
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689555,
+          "transferSize": 689563,
           "resourceSize": 1363388
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2446,
+          "transferSize": 2442,
           "resourceSize": 4946
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689726,
+          "transferSize": 689723,
           "resourceSize": 1363814
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2299,
+          "transferSize": 2298,
           "resourceSize": 4537
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689579,
+          "transferSize": 689578,
           "resourceSize": 1363405
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2502,
+          "transferSize": 2499,
           "resourceSize": 5056
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689785,
+          "transferSize": 689777,
           "resourceSize": 1363924
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3184,
+          "transferSize": 3182,
           "resourceSize": 7528
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 914644,
+          "transferSize": 914633,
           "resourceSize": 1590402
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3124,
+          "transferSize": 3123,
           "resourceSize": 6382
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 696829,
+          "transferSize": 696827,
           "resourceSize": 1377646
         }
       },

--- a/.github/page_size_audit_results/v1.2.1.json
+++ b/.github/page_size_audit_results/v1.2.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.2.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:44.691Z"
+    "generatedAt": "2025-12-24T18:56:52.646Z"
   },
-  "timestamp": "2025-12-24T18:05:44.691Z",
+  "timestamp": "2025-12-24T18:56:52.646Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2597,
+          "transferSize": 2594,
           "resourceSize": 5460
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689653,
+          "transferSize": 689658,
           "resourceSize": 1363611
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2463,
+          "transferSize": 2457,
           "resourceSize": 5144
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689518,
+          "transferSize": 689512,
           "resourceSize": 1363295
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5221,
+          "transferSize": 5219,
           "resourceSize": 16758
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4978,
+          "transferSize": 4971,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478382,
+          "transferSize": 478373,
           "resourceSize": 1168789
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2284,
+          "transferSize": 2280,
           "resourceSize": 4528
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689342,
+          "transferSize": 689336,
           "resourceSize": 1362679
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2453,
+          "transferSize": 2450,
           "resourceSize": 4954
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689511,
+          "transferSize": 689505,
           "resourceSize": 1363105
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2305,
+          "transferSize": 2301,
           "resourceSize": 4545
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689364,
+          "transferSize": 689359,
           "resourceSize": 1362696
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2507,
+          "transferSize": 2505,
           "resourceSize": 5064
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689566,
+          "transferSize": 689563,
           "resourceSize": 1363215
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3195,
+          "transferSize": 3191,
           "resourceSize": 7530
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 914427,
+          "transferSize": 914422,
           "resourceSize": 1589687
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3131,
+          "transferSize": 3127,
           "resourceSize": 6390
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 696608,
+          "transferSize": 696606,
           "resourceSize": 1376937
         }
       },

--- a/.github/page_size_audit_results/v1.20.0.json
+++ b/.github/page_size_audit_results/v1.20.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.20.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:36.827Z"
+    "generatedAt": "2025-12-24T18:53:58.212Z"
   },
-  "timestamp": "2025-12-24T18:11:36.828Z",
+  "timestamp": "2025-12-24T18:53:58.212Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2116,
+          "transferSize": 2117,
           "resourceSize": 5153
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692358,
+          "transferSize": 692363,
           "resourceSize": 1377138
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692330,
+          "transferSize": 692326,
           "resourceSize": 1377135
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5380,
+          "transferSize": 5381,
           "resourceSize": 20616
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7813,
+          "transferSize": 7792,
           "resourceSize": 8841
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484287,
+          "transferSize": 484267,
           "resourceSize": 1188239
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1955,
+          "transferSize": 1956,
           "resourceSize": 4608
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692200,
+          "transferSize": 692196,
           "resourceSize": 1376593
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2085,
+          "transferSize": 2086,
           "resourceSize": 4960
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692330,
+          "transferSize": 692323,
           "resourceSize": 1376945
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1966,
+          "transferSize": 1967,
           "resourceSize": 4590
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692211,
+          "transferSize": 692209,
           "resourceSize": 1376575
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692399,
+          "transferSize": 692402,
           "resourceSize": 1377055
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2803,
+          "transferSize": 2804,
           "resourceSize": 7388
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917224,
+          "transferSize": 917223,
           "resourceSize": 1603379
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2840,
+          "transferSize": 2841,
           "resourceSize": 6492
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699237,
+          "transferSize": 699233,
           "resourceSize": 1389476
         }
       },

--- a/.github/page_size_audit_results/v1.21.0.json
+++ b/.github/page_size_audit_results/v1.21.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.21.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:53.889Z"
+    "generatedAt": "2025-12-24T18:56:45.709Z"
   },
-  "timestamp": "2025-12-24T18:05:53.889Z",
+  "timestamp": "2025-12-24T18:56:45.710Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2178,
+          "transferSize": 2179,
           "resourceSize": 5477
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692569,
+          "transferSize": 692567,
           "resourceSize": 1378420
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2143,
+          "transferSize": 2144,
           "resourceSize": 5474
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692529,
+          "transferSize": 692533,
           "resourceSize": 1378417
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9104,
+          "transferSize": 9082,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486093,
+          "transferSize": 486071,
           "resourceSize": 1195590
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2015,
+          "transferSize": 2016,
           "resourceSize": 4932
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2144,
+          "transferSize": 2145,
           "resourceSize": 5284
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692533,
+          "transferSize": 692538,
           "resourceSize": 1378227
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692421,
+          "transferSize": 692412,
           "resourceSize": 1377857
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2220,
+          "transferSize": 2221,
           "resourceSize": 5394
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692609,
+          "transferSize": 692617,
           "resourceSize": 1378337
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3057,
+          "transferSize": 3058,
           "resourceSize": 8872
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1328,
+          "transferSize": 1318,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918180,
+          "transferSize": 918171,
           "resourceSize": 1606230
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2906,
+          "transferSize": 2907,
           "resourceSize": 6816
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699451,
+          "transferSize": 699445,
           "resourceSize": 1390758
         }
       },

--- a/.github/page_size_audit_results/v1.22.0.json
+++ b/.github/page_size_audit_results/v1.22.0.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.22.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:30.861Z"
+    "generatedAt": "2025-12-24T18:53:59.698Z"
   },
-  "timestamp": "2025-12-24T18:11:30.862Z",
+  "timestamp": "2025-12-24T18:53:59.698Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692668,
+          "transferSize": 692666,
           "resourceSize": 1379006
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2102,
+          "transferSize": 2101,
           "resourceSize": 5438
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692631,
+          "transferSize": 692635,
           "resourceSize": 1378996
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5702,
+          "transferSize": 5704,
           "resourceSize": 23900
         },
         "font": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486163,
+          "transferSize": 486165,
           "resourceSize": 1196184
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1974,
+          "transferSize": 1975,
           "resourceSize": 4896
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692500,
+          "transferSize": 692506,
           "resourceSize": 1378454
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2104,
+          "transferSize": 2103,
           "resourceSize": 5248
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692637,
+          "transferSize": 692629,
           "resourceSize": 1378806
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1987,
+          "transferSize": 1988,
           "resourceSize": 4878
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692513,
+          "transferSize": 692523,
           "resourceSize": 1378436
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692707,
+          "transferSize": 692711,
           "resourceSize": 1378916
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3023,
+          "transferSize": 3025,
           "resourceSize": 8888
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1325,
+          "transferSize": 1316,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918283,
+          "transferSize": 918276,
           "resourceSize": 1606861
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2866,
+          "transferSize": 2867,
           "resourceSize": 6780
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699547,
+          "transferSize": 699545,
           "resourceSize": 1391337
         }
       },

--- a/.github/page_size_audit_results/v1.23.0.json
+++ b/.github/page_size_audit_results/v1.23.0.json
@@ -1,38 +1,38 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.23.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:09:09.008Z"
+    "generatedAt": "2025-12-24T18:59:46.086Z"
   },
-  "timestamp": "2025-12-24T18:09:09.008Z",
+  "timestamp": "2025-12-24T18:59:46.087Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2136,
-          "resourceSize": 5461
+          "transferSize": 2231,
+          "resourceSize": 5742
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147985,
-          "resourceSize": 433321
+          "transferSize": 295090,
+          "resourceSize": 940626
         },
         "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
+          "transferSize": 318722,
+          "resourceSize": 717131
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692696,
-          "resourceSize": 1379103
+          "transferSize": 841350,
+          "resourceSize": 1887975
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2100,
-          "resourceSize": 5438
+          "transferSize": 2194,
+          "resourceSize": 5719
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147985,
-          "resourceSize": 433321
+          "transferSize": 295090,
+          "resourceSize": 940626
         },
         "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
+          "transferSize": 318722,
+          "resourceSize": 717131
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692661,
-          "resourceSize": 1379080
+          "transferSize": 841313,
+          "resourceSize": 1887952
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5702,
-          "resourceSize": 23900
+          "transferSize": 5915,
+          "resourceSize": 24630
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 153782,
-          "resourceSize": 444319
+          "transferSize": 696803,
+          "resourceSize": 2097653
         },
         "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
+          "transferSize": 318722,
+          "resourceSize": 717131
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9109,
-          "resourceSize": 11929
+          "transferSize": 11952,
+          "resourceSize": 13227
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486225,
-          "resourceSize": 1196268
+          "transferSize": 1033754,
+          "resourceSize": 2852916
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1973,
-          "resourceSize": 4896
+          "transferSize": 2064,
+          "resourceSize": 5177
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147985,
-          "resourceSize": 433321
+          "transferSize": 295090,
+          "resourceSize": 940626
         },
         "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
+          "transferSize": 318722,
+          "resourceSize": 717131
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692533,
-          "resourceSize": 1378538
+          "transferSize": 841182,
+          "resourceSize": 1887410
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2103,
-          "resourceSize": 5248
+          "transferSize": 2196,
+          "resourceSize": 5529
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147985,
-          "resourceSize": 433321
+          "transferSize": 295090,
+          "resourceSize": 940626
         },
         "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
+          "transferSize": 318722,
+          "resourceSize": 717131
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692669,
-          "resourceSize": 1378890
+          "transferSize": 841316,
+          "resourceSize": 1887762
         }
       },
       "themeResources": {
@@ -367,240 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1988,
-          "resourceSize": 4878
+          "transferSize": 2077,
+          "resourceSize": 5159
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147985,
-          "resourceSize": 433321
+          "transferSize": 295090,
+          "resourceSize": 940626
         },
         "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
+          "transferSize": 318722,
+          "resourceSize": 717131
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
-          "resourceSize": 195
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 692549,
-          "resourceSize": 1378520
-        }
-      },
-      "themeResources": {
-        "document": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 147985,
-          "resourceSize": 433321
-        },
-        "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 689792,
-          "resourceSize": 1373447
-        }
-      }
-    },
-    {
-      "url": "/categories/default",
-      "resources": {
-        "document": {
-          "transferSize": 2178,
-          "resourceSize": 5358
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 147985,
-          "resourceSize": 433321
-        },
-        "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 768,
-          "resourceSize": 195
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 692738,
-          "resourceSize": 1379000
-        }
-      },
-      "themeResources": {
-        "document": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 147985,
-          "resourceSize": 433321
-        },
-        "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 689792,
-          "resourceSize": 1373447
-        }
-      }
-    },
-    {
-      "url": "/authors/admin",
-      "resources": {
-        "document": {
-          "transferSize": 3024,
-          "resourceSize": 8959
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 147985,
-          "resourceSize": 433321
-        },
-        "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
-        },
-        "image": {
-          "transferSize": 448350,
-          "resourceSize": 448012
-        },
-        "fetch": {
-          "transferSize": 1319,
-          "resourceSize": 604
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 918310,
-          "resourceSize": 1607016
-        }
-      },
-      "themeResources": {
-        "document": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 147985,
-          "resourceSize": 433321
-        },
-        "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
-        },
-        "image": {
-          "transferSize": 448350,
-          "resourceSize": 448012
-        },
-        "fetch": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 913967,
-          "resourceSize": 1597453
-        }
-      }
-    },
-    {
-      "url": "/about",
-      "resources": {
-        "document": {
-          "transferSize": 2865,
-          "resourceSize": 6780
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 153782,
-          "resourceSize": 444319
-        },
-        "stylesheet": {
-          "transferSize": 317270,
-          "resourceSize": 715845
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 1125,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +395,221 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699580,
-          "resourceSize": 1391421
+          "transferSize": 841204,
+          "resourceSize": 1887393
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 147985,
+          "resourceSize": 433321
+        },
+        "stylesheet": {
+          "transferSize": 317270,
+          "resourceSize": 715845
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 689793,
+          "resourceSize": 1373448
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 2272,
+          "resourceSize": 5639
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 295090,
+          "resourceSize": 940626
+        },
+        "stylesheet": {
+          "transferSize": 318722,
+          "resourceSize": 717131
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 771,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 841393,
+          "resourceSize": 1887873
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 147985,
+          "resourceSize": 433321
+        },
+        "stylesheet": {
+          "transferSize": 317270,
+          "resourceSize": 715845
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 689793,
+          "resourceSize": 1373448
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3114,
+          "resourceSize": 9240
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 295090,
+          "resourceSize": 940626
+        },
+        "stylesheet": {
+          "transferSize": 318722,
+          "resourceSize": 717131
+        },
+        "image": {
+          "transferSize": 448350,
+          "resourceSize": 448012
+        },
+        "fetch": {
+          "transferSize": 1313,
+          "resourceSize": 604
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 1066952,
+          "resourceSize": 2115889
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 147985,
+          "resourceSize": 433321
+        },
+        "stylesheet": {
+          "transferSize": 317270,
+          "resourceSize": 715845
+        },
+        "image": {
+          "transferSize": 448350,
+          "resourceSize": 448012
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 913968,
+          "resourceSize": 1597454
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3071,
+          "resourceSize": 7564
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 696803,
+          "resourceSize": 2097653
+        },
+        "stylesheet": {
+          "transferSize": 318722,
+          "resourceSize": 717131
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 4000,
+          "resourceSize": 1493
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 1247134,
+          "resourceSize": 3048123
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.24.0.json
+++ b/.github/page_size_audit_results/v1.24.0.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.24.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:35.240Z"
+    "generatedAt": "2025-12-24T18:53:42.129Z"
   },
-  "timestamp": "2025-12-24T18:11:35.240Z",
+  "timestamp": "2025-12-24T18:53:42.130Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692702,
+          "transferSize": 692699,
           "resourceSize": 1379103
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5707,
+          "transferSize": 5705,
           "resourceSize": 23900
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9078,
+          "transferSize": 9489,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486199,
+          "transferSize": 486608,
           "resourceSize": 1196268
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692674,
+          "transferSize": 692675,
           "resourceSize": 1378931
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1990,
+          "transferSize": 1991,
           "resourceSize": 4878
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692551,
+          "transferSize": 692556,
           "resourceSize": 1378520
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2185,
+          "transferSize": 2184,
           "resourceSize": 5399
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692745,
+          "transferSize": 692746,
           "resourceSize": 1379041
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3027,
+          "transferSize": 3028,
           "resourceSize": 8959
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1323,
+          "transferSize": 1330,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918317,
+          "transferSize": 918325,
           "resourceSize": 1607016
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1128,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699580,
+          "transferSize": 699587,
           "resourceSize": 1391421
         }
       },

--- a/.github/page_size_audit_results/v1.25.0.json
+++ b/.github/page_size_audit_results/v1.25.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.25.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:06:14.113Z"
+    "generatedAt": "2025-12-24T18:53:50.496Z"
   },
-  "timestamp": "2025-12-24T18:06:14.113Z",
+  "timestamp": "2025-12-24T18:53:50.497Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2139,
+          "transferSize": 2137,
           "resourceSize": 5461
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692856,
+          "transferSize": 692842,
           "resourceSize": 1379466
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2107,
+          "transferSize": 2106,
           "resourceSize": 5457
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692818,
+          "transferSize": 692822,
           "resourceSize": 1379462
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5706,
+          "transferSize": 5704,
           "resourceSize": 23900
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9075,
+          "transferSize": 9088,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486342,
+          "transferSize": 486353,
           "resourceSize": 1196631
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1977,
+          "transferSize": 1974,
           "resourceSize": 4896
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692692,
+          "transferSize": 692682,
           "resourceSize": 1378901
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2109,
+          "transferSize": 2108,
           "resourceSize": 5289
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692819,
+          "transferSize": 692815,
           "resourceSize": 1379294
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1990,
+          "transferSize": 1987,
           "resourceSize": 4878
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692700,
+          "transferSize": 692694,
           "resourceSize": 1378883
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2184,
+          "transferSize": 2181,
           "resourceSize": 5399
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692896,
+          "transferSize": 692892,
           "resourceSize": 1379404
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3027,
+          "transferSize": 3024,
           "resourceSize": 8959
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1316,
+          "transferSize": 1329,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918457,
+          "transferSize": 918467,
           "resourceSize": 1607379
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2868,
+          "transferSize": 2865,
           "resourceSize": 6780
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1115,
+          "transferSize": 1118,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.26.0.json
+++ b/.github/page_size_audit_results/v1.26.0.json
@@ -1,38 +1,38 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.26.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:59.137Z"
+    "generatedAt": "2025-12-24T18:53:57.479Z"
   },
-  "timestamp": "2025-12-24T18:08:59.137Z",
+  "timestamp": "2025-12-24T18:53:57.479Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2232,
-          "resourceSize": 5742
+          "transferSize": 2220,
+          "resourceSize": 5753
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295195,
-          "resourceSize": 940852
+          "transferSize": 161770,
+          "resourceSize": 502487
         },
         "stylesheet": {
-          "transferSize": 318764,
-          "resourceSize": 717268
+          "transferSize": 319226,
+          "resourceSize": 717730
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841496,
-          "resourceSize": 1888338
+          "transferSize": 708526,
+          "resourceSize": 1450446
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2199,
-          "resourceSize": 5738
+          "transferSize": 2187,
+          "resourceSize": 5749
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295195,
-          "resourceSize": 940852
+          "transferSize": 161770,
+          "resourceSize": 502487
         },
         "stylesheet": {
-          "transferSize": 318764,
-          "resourceSize": 717268
+          "transferSize": 319226,
+          "resourceSize": 717730
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841468,
-          "resourceSize": 1888334
+          "transferSize": 708487,
+          "resourceSize": 1450442
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5918,
-          "resourceSize": 24630
+          "transferSize": 5785,
+          "resourceSize": 24192
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 696908,
-          "resourceSize": 2097879
+          "transferSize": 167567,
+          "resourceSize": 513485
         },
         "stylesheet": {
-          "transferSize": 318764,
-          "resourceSize": 717268
+          "transferSize": 319226,
+          "resourceSize": 717730
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 11967,
-          "resourceSize": 13227
+          "transferSize": 9081,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 1033919,
-          "resourceSize": 2853279
+          "transferSize": 502021,
+          "resourceSize": 1267611
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2067,
-          "resourceSize": 5177
+          "transferSize": 2053,
+          "resourceSize": 5188
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295195,
-          "resourceSize": 940852
+          "transferSize": 161770,
+          "resourceSize": 502487
         },
         "stylesheet": {
-          "transferSize": 318764,
-          "resourceSize": 717268
+          "transferSize": 319226,
+          "resourceSize": 717730
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841330,
-          "resourceSize": 1887773
+          "transferSize": 708354,
+          "resourceSize": 1449881
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2201,
-          "resourceSize": 5570
+          "transferSize": 2189,
+          "resourceSize": 5581
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295195,
-          "resourceSize": 940852
+          "transferSize": 161770,
+          "resourceSize": 502487
         },
         "stylesheet": {
-          "transferSize": 318764,
-          "resourceSize": 717268
+          "transferSize": 319226,
+          "resourceSize": 717730
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841468,
-          "resourceSize": 1888166
+          "transferSize": 708493,
+          "resourceSize": 1450274
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2081,
-          "resourceSize": 5159
+          "transferSize": 2067,
+          "resourceSize": 5170
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295195,
-          "resourceSize": 940852
+          "transferSize": 161770,
+          "resourceSize": 502487
         },
         "stylesheet": {
-          "transferSize": 318764,
-          "resourceSize": 717268
+          "transferSize": 319226,
+          "resourceSize": 717730
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 841351,
-          "resourceSize": 1887756
+          "transferSize": 708368,
+          "resourceSize": 1449863
         }
       },
       "themeResources": {
@@ -425,12 +425,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 689940,
-          "resourceSize": 1373811
+          "transferSize": 689939,
+          "resourceSize": 1373810
         }
       }
     },
@@ -438,20 +438,20 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2275,
-          "resourceSize": 5680
+          "transferSize": 2264,
+          "resourceSize": 5691
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295195,
-          "resourceSize": 940852
+          "transferSize": 161770,
+          "resourceSize": 502487
         },
         "stylesheet": {
-          "transferSize": 318764,
-          "resourceSize": 717268
+          "transferSize": 319226,
+          "resourceSize": 717730
         },
         "image": {
           "transferSize": 224175,
@@ -462,12 +462,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 841542,
-          "resourceSize": 1888277
+          "transferSize": 708567,
+          "resourceSize": 1450384
         }
       },
       "themeResources": {
@@ -496,12 +496,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 689940,
-          "resourceSize": 1373811
+          "transferSize": 689939,
+          "resourceSize": 1373810
         }
       }
     },
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3119,
-          "resourceSize": 9253
+          "transferSize": 3105,
+          "resourceSize": 9264
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295195,
-          "resourceSize": 940852
+          "transferSize": 161770,
+          "resourceSize": 502487
         },
         "stylesheet": {
-          "transferSize": 318764,
-          "resourceSize": 717268
+          "transferSize": 319226,
+          "resourceSize": 717730
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1321,
+          "transferSize": 1324,
           "resourceSize": 604
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 1067112,
-          "resourceSize": 2116265
+          "transferSize": 934138,
+          "resourceSize": 1678373
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3075,
-          "resourceSize": 7564
+          "transferSize": 2941,
+          "resourceSize": 7072
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 696908,
-          "resourceSize": 2097879
+          "transferSize": 167567,
+          "resourceSize": 513485
         },
         "stylesheet": {
-          "transferSize": 318764,
-          "resourceSize": 717268
+          "transferSize": 319226,
+          "resourceSize": 717730
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3993,
-          "resourceSize": 1493
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 363,
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 1247278,
-          "resourceSize": 3048486
+          "transferSize": 715394,
+          "resourceSize": 1462764
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.27.0.json
+++ b/.github/page_size_audit_results/v1.27.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.27.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:51.628Z"
+    "generatedAt": "2025-12-24T18:53:53.811Z"
   },
-  "timestamp": "2025-12-24T18:05:51.628Z",
+  "timestamp": "2025-12-24T18:53:53.812Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2150,
+          "transferSize": 2151,
           "resourceSize": 5621
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693386,
+          "transferSize": 693384,
           "resourceSize": 1379201
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9080,
+          "transferSize": 9079,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486879,
+          "transferSize": 486878,
           "resourceSize": 1196366
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693219,
+          "transferSize": 693216,
           "resourceSize": 1378636
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2119,
           "resourceSize": 5449
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693352,
+          "transferSize": 693353,
           "resourceSize": 1379029
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693235,
+          "transferSize": 693233,
           "resourceSize": 1378618
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2192,
+          "transferSize": 2194,
           "resourceSize": 5559
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693422,
+          "transferSize": 693427,
           "resourceSize": 1379139
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3038,
+          "transferSize": 3039,
           "resourceSize": 9132
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1324,
+          "transferSize": 1322,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 919001,
+          "transferSize": 919000,
           "resourceSize": 1607127
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700257,
+          "transferSize": 700261,
           "resourceSize": 1391519
         }
       },

--- a/.github/page_size_audit_results/v1.28.0.json
+++ b/.github/page_size_audit_results/v1.28.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.28.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:48.701Z"
+    "generatedAt": "2025-12-24T18:58:51.311Z"
   },
-  "timestamp": "2025-12-24T18:05:48.702Z",
+  "timestamp": "2025-12-24T18:58:51.311Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2145,
+          "transferSize": 2146,
           "resourceSize": 5628
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690229,
+          "transferSize": 690228,
           "resourceSize": 1348646
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2110,
+          "transferSize": 2111,
           "resourceSize": 5617
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690196,
+          "transferSize": 690193,
           "resourceSize": 1348635
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5708,
+          "transferSize": 5709,
           "resourceSize": 24062
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9085,
+          "transferSize": 9101,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483731,
+          "transferSize": 483748,
           "resourceSize": 1165806
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690066,
+          "transferSize": 690065,
           "resourceSize": 1348074
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2112,
+          "transferSize": 2113,
           "resourceSize": 5449
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690199,
+          "transferSize": 690198,
           "resourceSize": 1348467
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690081,
+          "transferSize": 690084,
           "resourceSize": 1348056
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2187,
+          "transferSize": 2188,
           "resourceSize": 5559
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690276,
+          "transferSize": 690273,
           "resourceSize": 1348577
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1316,
+          "transferSize": 1319,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915841,
+          "transferSize": 915844,
           "resourceSize": 1576565
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697104,
+          "transferSize": 697108,
           "resourceSize": 1360959
         }
       },

--- a/.github/page_size_audit_results/v1.29.0.json
+++ b/.github/page_size_audit_results/v1.29.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.29.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:54.342Z"
+    "generatedAt": "2025-12-24T18:56:59.133Z"
   },
-  "timestamp": "2025-12-24T18:05:54.343Z",
+  "timestamp": "2025-12-24T18:56:59.133Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2147,
+          "transferSize": 2148,
           "resourceSize": 5633
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690235,
+          "transferSize": 690230,
           "resourceSize": 1348651
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2112,
+          "transferSize": 2113,
           "resourceSize": 5622
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690195,
+          "transferSize": 690201,
           "resourceSize": 1348640
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9081,
+          "transferSize": 9071,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483729,
+          "transferSize": 483719,
           "resourceSize": 1165811
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1982,
+          "transferSize": 1983,
           "resourceSize": 5061
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690202,
+          "transferSize": 690199,
           "resourceSize": 1348472
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690079,
+          "transferSize": 690085,
           "resourceSize": 1348061
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2188,
+          "transferSize": 2189,
           "resourceSize": 5564
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690271,
+          "transferSize": 690277,
           "resourceSize": 1348582
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1321,
+          "transferSize": 1327,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915847,
+          "transferSize": 915853,
           "resourceSize": 1576570
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697105,
+          "transferSize": 697109,
           "resourceSize": 1360964
         }
       },

--- a/.github/page_size_audit_results/v1.29.1.json
+++ b/.github/page_size_audit_results/v1.29.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.29.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:37.485Z"
+    "generatedAt": "2025-12-24T18:56:36.311Z"
   },
-  "timestamp": "2025-12-24T18:08:37.485Z",
+  "timestamp": "2025-12-24T18:56:36.311Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2149,
+          "transferSize": 2145,
           "resourceSize": 5633
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690238,
+          "transferSize": 690234,
           "resourceSize": 1348669
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2113,
+          "transferSize": 2110,
           "resourceSize": 5622
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690205,
+          "transferSize": 690201,
           "resourceSize": 1348658
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5711,
+          "transferSize": 5708,
           "resourceSize": 24067
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9413,
+          "transferSize": 9123,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484067,
+          "transferSize": 483774,
           "resourceSize": 1165829
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1982,
+          "transferSize": 1980,
           "resourceSize": 5061
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2115,
+          "transferSize": 2112,
           "resourceSize": 5454
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690202,
+          "transferSize": 690200,
           "resourceSize": 1348490
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1996,
+          "transferSize": 1993,
           "resourceSize": 5043
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690092,
+          "transferSize": 690089,
           "resourceSize": 1348079
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2189,
+          "transferSize": 2188,
           "resourceSize": 5564
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690280,
+          "transferSize": 690276,
           "resourceSize": 1348600
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3035,
+          "transferSize": 3032,
           "resourceSize": 9137
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1316,
+          "transferSize": 1319,
           "resourceSize": 604
         },
         "other": {
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2871,
+          "transferSize": 2867,
           "resourceSize": 6947
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697113,
+          "transferSize": 697112,
           "resourceSize": 1360982
         }
       },

--- a/.github/page_size_audit_results/v1.3.0.json
+++ b/.github/page_size_audit_results/v1.3.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.3.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:38.595Z"
+    "generatedAt": "2025-12-24T18:56:32.453Z"
   },
-  "timestamp": "2025-12-24T18:08:38.595Z",
+  "timestamp": "2025-12-24T18:56:32.453Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2593,
+          "transferSize": 2595,
           "resourceSize": 5460
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690268,
+          "transferSize": 690273,
           "resourceSize": 1367125
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2458,
+          "transferSize": 2456,
           "resourceSize": 5144
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5226,
+          "transferSize": 5227,
           "resourceSize": 16790
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4966,
+          "transferSize": 5007,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478996,
+          "transferSize": 479038,
           "resourceSize": 1172335
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2282,
+          "transferSize": 2283,
           "resourceSize": 4528
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689963,
+          "transferSize": 689965,
           "resourceSize": 1366193
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2447,
+          "transferSize": 2451,
           "resourceSize": 4954
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690125,
+          "transferSize": 690127,
           "resourceSize": 1366619
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2302,
+          "transferSize": 2303,
           "resourceSize": 4545
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2504,
+          "transferSize": 2506,
           "resourceSize": 5064
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690181,
+          "transferSize": 690183,
           "resourceSize": 1366729
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3190,
+          "transferSize": 3192,
           "resourceSize": 7530
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915041,
+          "transferSize": 915045,
           "resourceSize": 1593201
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3150,
+          "transferSize": 3151,
           "resourceSize": 6460
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697249,
+          "transferSize": 697250,
           "resourceSize": 1380521
         }
       },

--- a/.github/page_size_audit_results/v1.30.0.json
+++ b/.github/page_size_audit_results/v1.30.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.30.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:42.026Z"
+    "generatedAt": "2025-12-24T18:53:59.192Z"
   },
-  "timestamp": "2025-12-24T18:05:42.026Z",
+  "timestamp": "2025-12-24T18:53:59.193Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2152,
+          "transferSize": 2151,
           "resourceSize": 5712
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2113,
+          "transferSize": 2114,
           "resourceSize": 5701
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690214,
+          "transferSize": 690211,
           "resourceSize": 1348688
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9417,
+          "transferSize": 9094,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484086,
+          "transferSize": 483763,
           "resourceSize": 1165875
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1983,
+          "transferSize": 1984,
           "resourceSize": 5140
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690078,
+          "transferSize": 690084,
           "resourceSize": 1348127
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690218,
+          "transferSize": 690217,
           "resourceSize": 1348520
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1995,
+          "transferSize": 1996,
           "resourceSize": 5122
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690094,
+          "transferSize": 690096,
           "resourceSize": 1348109
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2191,
+          "transferSize": 2192,
           "resourceSize": 5643
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690289,
+          "transferSize": 690293,
           "resourceSize": 1348630
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3038,
+          "transferSize": 3039,
           "resourceSize": 9216
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1329,
+          "transferSize": 1322,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915872,
+          "transferSize": 915866,
           "resourceSize": 1576618
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697129,
+          "transferSize": 697133,
           "resourceSize": 1361034
         }
       },

--- a/.github/page_size_audit_results/v1.31.0.json
+++ b/.github/page_size_audit_results/v1.31.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.31.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:51.813Z"
+    "generatedAt": "2025-12-24T18:55:52.320Z"
   },
-  "timestamp": "2025-12-24T18:08:51.814Z",
+  "timestamp": "2025-12-24T18:55:52.321Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2153,
+          "transferSize": 2152,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690256,
+          "transferSize": 690253,
           "resourceSize": 1348703
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2116,
+          "transferSize": 2117,
           "resourceSize": 5705
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690215,
+          "transferSize": 690217,
           "resourceSize": 1348692
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5716,
+          "transferSize": 5714,
           "resourceSize": 24170
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9488,
+          "transferSize": 9434,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484156,
+          "transferSize": 484100,
           "resourceSize": 1165883
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1981,
+          "transferSize": 1982,
           "resourceSize": 5144
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690083,
+          "transferSize": 690080,
           "resourceSize": 1348131
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690217,
+          "transferSize": 690224,
           "resourceSize": 1348524
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690091,
+          "transferSize": 690093,
           "resourceSize": 1348113
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690291,
+          "transferSize": 690288,
           "resourceSize": 1348634
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1321,
+          "transferSize": 1324,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915864,
+          "transferSize": 915867,
           "resourceSize": 1576622
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2877,
+          "transferSize": 2878,
           "resourceSize": 7052
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697130,
+          "transferSize": 697128,
           "resourceSize": 1361038
         }
       },

--- a/.github/page_size_audit_results/v1.32.0.json
+++ b/.github/page_size_audit_results/v1.32.0.json
@@ -1,31 +1,31 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.32.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:51.943Z"
+    "generatedAt": "2025-12-24T18:54:05.361Z"
   },
-  "timestamp": "2025-12-24T18:05:51.943Z",
+  "timestamp": "2025-12-24T18:54:05.361Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2241,
-          "resourceSize": 5997
+          "transferSize": 2149,
+          "resourceSize": 5716
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 292616,
-          "resourceSize": 909868
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 318757,
-          "resourceSize": 717347
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 838923,
-          "resourceSize": 1857688
+          "transferSize": 690274,
+          "resourceSize": 1348816
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2205,
-          "resourceSize": 5986
+          "transferSize": 2113,
+          "resourceSize": 5705
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 292616,
-          "resourceSize": 909868
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 318757,
-          "resourceSize": 717347
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 838885,
-          "resourceSize": 1857677
+          "transferSize": 690235,
+          "resourceSize": 1348805
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5956,
-          "resourceSize": 24974
+          "transferSize": 5732,
+          "resourceSize": 24244
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 694329,
-          "resourceSize": 2066895
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 318757,
-          "resourceSize": 717347
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 11944,
-          "resourceSize": 13227
+          "transferSize": 9083,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 1031348,
-          "resourceSize": 2822718
+          "transferSize": 483790,
+          "resourceSize": 1166070
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2071,
-          "resourceSize": 5425
+          "transferSize": 1978,
+          "resourceSize": 5144
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 292616,
-          "resourceSize": 909868
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 318757,
-          "resourceSize": 717347
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 838751,
-          "resourceSize": 1857116
+          "transferSize": 690107,
+          "resourceSize": 1348244
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2206,
-          "resourceSize": 5818
+          "transferSize": 2114,
+          "resourceSize": 5537
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 292616,
-          "resourceSize": 909868
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 318757,
-          "resourceSize": 717347
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 838884,
-          "resourceSize": 1857509
+          "transferSize": 690235,
+          "resourceSize": 1348637
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2083,
-          "resourceSize": 5407
+          "transferSize": 1991,
+          "resourceSize": 5126
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 292616,
-          "resourceSize": 909868
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 318757,
-          "resourceSize": 717347
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 838762,
-          "resourceSize": 1857099
+          "transferSize": 690111,
+          "resourceSize": 1348226
         }
       },
       "themeResources": {
@@ -425,12 +425,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 687354,
-          "resourceSize": 1342906
+          "transferSize": 687353,
+          "resourceSize": 1342905
         }
       }
     },
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2281,
-          "resourceSize": 5928
+          "transferSize": 2188,
+          "resourceSize": 5647
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 292616,
-          "resourceSize": 909868
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 318757,
-          "resourceSize": 717347
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 838957,
-          "resourceSize": 1857620
+          "transferSize": 690312,
+          "resourceSize": 1348747
         }
       },
       "themeResources": {
@@ -496,12 +496,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 687354,
-          "resourceSize": 1342906
+          "transferSize": 687353,
+          "resourceSize": 1342905
         }
       }
     },
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3121,
-          "resourceSize": 9501
+          "transferSize": 3035,
+          "resourceSize": 9220
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 292616,
-          "resourceSize": 909868
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
-          "transferSize": 318757,
-          "resourceSize": 717347
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1319,
+          "transferSize": 1325,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 1064526,
-          "resourceSize": 2085608
+          "transferSize": 915888,
+          "resourceSize": 1576735
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 911529,
-          "resourceSize": 1566912
+          "transferSize": 911528,
+          "resourceSize": 1566911
         }
       }
     },
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3089,
-          "resourceSize": 7836
+          "transferSize": 2874,
+          "resourceSize": 7052
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 694329,
-          "resourceSize": 2066895
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
-          "transferSize": 318757,
-          "resourceSize": 717347
+          "transferSize": 317305,
+          "resourceSize": 716061
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3995,
-          "resourceSize": 1493
+          "transferSize": 1129,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 363,
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 1244708,
-          "resourceSize": 3017853
+          "transferSize": 697154,
+          "resourceSize": 1361151
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.32.1.json
+++ b/.github/page_size_audit_results/v1.32.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.32.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:43.315Z"
+    "generatedAt": "2025-12-24T18:53:48.188Z"
   },
-  "timestamp": "2025-12-24T18:08:43.315Z",
+  "timestamp": "2025-12-24T18:53:48.188Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2152,
+          "transferSize": 2151,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690314,
+          "transferSize": 690308,
           "resourceSize": 1348953
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2115,
           "resourceSize": 5705
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690274,
+          "transferSize": 690276,
           "resourceSize": 1348942
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9092,
+          "transferSize": 9097,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483834,
+          "transferSize": 483839,
           "resourceSize": 1166253
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1982,
+          "transferSize": 1981,
           "resourceSize": 5144
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690144,
+          "transferSize": 690139,
           "resourceSize": 1348381
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2115,
           "resourceSize": 5537
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690280,
+          "transferSize": 690277,
           "resourceSize": 1348774
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1995,
+          "transferSize": 1994,
           "resourceSize": 5126
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690154,
+          "transferSize": 690155,
           "resourceSize": 1348363
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2190,
+          "transferSize": 2188,
           "resourceSize": 5647
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690351,
+          "transferSize": 690346,
           "resourceSize": 1348884
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3038,
+          "transferSize": 3037,
           "resourceSize": 9220
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1331,
+          "transferSize": 1318,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915934,
+          "transferSize": 915920,
           "resourceSize": 1576872
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2878,
+          "transferSize": 2877,
           "resourceSize": 7052
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697189,
+          "transferSize": 697187,
           "resourceSize": 1361288
         }
       },

--- a/.github/page_size_audit_results/v1.33.0.json
+++ b/.github/page_size_audit_results/v1.33.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.33.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:39.967Z"
+    "generatedAt": "2025-12-24T18:53:48.875Z"
   },
-  "timestamp": "2025-12-24T18:05:39.968Z",
+  "timestamp": "2025-12-24T18:53:48.875Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2153,
+          "transferSize": 2152,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690308,
+          "transferSize": 690313,
           "resourceSize": 1348953
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2116,
           "resourceSize": 5705
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690281,
+          "transferSize": 690275,
           "resourceSize": 1348942
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9087,
+          "transferSize": 9482,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483829,
+          "transferSize": 484224,
           "resourceSize": 1166258
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1982,
+          "transferSize": 1983,
           "resourceSize": 5144
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690147,
+          "transferSize": 690146,
           "resourceSize": 1348381
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2118,
+          "transferSize": 2117,
           "resourceSize": 5537
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690277,
+          "transferSize": 690274,
           "resourceSize": 1348774
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690155,
+          "transferSize": 690156,
           "resourceSize": 1348363
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2191,
+          "transferSize": 2190,
           "resourceSize": 5647
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690351,
+          "transferSize": 690345,
           "resourceSize": 1348884
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1321,
+          "transferSize": 1319,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915925,
+          "transferSize": 915923,
           "resourceSize": 1576872
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697190,
+          "transferSize": 697192,
           "resourceSize": 1361288
         }
       },

--- a/.github/page_size_audit_results/v1.34.0.json
+++ b/.github/page_size_audit_results/v1.34.0.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.34.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:44.113Z"
+    "generatedAt": "2025-12-24T18:57:01.332Z"
   },
-  "timestamp": "2025-12-24T18:08:44.114Z",
+  "timestamp": "2025-12-24T18:57:01.332Z",
   "results": [
     {
       "url": "/",
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690274,
+          "transferSize": 690275,
           "resourceSize": 1348942
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9416,
+          "transferSize": 9100,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483870,
+          "transferSize": 483554,
           "resourceSize": 1165837
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1982,
+          "transferSize": 1983,
           "resourceSize": 5144
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690279,
+          "transferSize": 690276,
           "resourceSize": 1348774
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690153,
+          "transferSize": 690152,
           "resourceSize": 1348363
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690356,
+          "transferSize": 690351,
           "resourceSize": 1348884
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1320,
+          "transferSize": 1319,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915924,
+          "transferSize": 915923,
           "resourceSize": 1576872
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1131,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697179,
+          "transferSize": 697190,
           "resourceSize": 1361286
         }
       },

--- a/.github/page_size_audit_results/v1.34.1.json
+++ b/.github/page_size_audit_results/v1.34.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.34.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:46.848Z"
+    "generatedAt": "2025-12-24T18:53:53.299Z"
   },
-  "timestamp": "2025-12-24T18:08:46.848Z",
+  "timestamp": "2025-12-24T18:53:53.300Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2166,
+          "transferSize": 2167,
           "resourceSize": 5770
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690449,
+          "transferSize": 690446,
           "resourceSize": 1350739
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690407,
+          "transferSize": 690410,
           "resourceSize": 1350728
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5459,
+          "transferSize": 5460,
           "resourceSize": 23928
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9491,
+          "transferSize": 9101,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484085,
+          "transferSize": 483696,
           "resourceSize": 1167623
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2131,
+          "transferSize": 2130,
           "resourceSize": 5591
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690409,
+          "transferSize": 690412,
           "resourceSize": 1350560
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690286,
+          "transferSize": 690289,
           "resourceSize": 1350149
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2206,
+          "transferSize": 2205,
           "resourceSize": 5701
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690489,
+          "transferSize": 690490,
           "resourceSize": 1350670
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1321,
+          "transferSize": 1312,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 916079,
+          "transferSize": 916070,
           "resourceSize": 1578650
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2885,
+          "transferSize": 2884,
           "resourceSize": 7104
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697317,
+          "transferSize": 697315,
           "resourceSize": 1363072
         }
       },

--- a/.github/page_size_audit_results/v1.35.0.json
+++ b/.github/page_size_audit_results/v1.35.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.35.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:31.840Z"
+    "generatedAt": "2025-12-24T18:53:48.447Z"
   },
-  "timestamp": "2025-12-24T18:11:31.841Z",
+  "timestamp": "2025-12-24T18:53:48.448Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2164,
+          "transferSize": 2165,
           "resourceSize": 5783
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689416,
+          "transferSize": 689423,
           "resourceSize": 1345673
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2124,
+          "transferSize": 2126,
           "resourceSize": 5768
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689377,
+          "transferSize": 689379,
           "resourceSize": 1345658
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5238,
+          "transferSize": 5241,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9072,
+          "transferSize": 9101,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478631,
+          "transferSize": 478663,
           "resourceSize": 1153244
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1994,
+          "transferSize": 1995,
           "resourceSize": 5207
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689250,
+          "transferSize": 689248,
           "resourceSize": 1345097
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2128,
+          "transferSize": 2129,
           "resourceSize": 5600
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689386,
+          "transferSize": 689379,
           "resourceSize": 1345490
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2008,
+          "transferSize": 2009,
           "resourceSize": 5189
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689261,
+          "transferSize": 689267,
           "resourceSize": 1345079
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2202,
+          "transferSize": 2203,
           "resourceSize": 5710
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689455,
+          "transferSize": 689458,
           "resourceSize": 1345600
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3080,
+          "transferSize": 3081,
           "resourceSize": 9307
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1284,
+          "transferSize": 1277,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915024,
+          "transferSize": 915018,
           "resourceSize": 1573565
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2360,
+          "transferSize": 2361,
           "resourceSize": 5976
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691977,
+          "transferSize": 691981,
           "resourceSize": 1347704
         }
       },

--- a/.github/page_size_audit_results/v1.36.0.json
+++ b/.github/page_size_audit_results/v1.36.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.36.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:44.243Z"
+    "generatedAt": "2025-12-24T18:59:47.857Z"
   },
-  "timestamp": "2025-12-24T18:08:44.244Z",
+  "timestamp": "2025-12-24T18:59:47.858Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2166,
+          "transferSize": 2167,
           "resourceSize": 5788
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689267,
+          "transferSize": 689262,
           "resourceSize": 1345259
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689225,
+          "transferSize": 689219,
           "resourceSize": 1345239
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5239,
+          "transferSize": 5241,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9081,
+          "transferSize": 9109,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478485,
+          "transferSize": 478515,
           "resourceSize": 1152825
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1994,
+          "transferSize": 1995,
           "resourceSize": 5207
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689095,
+          "transferSize": 689092,
           "resourceSize": 1344678
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2129,
+          "transferSize": 2130,
           "resourceSize": 5600
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689229,
+          "transferSize": 689230,
           "resourceSize": 1345071
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2008,
+          "transferSize": 2009,
           "resourceSize": 5189
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689106,
+          "transferSize": 689104,
           "resourceSize": 1344660
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2203,
+          "transferSize": 2204,
           "resourceSize": 5710
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689299,
+          "transferSize": 689305,
           "resourceSize": 1345181
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3080,
+          "transferSize": 3081,
           "resourceSize": 9307
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1282,
+          "transferSize": 1280,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 914866,
+          "transferSize": 914865,
           "resourceSize": 1573146
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2360,
+          "transferSize": 2361,
           "resourceSize": 5976
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691828,
+          "transferSize": 691825,
           "resourceSize": 1347285
         }
       },

--- a/.github/page_size_audit_results/v1.37.0.json
+++ b/.github/page_size_audit_results/v1.37.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.37.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:49.203Z"
+    "generatedAt": "2025-12-24T18:59:37.502Z"
   },
-  "timestamp": "2025-12-24T18:05:49.203Z",
+  "timestamp": "2025-12-24T18:59:37.502Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2169,
+          "transferSize": 2170,
           "resourceSize": 5788
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689969,
+          "transferSize": 689971,
           "resourceSize": 1363050
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2129,
+          "transferSize": 2130,
           "resourceSize": 5768
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689933,
+          "transferSize": 689926,
           "resourceSize": 1363030
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9086,
+          "transferSize": 9073,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479193,
+          "transferSize": 479180,
           "resourceSize": 1170616
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689796,
+          "transferSize": 689799,
           "resourceSize": 1362469
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2132,
+          "transferSize": 2133,
           "resourceSize": 5600
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689928,
+          "transferSize": 689930,
           "resourceSize": 1362862
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689806,
+          "transferSize": 689809,
           "resourceSize": 1362451
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690007,
+          "transferSize": 689998,
           "resourceSize": 1362972
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3154,
+          "transferSize": 3155,
           "resourceSize": 9638
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1287,
+          "transferSize": 1281,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915643,
+          "transferSize": 915638,
           "resourceSize": 1591268
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2364,
+          "transferSize": 2365,
           "resourceSize": 5976
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692528,
+          "transferSize": 692530,
           "resourceSize": 1365076
         }
       },

--- a/.github/page_size_audit_results/v1.38.0.json
+++ b/.github/page_size_audit_results/v1.38.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.38.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:53.767Z"
+    "generatedAt": "2025-12-24T18:56:49.189Z"
   },
-  "timestamp": "2025-12-24T18:08:53.768Z",
+  "timestamp": "2025-12-24T18:56:49.189Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2166,
+          "transferSize": 2167,
           "resourceSize": 5788
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690141,
+          "transferSize": 690140,
           "resourceSize": 1363343
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2126,
+          "transferSize": 2127,
           "resourceSize": 5768
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690094,
+          "transferSize": 690097,
           "resourceSize": 1363323
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9078,
+          "transferSize": 9097,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479355,
+          "transferSize": 479374,
           "resourceSize": 1170909
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2006,
+          "transferSize": 2007,
           "resourceSize": 5262
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689975,
+          "transferSize": 689974,
           "resourceSize": 1362817
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690113,
+          "transferSize": 690108,
           "resourceSize": 1363193
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2008,
+          "transferSize": 2009,
           "resourceSize": 5189
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690176,
+          "transferSize": 690183,
           "resourceSize": 1363303
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2360,
+          "transferSize": 2361,
           "resourceSize": 5976
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692694,
+          "transferSize": 692698,
           "resourceSize": 1365369
         }
       },

--- a/.github/page_size_audit_results/v1.39.0.json
+++ b/.github/page_size_audit_results/v1.39.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.39.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:53.967Z"
+    "generatedAt": "2025-12-24T18:56:50.387Z"
   },
-  "timestamp": "2025-12-24T18:05:53.968Z",
+  "timestamp": "2025-12-24T18:56:50.388Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2192,
+          "transferSize": 2190,
           "resourceSize": 5873
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690163,
+          "transferSize": 690167,
           "resourceSize": 1363368
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2152,
+          "transferSize": 2149,
           "resourceSize": 5853
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690124,
+          "transferSize": 690122,
           "resourceSize": 1363348
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5273,
+          "transferSize": 5271,
           "resourceSize": 23873
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9085,
+          "transferSize": 9092,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479394,
+          "transferSize": 479399,
           "resourceSize": 1170934
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2033,
+          "transferSize": 2030,
           "resourceSize": 5347
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690001,
+          "transferSize": 689995,
           "resourceSize": 1362842
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2161,
+          "transferSize": 2159,
           "resourceSize": 5723
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690132,
+          "transferSize": 690127,
           "resourceSize": 1363218
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2035,
+          "transferSize": 2033,
           "resourceSize": 5274
         },
         "font": {
@@ -387,16 +387,16 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 359,
-          "resourceSize": 272
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 690002,
-          "resourceSize": 1362766
+          "transferSize": 689999,
+          "resourceSize": 1362769
         }
       },
       "themeResources": {
@@ -425,12 +425,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 359,
-          "resourceSize": 272
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 687197,
-          "resourceSize": 1357297
+          "transferSize": 687200,
+          "resourceSize": 1357300
         }
       }
     },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2236,
+          "transferSize": 2233,
           "resourceSize": 5833
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690209,
+          "transferSize": 690205,
           "resourceSize": 1363328
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3196,
+          "transferSize": 3193,
           "resourceSize": 9791
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1278,
+          "transferSize": 1290,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915849,
+          "transferSize": 915858,
           "resourceSize": 1591654
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2387,
+          "transferSize": 2384,
           "resourceSize": 6061
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692726,
+          "transferSize": 692721,
           "resourceSize": 1365394
         }
       },

--- a/.github/page_size_audit_results/v1.4.0.json
+++ b/.github/page_size_audit_results/v1.4.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.4.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:47.899Z"
+    "generatedAt": "2025-12-24T18:53:59.057Z"
   },
-  "timestamp": "2025-12-24T18:05:47.899Z",
+  "timestamp": "2025-12-24T18:53:59.057Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2601,
+          "transferSize": 2598,
           "resourceSize": 5465
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690280,
+          "transferSize": 690276,
           "resourceSize": 1367130
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2466,
+          "transferSize": 2463,
           "resourceSize": 5149
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690148,
+          "transferSize": 690138,
           "resourceSize": 1366814
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5227,
+          "transferSize": 5228,
           "resourceSize": 16795
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4972,
+          "transferSize": 4954,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479003,
+          "transferSize": 478986,
           "resourceSize": 1172340
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2287,
+          "transferSize": 2285,
           "resourceSize": 4533
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2456,
+          "transferSize": 2453,
           "resourceSize": 4959
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690131,
+          "transferSize": 690129,
           "resourceSize": 1366624
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2307,
+          "transferSize": 2306,
           "resourceSize": 4550
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689982,
+          "transferSize": 689985,
           "resourceSize": 1366215
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2512,
+          "transferSize": 2509,
           "resourceSize": 5069
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690187,
+          "transferSize": 690189,
           "resourceSize": 1366734
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3199,
+          "transferSize": 3195,
           "resourceSize": 7535
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915047,
+          "transferSize": 915046,
           "resourceSize": 1593206
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3156,
+          "transferSize": 3153,
           "resourceSize": 6465
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697259,
+          "transferSize": 697254,
           "resourceSize": 1380526
         }
       },

--- a/.github/page_size_audit_results/v1.40.0.json
+++ b/.github/page_size_audit_results/v1.40.0.json
@@ -1,27 +1,27 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.40.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:44.131Z"
+    "generatedAt": "2025-12-24T18:57:04.386Z"
   },
-  "timestamp": "2025-12-24T18:05:44.131Z",
+  "timestamp": "2025-12-24T18:57:04.386Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2205,
-          "resourceSize": 5922
+          "transferSize": 2271,
+          "resourceSize": 6072
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146217,
-          "resourceSize": 405056
+          "transferSize": 158831,
+          "resourceSize": 449626
         },
         "stylesheet": {
           "transferSize": 317128,
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690858,
-          "resourceSize": 1365882
+          "transferSize": 703537,
+          "resourceSize": 1410602
         }
       },
       "themeResources": {
@@ -83,16 +83,16 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2164,
-          "resourceSize": 5902
+          "transferSize": 2229,
+          "resourceSize": 6052
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146217,
-          "resourceSize": 405056
+          "transferSize": 158831,
+          "resourceSize": 449626
         },
         "stylesheet": {
           "transferSize": 317128,
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690818,
-          "resourceSize": 1365862
+          "transferSize": 703504,
+          "resourceSize": 1410582
         }
       },
       "themeResources": {
@@ -154,16 +154,16 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5252,
-          "resourceSize": 23894
+          "transferSize": 5378,
+          "resourceSize": 24191
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 148228,
-          "resourceSize": 406894
+          "transferSize": 160842,
+          "resourceSize": 451464
         },
         "stylesheet": {
           "transferSize": 317128,
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9070,
+          "transferSize": 9078,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480040,
-          "resourceSize": 1173420
+          "transferSize": 492788,
+          "resourceSize": 1218287
         }
       },
       "themeResources": {
@@ -225,16 +225,16 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2046,
-          "resourceSize": 5396
+          "transferSize": 2110,
+          "resourceSize": 5546
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146217,
-          "resourceSize": 405056
+          "transferSize": 158831,
+          "resourceSize": 449626
         },
         "stylesheet": {
           "transferSize": 317128,
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690699,
-          "resourceSize": 1365356
+          "transferSize": 703376,
+          "resourceSize": 1410076
         }
       },
       "themeResources": {
@@ -296,16 +296,16 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2174,
-          "resourceSize": 5772
+          "transferSize": 2239,
+          "resourceSize": 5922
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146217,
-          "resourceSize": 405056
+          "transferSize": 158831,
+          "resourceSize": 449626
         },
         "stylesheet": {
           "transferSize": 317128,
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690827,
-          "resourceSize": 1365732
+          "transferSize": 703504,
+          "resourceSize": 1410452
         }
       },
       "themeResources": {
@@ -367,16 +367,16 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2046,
-          "resourceSize": 5323
+          "transferSize": 2110,
+          "resourceSize": 5473
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146217,
-          "resourceSize": 405056
+          "transferSize": 158831,
+          "resourceSize": 449626
         },
         "stylesheet": {
           "transferSize": 317128,
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690699,
-          "resourceSize": 1365283
+          "transferSize": 703377,
+          "resourceSize": 1410003
         }
       },
       "themeResources": {
@@ -438,16 +438,16 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2249,
-          "resourceSize": 5882
+          "transferSize": 2313,
+          "resourceSize": 6032
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146217,
-          "resourceSize": 405056
+          "transferSize": 158831,
+          "resourceSize": 449626
         },
         "stylesheet": {
           "transferSize": 317128,
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690901,
-          "resourceSize": 1365842
+          "transferSize": 703577,
+          "resourceSize": 1410562
         }
       },
       "themeResources": {
@@ -509,16 +509,16 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3209,
-          "resourceSize": 9840
+          "transferSize": 3274,
+          "resourceSize": 9990
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146217,
-          "resourceSize": 405056
+          "transferSize": 158831,
+          "resourceSize": 449626
         },
         "stylesheet": {
           "transferSize": 317128,
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1279,
+          "transferSize": 1274,
           "resourceSize": 557
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 916545,
-          "resourceSize": 1594168
+          "transferSize": 929219,
+          "resourceSize": 1638888
         }
       },
       "themeResources": {
@@ -580,16 +580,16 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2399,
-          "resourceSize": 6120
+          "transferSize": 2530,
+          "resourceSize": 6417
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 148228,
-          "resourceSize": 406894
+          "transferSize": 160842,
+          "resourceSize": 451464
         },
         "stylesheet": {
           "transferSize": 317128,
@@ -600,16 +600,16 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 693418,
-          "resourceSize": 1367918
+          "transferSize": 706162,
+          "resourceSize": 1412786
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 687882,
-          "resourceSize": 1359765
+          "transferSize": 687883,
+          "resourceSize": 1359766
         }
       }
     }

--- a/.github/page_size_audit_results/v1.40.1.json
+++ b/.github/page_size_audit_results/v1.40.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.40.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:41.143Z"
+    "generatedAt": "2025-12-24T18:59:42.196Z"
   },
-  "timestamp": "2025-12-24T18:08:41.144Z",
+  "timestamp": "2025-12-24T18:59:42.196Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2191,
+          "transferSize": 2188,
           "resourceSize": 5810
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656885,
+          "transferSize": 656890,
           "resourceSize": 1280081
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2150,
+          "transferSize": 2145,
           "resourceSize": 5790
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5240,
+          "transferSize": 5235,
           "resourceSize": 23782
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9074,
+          "transferSize": 9079,
           "resourceSize": 11929
         },
         "other": {
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2032,
+          "transferSize": 2030,
           "resourceSize": 5284
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656728,
+          "transferSize": 656723,
           "resourceSize": 1279555
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2162,
+          "transferSize": 2157,
           "resourceSize": 5660
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656859,
+          "transferSize": 656847,
           "resourceSize": 1279931
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2032,
+          "transferSize": 2030,
           "resourceSize": 5211
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2235,
+          "transferSize": 2232,
           "resourceSize": 5770
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656933,
+          "transferSize": 656923,
           "resourceSize": 1280041
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1279,
+          "transferSize": 1277,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 882568,
+          "transferSize": 882566,
           "resourceSize": 1508367
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2386,
+          "transferSize": 2383,
           "resourceSize": 6008
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 659446,
+          "transferSize": 659439,
           "resourceSize": 1282117
         }
       },

--- a/.github/page_size_audit_results/v1.41.0.json
+++ b/.github/page_size_audit_results/v1.41.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:50.744Z"
+    "generatedAt": "2025-12-24T18:56:39.015Z"
   },
-  "timestamp": "2025-12-24T18:08:50.745Z",
+  "timestamp": "2025-12-24T18:56:39.015Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2194,
+          "transferSize": 2191,
           "resourceSize": 5816
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656885,
+          "transferSize": 656887,
           "resourceSize": 1280087
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2150,
+          "transferSize": 2149,
           "resourceSize": 5796
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5244,
+          "transferSize": 5240,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9076,
+          "transferSize": 9083,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 446081,
+          "transferSize": 446084,
           "resourceSize": 1087625
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2033,
+          "transferSize": 2031,
           "resourceSize": 5290
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656733,
+          "transferSize": 656725,
           "resourceSize": 1279561
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2163,
+          "transferSize": 2160,
           "resourceSize": 5666
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656859,
+          "transferSize": 656852,
           "resourceSize": 1279937
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2034,
+          "transferSize": 2032,
           "resourceSize": 5217
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656729,
+          "transferSize": 656724,
           "resourceSize": 1279488
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2237,
+          "transferSize": 2234,
           "resourceSize": 5776
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656932,
+          "transferSize": 656928,
           "resourceSize": 1280047
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3189,
+          "transferSize": 3188,
           "resourceSize": 9734
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1278,
+          "transferSize": 1287,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 882567,
+          "transferSize": 882575,
           "resourceSize": 1508373
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2388,
+          "transferSize": 2385,
           "resourceSize": 6014
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 659446,
+          "transferSize": 659445,
           "resourceSize": 1282123
         }
       },

--- a/.github/page_size_audit_results/v1.41.1.json
+++ b/.github/page_size_audit_results/v1.41.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:09:09.518Z"
+    "generatedAt": "2025-12-24T18:53:49.001Z"
   },
-  "timestamp": "2025-12-24T18:09:09.518Z",
+  "timestamp": "2025-12-24T18:53:49.002Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2195,
+          "transferSize": 2194,
           "resourceSize": 5816
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656896,
+          "transferSize": 656888,
           "resourceSize": 1280087
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2151,
+          "transferSize": 2152,
           "resourceSize": 5796
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656851,
+          "transferSize": 656848,
           "resourceSize": 1280067
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5246,
+          "transferSize": 5244,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9108,
+          "transferSize": 9099,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 446115,
+          "transferSize": 446104,
           "resourceSize": 1087625
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656725,
+          "transferSize": 656730,
           "resourceSize": 1279561
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2164,
+          "transferSize": 2163,
           "resourceSize": 5666
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656860,
+          "transferSize": 656858,
           "resourceSize": 1279937
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656733,
+          "transferSize": 656731,
           "resourceSize": 1279488
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2239,
+          "transferSize": 2237,
           "resourceSize": 5776
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1287,
+          "transferSize": 1280,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 882577,
+          "transferSize": 882570,
           "resourceSize": 1508373
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 659453,
+          "transferSize": 659450,
           "resourceSize": 1282123
         }
       },

--- a/.github/page_size_audit_results/v1.41.2.json
+++ b/.github/page_size_audit_results/v1.41.2.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:46.338Z"
+    "generatedAt": "2025-12-24T18:53:53.356Z"
   },
-  "timestamp": "2025-12-24T18:08:46.338Z",
+  "timestamp": "2025-12-24T18:53:53.356Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2193,
+          "transferSize": 2195,
           "resourceSize": 5816
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654881,
+          "transferSize": 654888,
           "resourceSize": 1275630
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2150,
+          "transferSize": 2153,
           "resourceSize": 5796
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654840,
+          "transferSize": 654842,
           "resourceSize": 1275610
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9088,
+          "transferSize": 9478,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 444089,
+          "transferSize": 444479,
           "resourceSize": 1083173
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654722,
+          "transferSize": 654721,
           "resourceSize": 1275104
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2161,
+          "transferSize": 2163,
           "resourceSize": 5666
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654855,
+          "transferSize": 654850,
           "resourceSize": 1275480
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2034,
+          "transferSize": 2035,
           "resourceSize": 5217
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2237,
+          "transferSize": 2238,
           "resourceSize": 5776
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654928,
+          "transferSize": 654931,
           "resourceSize": 1275590
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3190,
+          "transferSize": 3191,
           "resourceSize": 9734
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1283,
+          "transferSize": 1279,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 880568,
+          "transferSize": 880565,
           "resourceSize": 1503916
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2390,
+          "transferSize": 2389,
           "resourceSize": 6019
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1117,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 657438,
+          "transferSize": 657444,
           "resourceSize": 1277671
         }
       },

--- a/.github/page_size_audit_results/v1.42.0.json
+++ b/.github/page_size_audit_results/v1.42.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:09:12.654Z"
+    "generatedAt": "2025-12-24T18:56:36.651Z"
   },
-  "timestamp": "2025-12-24T18:09:12.654Z",
+  "timestamp": "2025-12-24T18:56:36.651Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2329,
+          "transferSize": 2334,
           "resourceSize": 6309
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408114,
+          "transferSize": 408120,
           "resourceSize": 477464
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2267,
+          "transferSize": 2271,
           "resourceSize": 6191
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407503,
+          "transferSize": 407507,
           "resourceSize": 476968
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5371,
+          "transferSize": 5376,
           "resourceSize": 24295
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10191,
+          "transferSize": 10205,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 277580,
+          "transferSize": 277599,
           "resourceSize": 524677
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2127,
+          "transferSize": 2131,
           "resourceSize": 5578
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405596,
+          "transferSize": 405603,
           "resourceSize": 473039
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2258,
+          "transferSize": 2261,
           "resourceSize": 5954
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405730,
+          "transferSize": 405731,
           "resourceSize": 473415
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2129,
+          "transferSize": 2134,
           "resourceSize": 5505
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405601,
+          "transferSize": 405604,
           "resourceSize": 472966
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2332,
+          "transferSize": 2337,
           "resourceSize": 6064
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405799,
+          "transferSize": 405804,
           "resourceSize": 473525
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3297,
+          "transferSize": 3301,
           "resourceSize": 10016
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1904,
+          "transferSize": 1926,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632787,
+          "transferSize": 632813,
           "resourceSize": 703242
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2524,
+          "transferSize": 2529,
           "resourceSize": 6519
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 489841,
+          "transferSize": 489846,
           "resourceSize": 718149
         }
       },

--- a/.github/page_size_audit_results/v1.42.1.json
+++ b/.github/page_size_audit_results/v1.42.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:35.185Z"
+    "generatedAt": "2025-12-24T18:56:38.684Z"
   },
-  "timestamp": "2025-12-24T18:08:35.186Z",
+  "timestamp": "2025-12-24T18:56:38.685Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2836,
+          "transferSize": 2834,
           "resourceSize": 7581
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408250,
+          "transferSize": 408246,
           "resourceSize": 476789
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2799,
+          "transferSize": 2796,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407896,
+          "transferSize": 407890,
           "resourceSize": 476458
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5915,
+          "transferSize": 5913,
           "resourceSize": 25659
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10189,
+          "transferSize": 10209,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 277758,
+          "transferSize": 277776,
           "resourceSize": 523718
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2659,
+          "transferSize": 2658,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405990,
+          "transferSize": 405984,
           "resourceSize": 472520
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2797,
+          "transferSize": 2795,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406125,
+          "transferSize": 406124,
           "resourceSize": 472894
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2662,
+          "transferSize": 2660,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405994,
+          "transferSize": 405991,
           "resourceSize": 472459
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2877,
+          "transferSize": 2876,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406215,
+          "transferSize": 406203,
           "resourceSize": 473015
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3853,
+          "transferSize": 3852,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1941,
+          "transferSize": 1913,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633174,
+          "transferSize": 633145,
           "resourceSize": 702666
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3051,
+          "transferSize": 3050,
           "resourceSize": 7883
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 490004,
+          "transferSize": 489999,
           "resourceSize": 717190
         }
       },

--- a/.github/page_size_audit_results/v1.42.10.json
+++ b/.github/page_size_audit_results/v1.42.10.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.10",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:06:08.761Z"
+    "generatedAt": "2025-12-24T18:53:51.723Z"
   },
-  "timestamp": "2025-12-24T18:06:08.761Z",
+  "timestamp": "2025-12-24T18:53:51.723Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2859,
+          "transferSize": 2853,
           "resourceSize": 7690
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408058,
+          "transferSize": 408053,
           "resourceSize": 476340
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2807,
+          "transferSize": 2803,
           "resourceSize": 7574
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407487,
+          "transferSize": 407477,
           "resourceSize": 475879
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5646,
+          "transferSize": 5640,
           "resourceSize": 24914
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10193,
+          "transferSize": 10164,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 201352,
+          "transferSize": 201317,
           "resourceSize": 294503
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2667,
+          "transferSize": 2664,
           "resourceSize": 6954
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405562,
+          "transferSize": 405550,
           "resourceSize": 471793
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2802,
+          "transferSize": 2798,
           "resourceSize": 7328
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405690,
+          "transferSize": 405683,
           "resourceSize": 472167
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2667,
+          "transferSize": 2665,
           "resourceSize": 6893
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405559,
+          "transferSize": 405552,
           "resourceSize": 471732
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2882,
+          "transferSize": 2880,
           "resourceSize": 7448
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405773,
+          "transferSize": 405771,
           "resourceSize": 472288
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3855,
+          "transferSize": 3853,
           "resourceSize": 11399
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1936,
+          "transferSize": 1910,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632732,
+          "transferSize": 632704,
           "resourceSize": 701939
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3089,
+          "transferSize": 3086,
           "resourceSize": 8091
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 414421,
+          "transferSize": 414418,
           "resourceSize": 489273
         }
       },

--- a/.github/page_size_audit_results/v1.42.11.json
+++ b/.github/page_size_audit_results/v1.42.11.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.11",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:28.055Z"
+    "generatedAt": "2025-12-24T18:56:51.006Z"
   },
-  "timestamp": "2025-12-24T18:11:28.056Z",
+  "timestamp": "2025-12-24T18:56:51.006Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408056,
+          "transferSize": 408054,
           "resourceSize": 476340
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2806,
+          "transferSize": 2805,
           "resourceSize": 7574
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407488,
+          "transferSize": 407483,
           "resourceSize": 475879
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10173,
+          "transferSize": 10158,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 201332,
+          "transferSize": 201317,
           "resourceSize": 294503
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405559,
+          "transferSize": 405552,
           "resourceSize": 471793
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2801,
+          "transferSize": 2800,
           "resourceSize": 7328
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405693,
+          "transferSize": 405690,
           "resourceSize": 472167
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2881,
+          "transferSize": 2882,
           "resourceSize": 7448
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405776,
+          "transferSize": 405773,
           "resourceSize": 472288
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3855,
+          "transferSize": 3856,
           "resourceSize": 11399
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1907,
+          "transferSize": 1947,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632703,
+          "transferSize": 632744,
           "resourceSize": 701939
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 414417,
+          "transferSize": 414419,
           "resourceSize": 489273
         }
       },

--- a/.github/page_size_audit_results/v1.42.12.json
+++ b/.github/page_size_audit_results/v1.42.12.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.12",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:06:25.208Z"
+    "generatedAt": "2025-12-24T18:56:40.282Z"
   },
-  "timestamp": "2025-12-24T18:06:25.209Z",
+  "timestamp": "2025-12-24T18:56:40.282Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406971,
+          "transferSize": 406972,
           "resourceSize": 476139
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5615,
+          "transferSize": 5614,
           "resourceSize": 24706
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10175,
+          "transferSize": 10166,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200240,
+          "transferSize": 200230,
           "resourceSize": 294284
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2667,
+          "transferSize": 2666,
           "resourceSize": 6963
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406944,
+          "transferSize": 406938,
           "resourceSize": 475985
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406812,
+          "transferSize": 406806,
           "resourceSize": 475550
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2879,
+          "transferSize": 2878,
           "resourceSize": 7457
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407022,
+          "transferSize": 407021,
           "resourceSize": 476105
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3871,
+          "transferSize": 3868,
           "resourceSize": 11512
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1925,
+          "transferSize": 1913,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 634191,
+          "transferSize": 634176,
           "resourceSize": 705891
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413336,
+          "transferSize": 413330,
           "resourceSize": 489072
         }
       },

--- a/.github/page_size_audit_results/v1.42.13.json
+++ b/.github/page_size_audit_results/v1.42.13.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.13",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:34.458Z"
+    "generatedAt": "2025-12-24T18:53:55.982Z"
   },
-  "timestamp": "2025-12-24T18:11:34.458Z",
+  "timestamp": "2025-12-24T18:53:55.982Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2855,
+          "transferSize": 2852,
           "resourceSize": 7687
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407599,
+          "transferSize": 407596,
           "resourceSize": 476400
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2817,
+          "transferSize": 2814,
           "resourceSize": 7675
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407558,
+          "transferSize": 407562,
           "resourceSize": 476388
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5551,
+          "transferSize": 5546,
           "resourceSize": 24731
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10180,
+          "transferSize": 10191,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200782,
+          "transferSize": 200788,
           "resourceSize": 294374
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2694,
+          "transferSize": 2691,
           "resourceSize": 7166
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407435,
+          "transferSize": 407437,
           "resourceSize": 475879
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2827,
+          "transferSize": 2824,
           "resourceSize": 7540
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407576,
+          "transferSize": 407568,
           "resourceSize": 476253
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2694,
+          "transferSize": 2691,
           "resourceSize": 7105
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407437,
+          "transferSize": 407435,
           "resourceSize": 475818
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2912,
+          "transferSize": 2909,
           "resourceSize": 7660
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 407659,
+          "transferSize": 407653,
           "resourceSize": 476374
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3770,
+          "transferSize": 3766,
           "resourceSize": 11474
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1916,
+          "transferSize": 1917,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 634682,
+          "transferSize": 634679,
           "resourceSize": 705918
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3086,
+          "transferSize": 3077,
           "resourceSize": 8115
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413965,
+          "transferSize": 413954,
           "resourceSize": 489360
         }
       },

--- a/.github/page_size_audit_results/v1.42.14.json
+++ b/.github/page_size_audit_results/v1.42.14.json
@@ -1,31 +1,31 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.14",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:32.978Z"
+    "generatedAt": "2025-12-24T18:56:42.233Z"
   },
-  "timestamp": "2025-12-24T18:11:32.979Z",
+  "timestamp": "2025-12-24T18:56:42.234Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2967,
-          "resourceSize": 7978
+          "transferSize": 2879,
+          "resourceSize": 7686
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 27781,
-          "resourceSize": 101112
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 10442,
-          "resourceSize": 57193
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 422345,
-          "resourceSize": 546439
+          "transferSize": 406663,
+          "resourceSize": 475459
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2928,
-          "resourceSize": 7966
+          "transferSize": 2837,
+          "resourceSize": 7674
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 27781,
-          "resourceSize": 101112
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 10442,
-          "resourceSize": 57193
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 422306,
-          "resourceSize": 546427
+          "transferSize": 406617,
+          "resourceSize": 475447
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5766,
-          "resourceSize": 25729
+          "transferSize": 5691,
+          "resourceSize": 25437
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 31431,
-          "resourceSize": 107420
+          "transferSize": 17751,
+          "resourceSize": 38480
         },
         "stylesheet": {
-          "transferSize": 12038,
-          "resourceSize": 63045
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10163,
+          "transferSize": 10157,
           "resourceSize": 12954
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 215610,
-          "resourceSize": 365103
+          "transferSize": 199935,
+          "resourceSize": 294123
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2804,
-          "resourceSize": 7457
+          "transferSize": 2718,
+          "resourceSize": 7165
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 27781,
-          "resourceSize": 101112
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 10442,
-          "resourceSize": 57193
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 422185,
-          "resourceSize": 545918
+          "transferSize": 406503,
+          "resourceSize": 474938
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2969,
-          "resourceSize": 7968
+          "transferSize": 2882,
+          "resourceSize": 7676
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 27781,
-          "resourceSize": 101112
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 10442,
-          "resourceSize": 57193
+          "transferSize": 8528,
+          "resourceSize": 55445
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 422346,
-          "resourceSize": 546429
+          "transferSize": 406665,
+          "resourceSize": 475449
         }
       },
       "themeResources": {
@@ -367,42 +367,8 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2807,
-          "resourceSize": 7396
-        },
-        "font": {
-          "transferSize": 155850,
-          "resourceSize": 155680
-        },
-        "script": {
-          "transferSize": 27781,
-          "resourceSize": 101112
-        },
-        "stylesheet": {
-          "transferSize": 10442,
-          "resourceSize": 57193
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 766,
-          "resourceSize": 195
-        },
-        "other": {
-          "transferSize": 363,
-          "resourceSize": 276
-        },
-        "total": {
-          "transferSize": 422184,
-          "resourceSize": 545858
-        }
-      },
-      "themeResources": {
-        "document": {
-          "transferSize": 0,
-          "resourceSize": 0
+          "transferSize": 2717,
+          "resourceSize": 7104
         },
         "font": {
           "transferSize": 155850,
@@ -415,43 +381,6 @@
         "stylesheet": {
           "transferSize": 8528,
           "resourceSize": 55445
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "other": {
-          "transferSize": 363,
-          "resourceSize": 276
-        },
-        "total": {
-          "transferSize": 403017,
-          "resourceSize": 467579
-        }
-      }
-    },
-    {
-      "url": "/categories/default",
-      "resources": {
-        "document": {
-          "transferSize": 3063,
-          "resourceSize": 8110
-        },
-        "font": {
-          "transferSize": 155850,
-          "resourceSize": 155680
-        },
-        "script": {
-          "transferSize": 27781,
-          "resourceSize": 101112
-        },
-        "stylesheet": {
-          "transferSize": 10442,
-          "resourceSize": 57193
         },
         "image": {
           "transferSize": 224175,
@@ -462,12 +391,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 422439,
-          "resourceSize": 546572
+          "transferSize": 406498,
+          "resourceSize": 474877
         }
       },
       "themeResources": {
@@ -496,12 +425,83 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 403017,
-          "resourceSize": 467579
+          "transferSize": 403016,
+          "resourceSize": 467578
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 2974,
+          "resourceSize": 7818
+        },
+        "font": {
+          "transferSize": 155850,
+          "resourceSize": 155680
+        },
+        "script": {
+          "transferSize": 14101,
+          "resourceSize": 32172
+        },
+        "stylesheet": {
+          "transferSize": 8528,
+          "resourceSize": 55445
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 769,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 362,
+          "resourceSize": 275
+        },
+        "total": {
+          "transferSize": 406759,
+          "resourceSize": 475591
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 155850,
+          "resourceSize": 155680
+        },
+        "script": {
+          "transferSize": 14101,
+          "resourceSize": 32172
+        },
+        "stylesheet": {
+          "transferSize": 8528,
+          "resourceSize": 55445
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 362,
+          "resourceSize": 275
+        },
+        "total": {
+          "transferSize": 403016,
+          "resourceSize": 467578
         }
       }
     },
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3905,
-          "resourceSize": 11918
+          "transferSize": 3822,
+          "resourceSize": 11626
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 27781,
-          "resourceSize": 101112
+          "transferSize": 14101,
+          "resourceSize": 32172
         },
         "stylesheet": {
-          "transferSize": 11287,
-          "resourceSize": 57873
+          "transferSize": 9373,
+          "resourceSize": 56125
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1910,
+          "transferSize": 1912,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 649446,
-          "resourceSize": 776110
+          "transferSize": 633771,
+          "resourceSize": 705130
         }
       },
       "themeResources": {
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3216,
-          "resourceSize": 8406
+          "transferSize": 3111,
+          "resourceSize": 8114
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 31957,
-          "resourceSize": 107774
+          "transferSize": 18277,
+          "resourceSize": 38834
         },
         "stylesheet": {
-          "transferSize": 12038,
-          "resourceSize": 63045
+          "transferSize": 10124,
+          "resourceSize": 61297
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 428726,
-          "resourceSize": 559382
+          "transferSize": 413023,
+          "resourceSize": 488402
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.2.json
+++ b/.github/page_size_audit_results/v1.42.2.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:37.178Z"
+    "generatedAt": "2025-12-24T18:53:41.920Z"
   },
-  "timestamp": "2025-12-24T18:08:37.178Z",
+  "timestamp": "2025-12-24T18:53:41.920Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2831,
+          "transferSize": 2835,
           "resourceSize": 7581
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408263,
+          "transferSize": 408265,
           "resourceSize": 476838
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2792,
+          "transferSize": 2796,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407910,
+          "transferSize": 407909,
           "resourceSize": 476507
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5588,
+          "transferSize": 5594,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10164,
+          "transferSize": 10178,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199987,
+          "transferSize": 200007,
           "resourceSize": 288729
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2656,
+          "transferSize": 2660,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406001,
+          "transferSize": 406012,
           "resourceSize": 472569
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2791,
+          "transferSize": 2794,
           "resourceSize": 7321
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406141,
+          "transferSize": 406144,
           "resourceSize": 472943
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2655,
+          "transferSize": 2659,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406005,
+          "transferSize": 406012,
           "resourceSize": 472508
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2871,
+          "transferSize": 2875,
           "resourceSize": 7441
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406221,
+          "transferSize": 406225,
           "resourceSize": 473064
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3849,
+          "transferSize": 3853,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1964,
+          "transferSize": 1923,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633214,
+          "transferSize": 633177,
           "resourceSize": 702715
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3047,
+          "transferSize": 3052,
           "resourceSize": 7883
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412582,
+          "transferSize": 412586,
           "resourceSize": 483197
         }
       },

--- a/.github/page_size_audit_results/v1.42.3.json
+++ b/.github/page_size_audit_results/v1.42.3.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:41.613Z"
+    "generatedAt": "2025-12-24T18:59:40.004Z"
   },
-  "timestamp": "2025-12-24T18:05:41.613Z",
+  "timestamp": "2025-12-24T18:59:40.005Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2834,
+          "transferSize": 2837,
           "resourceSize": 7581
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408272,
+          "transferSize": 408273,
           "resourceSize": 476838
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2797,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407917,
+          "transferSize": 407915,
           "resourceSize": 476507
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5593,
+          "transferSize": 5595,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10192,
+          "transferSize": 10162,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200004,
+          "transferSize": 199976,
           "resourceSize": 288700
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406007,
+          "transferSize": 406012,
           "resourceSize": 472569
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2794,
+          "transferSize": 2796,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406005,
+          "transferSize": 406013,
           "resourceSize": 472508
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2875,
+          "transferSize": 2876,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406228,
+          "transferSize": 406224,
           "resourceSize": 473064
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1909,
+          "transferSize": 1944,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633165,
+          "transferSize": 633200,
           "resourceSize": 702715
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3052,
+          "transferSize": 3053,
           "resourceSize": 7883
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.42.4.json
+++ b/.github/page_size_audit_results/v1.42.4.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:41.719Z"
+    "generatedAt": "2025-12-24T18:57:06.056Z"
   },
-  "timestamp": "2025-12-24T18:05:41.720Z",
+  "timestamp": "2025-12-24T18:57:06.056Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2832,
+          "transferSize": 2839,
           "resourceSize": 7581
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408268,
+          "transferSize": 408271,
           "resourceSize": 476838
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2794,
+          "transferSize": 2798,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407916,
+          "transferSize": 407912,
           "resourceSize": 476507
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5589,
+          "transferSize": 5598,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10171,
+          "transferSize": 10184,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199979,
+          "transferSize": 200001,
           "resourceSize": 288700
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2657,
+          "transferSize": 2662,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406009,
+          "transferSize": 406013,
           "resourceSize": 472569
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2792,
+          "transferSize": 2797,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406140,
+          "transferSize": 406144,
           "resourceSize": 472943
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2656,
+          "transferSize": 2662,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2872,
+          "transferSize": 2878,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406225,
+          "transferSize": 406229,
           "resourceSize": 473064
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3850,
+          "transferSize": 3857,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1917,
+          "transferSize": 1913,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633168,
+          "transferSize": 633171,
           "resourceSize": 702715
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3049,
+          "transferSize": 3053,
           "resourceSize": 7883
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.42.5.json
+++ b/.github/page_size_audit_results/v1.42.5.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.5",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:37.626Z"
+    "generatedAt": "2025-12-24T18:53:43.116Z"
   },
-  "timestamp": "2025-12-24T18:11:37.627Z",
+  "timestamp": "2025-12-24T18:53:43.117Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2848,
+          "transferSize": 2849,
           "resourceSize": 7683
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408483,
+          "transferSize": 408481,
           "resourceSize": 476970
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2794,
+          "transferSize": 2796,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407917,
+          "transferSize": 407916,
           "resourceSize": 476509
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5586,
+          "transferSize": 5588,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10169,
+          "transferSize": 10180,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199976,
+          "transferSize": 199989,
           "resourceSize": 288702
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2658,
+          "transferSize": 2659,
           "resourceSize": 6947
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406010,
+          "transferSize": 406011,
           "resourceSize": 472571
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2792,
+          "transferSize": 2794,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406143,
+          "transferSize": 406146,
           "resourceSize": 472945
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2657,
+          "transferSize": 2659,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406006,
+          "transferSize": 406010,
           "resourceSize": 472510
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2873,
+          "transferSize": 2875,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406229,
+          "transferSize": 406228,
           "resourceSize": 473066
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3851,
+          "transferSize": 3853,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1934,
+          "transferSize": 1911,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633188,
+          "transferSize": 633167,
           "resourceSize": 702717
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3060,
+          "transferSize": 3064,
           "resourceSize": 7985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1132,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413106,
+          "transferSize": 413099,
           "resourceSize": 483617
         }
       },

--- a/.github/page_size_audit_results/v1.42.6.json
+++ b/.github/page_size_audit_results/v1.42.6.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.6",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:51.593Z"
+    "generatedAt": "2025-12-24T18:56:55.930Z"
   },
-  "timestamp": "2025-12-24T18:05:51.594Z",
+  "timestamp": "2025-12-24T18:56:55.930Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2852,
+          "transferSize": 2854,
           "resourceSize": 7683
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408537,
+          "transferSize": 408541,
           "resourceSize": 477020
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2799,
+          "transferSize": 2800,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407964,
+          "transferSize": 407961,
           "resourceSize": 476559
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5592,
+          "transferSize": 5593,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10226,
+          "transferSize": 10162,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200086,
+          "transferSize": 200023,
           "resourceSize": 288752
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2661,
+          "transferSize": 2663,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406058,
+          "transferSize": 406064,
           "resourceSize": 472621
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2797,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406199,
+          "transferSize": 406196,
           "resourceSize": 472995
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2660,
+          "transferSize": 2662,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2874,
+          "transferSize": 2875,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406273,
+          "transferSize": 406278,
           "resourceSize": 473116
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3855,
+          "transferSize": 3856,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1932,
+          "transferSize": 1915,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633238,
+          "transferSize": 633222,
           "resourceSize": 702767
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3066,
+          "transferSize": 3068,
           "resourceSize": 7985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.42.7.json
+++ b/.github/page_size_audit_results/v1.42.7.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.7",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:46.332Z"
+    "generatedAt": "2025-12-24T18:56:48.194Z"
   },
-  "timestamp": "2025-12-24T18:05:46.332Z",
+  "timestamp": "2025-12-24T18:56:48.195Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407873,
+          "transferSize": 407880,
           "resourceSize": 472018
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2804,
+          "transferSize": 2805,
           "resourceSize": 7573
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407299,
+          "transferSize": 407300,
           "resourceSize": 471557
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5642,
+          "transferSize": 5645,
           "resourceSize": 24913
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10170,
+          "transferSize": 10205,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 201015,
+          "transferSize": 201053,
           "resourceSize": 290011
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2667,
+          "transferSize": 2668,
           "resourceSize": 6953
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405368,
+          "transferSize": 405375,
           "resourceSize": 467471
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2802,
+          "transferSize": 2803,
           "resourceSize": 7327
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405506,
+          "transferSize": 405510,
           "resourceSize": 467845
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2668,
+          "transferSize": 2669,
           "resourceSize": 6892
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2883,
+          "transferSize": 2884,
           "resourceSize": 7447
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405591,
+          "transferSize": 405593,
           "resourceSize": 467966
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3855,
+          "transferSize": 3857,
           "resourceSize": 11398
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1922,
+          "transferSize": 1908,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632533,
+          "transferSize": 632521,
           "resourceSize": 697617
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3090,
+          "transferSize": 3092,
           "resourceSize": 8090
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1128,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 414113,
+          "transferSize": 414116,
           "resourceSize": 484781
         }
       },

--- a/.github/page_size_audit_results/v1.42.8.json
+++ b/.github/page_size_audit_results/v1.42.8.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.8",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:49.711Z"
+    "generatedAt": "2025-12-24T18:56:34.064Z"
   },
-  "timestamp": "2025-12-24T18:05:49.711Z",
+  "timestamp": "2025-12-24T18:56:34.064Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2852,
+          "transferSize": 2857,
           "resourceSize": 7689
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408054,
+          "transferSize": 408063,
           "resourceSize": 476383
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2802,
+          "transferSize": 2804,
           "resourceSize": 7573
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407486,
+          "transferSize": 407490,
           "resourceSize": 475922
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5640,
+          "transferSize": 5641,
           "resourceSize": 24913
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10164,
+          "transferSize": 10178,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 201197,
+          "transferSize": 201212,
           "resourceSize": 294376
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2666,
+          "transferSize": 2667,
           "resourceSize": 6953
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405560,
+          "transferSize": 405567,
           "resourceSize": 471836
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2799,
           "resourceSize": 7327
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405692,
+          "transferSize": 405696,
           "resourceSize": 472210
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405564,
+          "transferSize": 405569,
           "resourceSize": 471775
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2880,
+          "transferSize": 2883,
           "resourceSize": 7447
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405778,
+          "transferSize": 405786,
           "resourceSize": 472331
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3856,
+          "transferSize": 3855,
           "resourceSize": 11398
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1912,
+          "transferSize": 1911,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632714,
+          "transferSize": 632712,
           "resourceSize": 701982
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3090,
+          "transferSize": 3091,
           "resourceSize": 8090
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 414299,
+          "transferSize": 414302,
           "resourceSize": 489146
         }
       },

--- a/.github/page_size_audit_results/v1.42.9.json
+++ b/.github/page_size_audit_results/v1.42.9.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.9",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:40.788Z"
+    "generatedAt": "2025-12-24T18:53:49.799Z"
   },
-  "timestamp": "2025-12-24T18:08:40.788Z",
+  "timestamp": "2025-12-24T18:53:49.800Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408057,
+          "transferSize": 408053,
           "resourceSize": 476339
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2802,
+          "transferSize": 2801,
           "resourceSize": 7573
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407485,
+          "transferSize": 407480,
           "resourceSize": 475878
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5638,
+          "transferSize": 5636,
           "resourceSize": 24913
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10177,
+          "transferSize": 10171,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 201307,
+          "transferSize": 201299,
           "resourceSize": 294617
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2663,
+          "transferSize": 2664,
           "resourceSize": 6953
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405557,
+          "transferSize": 405555,
           "resourceSize": 471792
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2797,
+          "transferSize": 2796,
           "resourceSize": 7327
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405688,
+          "transferSize": 405682,
           "resourceSize": 472166
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2664,
+          "transferSize": 2665,
           "resourceSize": 6892
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405764,
+          "transferSize": 405765,
           "resourceSize": 472287
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1911,
+          "transferSize": 1907,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632706,
+          "transferSize": 632702,
           "resourceSize": 701938
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3080,
+          "transferSize": 3083,
           "resourceSize": 8090
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 414390,
+          "transferSize": 414391,
           "resourceSize": 489387
         }
       },

--- a/.github/page_size_audit_results/v1.43.0.json
+++ b/.github/page_size_audit_results/v1.43.0.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.43.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:09:59.524Z"
+    "generatedAt": "2025-12-24T18:56:45.651Z"
   },
-  "timestamp": "2025-12-24T18:09:59.524Z",
+  "timestamp": "2025-12-24T18:56:45.652Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406670,
+          "transferSize": 406674,
           "resourceSize": 475489
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2838,
+          "transferSize": 2839,
           "resourceSize": 7673
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406629,
+          "transferSize": 406640,
           "resourceSize": 475477
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5688,
+          "transferSize": 5689,
           "resourceSize": 25436
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10181,
+          "transferSize": 10194,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199965,
+          "transferSize": 199979,
           "resourceSize": 294153
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2717,
+          "transferSize": 2718,
           "resourceSize": 7164
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2881,
+          "transferSize": 2883,
           "resourceSize": 7675
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406674,
+          "transferSize": 406677,
           "resourceSize": 475479
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2715,
+          "transferSize": 2716,
           "resourceSize": 7103
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406512,
+          "transferSize": 406515,
           "resourceSize": 474907
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406762,
+          "transferSize": 406767,
           "resourceSize": 475621
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3820,
+          "transferSize": 3821,
           "resourceSize": 11625
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1914,
+          "transferSize": 1919,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633780,
+          "transferSize": 633786,
           "resourceSize": 705160
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3108,
+          "transferSize": 3110,
           "resourceSize": 8113
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413025,
+          "transferSize": 413031,
           "resourceSize": 488432
         }
       },

--- a/.github/page_size_audit_results/v1.43.1.json
+++ b/.github/page_size_audit_results/v1.43.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.43.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:33.532Z"
+    "generatedAt": "2025-12-24T18:53:54.361Z"
   },
-  "timestamp": "2025-12-24T18:11:33.533Z",
+  "timestamp": "2025-12-24T18:53:54.361Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2878,
+          "transferSize": 2875,
           "resourceSize": 7579
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406674,
+          "transferSize": 406668,
           "resourceSize": 475383
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2837,
+          "transferSize": 2835,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5695,
+          "transferSize": 5693,
           "resourceSize": 25277
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10188,
+          "transferSize": 10177,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199979,
+          "transferSize": 199966,
           "resourceSize": 293994
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2718,
+          "transferSize": 2714,
           "resourceSize": 7058
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406510,
+          "transferSize": 406513,
           "resourceSize": 474862
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2880,
+          "transferSize": 2877,
           "resourceSize": 7569
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406671,
+          "transferSize": 406673,
           "resourceSize": 475373
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2714,
+          "transferSize": 2710,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406513,
+          "transferSize": 406505,
           "resourceSize": 474801
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2971,
+          "transferSize": 2968,
           "resourceSize": 7711
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406762,
+          "transferSize": 406757,
           "resourceSize": 475515
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3818,
+          "transferSize": 3821,
           "resourceSize": 11519
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1924,
+          "transferSize": 1915,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633788,
+          "transferSize": 633782,
           "resourceSize": 705054
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3109,
+          "transferSize": 3104,
           "resourceSize": 8007
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413030,
+          "transferSize": 413023,
           "resourceSize": 488326
         }
       },

--- a/.github/page_size_audit_results/v1.44.0.json
+++ b/.github/page_size_audit_results/v1.44.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.44.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:55.108Z"
+    "generatedAt": "2025-12-24T18:53:47.723Z"
   },
-  "timestamp": "2025-12-24T18:05:55.108Z",
+  "timestamp": "2025-12-24T18:53:47.723Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2871,
+          "transferSize": 2872,
           "resourceSize": 7579
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406631,
+          "transferSize": 406629,
           "resourceSize": 475351
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5686,
+          "transferSize": 5685,
           "resourceSize": 25299
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10160,
+          "transferSize": 10203,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199945,
+          "transferSize": 199987,
           "resourceSize": 293996
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2712,
+          "transferSize": 2713,
           "resourceSize": 7058
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406509,
+          "transferSize": 406515,
           "resourceSize": 474842
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2876,
+          "transferSize": 2877,
           "resourceSize": 7569
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406671,
+          "transferSize": 406672,
           "resourceSize": 475353
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406506,
+          "transferSize": 406504,
           "resourceSize": 474781
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406764,
+          "transferSize": 406763,
           "resourceSize": 475495
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1921,
+          "transferSize": 1915,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633789,
+          "transferSize": 633783,
           "resourceSize": 705047
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413043,
+          "transferSize": 413040,
           "resourceSize": 488430
         }
       },

--- a/.github/page_size_audit_results/v1.45.0.json
+++ b/.github/page_size_audit_results/v1.45.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:51.266Z"
+    "generatedAt": "2025-12-24T18:53:52.371Z"
   },
-  "timestamp": "2025-12-24T18:05:51.266Z",
+  "timestamp": "2025-12-24T18:53:52.372Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2875,
+          "transferSize": 2876,
           "resourceSize": 7621
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406675,
+          "transferSize": 406674,
           "resourceSize": 475405
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2861,
+          "transferSize": 2867,
           "resourceSize": 7616
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406657,
+          "transferSize": 406666,
           "resourceSize": 475400
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5686,
+          "transferSize": 5691,
           "resourceSize": 25299
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10169,
+          "transferSize": 10172,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199954,
+          "transferSize": 199962,
           "resourceSize": 293996
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2713,
+          "transferSize": 2716,
           "resourceSize": 7058
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406507,
+          "transferSize": 406516,
           "resourceSize": 474842
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2881,
+          "transferSize": 2884,
           "resourceSize": 7657
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406683,
+          "transferSize": 406685,
           "resourceSize": 475441
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2709,
+          "transferSize": 2712,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406515,
+          "transferSize": 406507,
           "resourceSize": 474781
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2976,
+          "transferSize": 2978,
           "resourceSize": 7799
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406771,
+          "transferSize": 406781,
           "resourceSize": 475583
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3156,
+          "transferSize": 3159,
           "resourceSize": 8770
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631973,
+          "transferSize": 631978,
           "resourceSize": 701241
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3119,
+          "transferSize": 3123,
           "resourceSize": 8131
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413047,
+          "transferSize": 413045,
           "resourceSize": 488430
         }
       },

--- a/.github/page_size_audit_results/v1.45.1.json
+++ b/.github/page_size_audit_results/v1.45.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:47.683Z"
+    "generatedAt": "2025-12-24T18:59:38.608Z"
   },
-  "timestamp": "2025-12-24T18:05:47.683Z",
+  "timestamp": "2025-12-24T18:59:38.609Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2871,
+          "transferSize": 2877,
           "resourceSize": 7621
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406658,
+          "transferSize": 406665,
           "resourceSize": 475418
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2861,
+          "transferSize": 2866,
           "resourceSize": 7616
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406648,
+          "transferSize": 406655,
           "resourceSize": 475413
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5684,
+          "transferSize": 5692,
           "resourceSize": 25299
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10174,
+          "transferSize": 10163,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199992,
+          "transferSize": 199989,
           "resourceSize": 294130
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2712,
+          "transferSize": 2717,
           "resourceSize": 7058
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406498,
+          "transferSize": 406509,
           "resourceSize": 474855
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2879,
+          "transferSize": 2884,
           "resourceSize": 7657
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406671,
+          "transferSize": 406672,
           "resourceSize": 475454
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2706,
+          "transferSize": 2710,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406493,
+          "transferSize": 406506,
           "resourceSize": 474794
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2977,
+          "transferSize": 2981,
           "resourceSize": 7799
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3153,
+          "transferSize": 3157,
           "resourceSize": 8770
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631968,
+          "transferSize": 631967,
           "resourceSize": 701254
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3115,
+          "transferSize": 3121,
           "resourceSize": 8131
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1118,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413077,
+          "transferSize": 413085,
           "resourceSize": 488572
         }
       },

--- a/.github/page_size_audit_results/v1.45.2.json
+++ b/.github/page_size_audit_results/v1.45.2.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:35.523Z"
+    "generatedAt": "2025-12-24T18:56:53.387Z"
   },
-  "timestamp": "2025-12-24T18:08:35.523Z",
+  "timestamp": "2025-12-24T18:56:53.387Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2874,
+          "transferSize": 2876,
           "resourceSize": 7621
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406666,
+          "transferSize": 406668,
           "resourceSize": 475418
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2864,
+          "transferSize": 2865,
           "resourceSize": 7616
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5690,
+          "transferSize": 5691,
           "resourceSize": 25299
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10179,
+          "transferSize": 10176,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200003,
+          "transferSize": 200001,
           "resourceSize": 294130
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406507,
+          "transferSize": 406509,
           "resourceSize": 474855
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2882,
+          "transferSize": 2883,
           "resourceSize": 7657
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2709,
+          "transferSize": 2710,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406496,
+          "transferSize": 406500,
           "resourceSize": 474794
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2977,
+          "transferSize": 2980,
           "resourceSize": 7799
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406769,
+          "transferSize": 406772,
           "resourceSize": 475596
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3155,
+          "transferSize": 3156,
           "resourceSize": 8770
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631969,
+          "transferSize": 631965,
           "resourceSize": 701254
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3119,
+          "transferSize": 3120,
           "resourceSize": 8131
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413083,
+          "transferSize": 413085,
           "resourceSize": 488572
         }
       },

--- a/.github/page_size_audit_results/v1.45.3.json
+++ b/.github/page_size_audit_results/v1.45.3.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:37.133Z"
+    "generatedAt": "2025-12-24T18:53:55.215Z"
   },
-  "timestamp": "2025-12-24T18:08:37.134Z",
+  "timestamp": "2025-12-24T18:53:55.215Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2872,
+          "transferSize": 2874,
           "resourceSize": 7621
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406685,
+          "transferSize": 406690,
           "resourceSize": 475459
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2859,
+          "transferSize": 2861,
           "resourceSize": 7616
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406671,
+          "transferSize": 406673,
           "resourceSize": 475454
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5695,
+          "transferSize": 5698,
           "resourceSize": 25352
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10172,
+          "transferSize": 10198,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200023,
+          "transferSize": 200052,
           "resourceSize": 294224
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2727,
+          "transferSize": 2728,
           "resourceSize": 7168
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406823,
+          "transferSize": 406821,
           "resourceSize": 475120
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2880,
+          "transferSize": 2882,
           "resourceSize": 7753
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406928,
+          "transferSize": 406935,
           "resourceSize": 475664
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2706,
+          "transferSize": 2708,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406521,
+          "transferSize": 406526,
           "resourceSize": 474835
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2972,
+          "transferSize": 2974,
           "resourceSize": 7799
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406783,
+          "transferSize": 406787,
           "resourceSize": 475637
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3152,
+          "transferSize": 3155,
           "resourceSize": 8770
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 762,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631978,
+          "transferSize": 631987,
           "resourceSize": 701295
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3116,
+          "transferSize": 3117,
           "resourceSize": 8131
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413110,
+          "transferSize": 413104,
           "resourceSize": 488613
         }
       },

--- a/.github/page_size_audit_results/v1.45.4.json
+++ b/.github/page_size_audit_results/v1.45.4.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:12:09.855Z"
+    "generatedAt": "2025-12-24T18:59:37.066Z"
   },
-  "timestamp": "2025-12-24T18:12:09.855Z",
+  "timestamp": "2025-12-24T18:59:37.066Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2878,
+          "transferSize": 2873,
           "resourceSize": 7621
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406698,
+          "transferSize": 406689,
           "resourceSize": 475459
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2864,
+          "transferSize": 2860,
           "resourceSize": 7616
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406677,
+          "transferSize": 406679,
           "resourceSize": 475454
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5703,
+          "transferSize": 5699,
           "resourceSize": 25352
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10171,
+          "transferSize": 10220,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200030,
+          "transferSize": 200075,
           "resourceSize": 294224
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2732,
+          "transferSize": 2729,
           "resourceSize": 7168
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406823,
+          "transferSize": 406819,
           "resourceSize": 475120
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2886,
+          "transferSize": 2881,
           "resourceSize": 7753
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406939,
+          "transferSize": 406930,
           "resourceSize": 475664
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2711,
+          "transferSize": 2709,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406529,
+          "transferSize": 406521,
           "resourceSize": 474835
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2979,
+          "transferSize": 2974,
           "resourceSize": 7799
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406796,
+          "transferSize": 406793,
           "resourceSize": 475637
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3157,
+          "transferSize": 3155,
           "resourceSize": 8770
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631989,
+          "transferSize": 631988,
           "resourceSize": 701295
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3122,
+          "transferSize": 3118,
           "resourceSize": 8131
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413110,
+          "transferSize": 413108,
           "resourceSize": 488613
         }
       },

--- a/.github/page_size_audit_results/v1.46.0.json
+++ b/.github/page_size_audit_results/v1.46.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.46.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:06:19.904Z"
+    "generatedAt": "2025-12-24T18:53:52.213Z"
   },
-  "timestamp": "2025-12-24T18:06:19.904Z",
+  "timestamp": "2025-12-24T18:53:52.214Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2900,
+          "transferSize": 2899,
           "resourceSize": 7807
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407286,
+          "transferSize": 407287,
           "resourceSize": 474626
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2872,
+          "transferSize": 2871,
           "resourceSize": 7702
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5707,
+          "transferSize": 5705,
           "resourceSize": 25303
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10177,
+          "transferSize": 10173,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199564,
+          "transferSize": 199558,
           "resourceSize": 292443
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2706,
+          "transferSize": 2705,
           "resourceSize": 7119
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2875,
+          "transferSize": 2873,
           "resourceSize": 7728
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406454,
+          "transferSize": 406446,
           "resourceSize": 473897
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2694,
+          "transferSize": 2693,
           "resourceSize": 6948
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406022,
+          "transferSize": 406031,
           "resourceSize": 473044
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2968,
+          "transferSize": 2967,
           "resourceSize": 7774
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406305,
+          "transferSize": 406309,
           "resourceSize": 473871
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3149,
+          "transferSize": 3147,
           "resourceSize": 8745
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631508,
+          "transferSize": 631501,
           "resourceSize": 699528
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3107,
+          "transferSize": 3106,
           "resourceSize": 8082
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412618,
+          "transferSize": 412623,
           "resourceSize": 486832
         }
       },

--- a/.github/page_size_audit_results/v1.47.0.json
+++ b/.github/page_size_audit_results/v1.47.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.47.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:49.292Z"
+    "generatedAt": "2025-12-24T18:56:41.650Z"
   },
-  "timestamp": "2025-12-24T18:08:49.292Z",
+  "timestamp": "2025-12-24T18:56:41.650Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2894,
+          "transferSize": 2898,
           "resourceSize": 7802
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407280,
+          "transferSize": 407292,
           "resourceSize": 474621
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2870,
+          "transferSize": 2872,
           "resourceSize": 7697
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406835,
+          "transferSize": 406834,
           "resourceSize": 474254
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5688,
+          "transferSize": 5693,
           "resourceSize": 25293
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10165,
+          "transferSize": 10195,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199533,
+          "transferSize": 199568,
           "resourceSize": 292433
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2707,
+          "transferSize": 2711,
           "resourceSize": 7114
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406323,
+          "transferSize": 406320,
           "resourceSize": 473324
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2872,
+          "transferSize": 2876,
           "resourceSize": 7723
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2687,
+          "transferSize": 2691,
           "resourceSize": 6943
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406025,
+          "transferSize": 406024,
           "resourceSize": 473039
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2964,
+          "transferSize": 2968,
           "resourceSize": 7769
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406299,
+          "transferSize": 406306,
           "resourceSize": 473866
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3144,
+          "transferSize": 3148,
           "resourceSize": 8740
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631500,
+          "transferSize": 631503,
           "resourceSize": 699523
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3100,
+          "transferSize": 3106,
           "resourceSize": 8077
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412612,
+          "transferSize": 412621,
           "resourceSize": 486827
         }
       },

--- a/.github/page_size_audit_results/v1.48.0.json
+++ b/.github/page_size_audit_results/v1.48.0.json
@@ -1,38 +1,38 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:51.683Z"
+    "generatedAt": "2025-12-24T18:59:31.281Z"
   },
-  "timestamp": "2025-12-24T18:05:51.684Z",
+  "timestamp": "2025-12-24T18:59:31.282Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2857,
-          "resourceSize": 7782
+          "transferSize": 3027,
+          "resourceSize": 8239
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 12419,
-          "resourceSize": 28959
+          "transferSize": 48977,
+          "resourceSize": 136511
         },
         "stylesheet": {
-          "transferSize": 9800,
-          "resourceSize": 54654
+          "transferSize": 10970,
+          "resourceSize": 55658
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406233,
-          "resourceSize": 471551
+          "transferSize": 444133,
+          "resourceSize": 580564
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2830,
-          "resourceSize": 7677
+          "transferSize": 2990,
+          "resourceSize": 8134
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 12419,
-          "resourceSize": 28959
+          "transferSize": 48977,
+          "resourceSize": 136511
         },
         "stylesheet": {
-          "transferSize": 9373,
-          "resourceSize": 54392
+          "transferSize": 10543,
+          "resourceSize": 55396
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405773,
-          "resourceSize": 471184
+          "transferSize": 443665,
+          "resourceSize": 580197
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5647,
-          "resourceSize": 25164
+          "transferSize": 5778,
+          "resourceSize": 25805
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 16074,
-          "resourceSize": 35359
+          "transferSize": 52632,
+          "resourceSize": 142911
         },
         "stylesheet": {
-          "transferSize": 9359,
-          "resourceSize": 57724
+          "transferSize": 10529,
+          "resourceSize": 58728
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10174,
+          "transferSize": 10215,
           "resourceSize": 12954
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 197466,
-          "resourceSize": 287156
+          "transferSize": 235366,
+          "resourceSize": 396353
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2672,
-          "resourceSize": 7094
+          "transferSize": 2820,
+          "resourceSize": 7551
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 12380,
-          "resourceSize": 28920
+          "transferSize": 48938,
+          "resourceSize": 136472
         },
         "stylesheet": {
-          "transferSize": 9065,
-          "resourceSize": 54084
+          "transferSize": 10235,
+          "resourceSize": 55088
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405276,
-          "resourceSize": 470254
+          "transferSize": 443148,
+          "resourceSize": 579267
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2835,
-          "resourceSize": 7703
+          "transferSize": 2989,
+          "resourceSize": 8160
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 12380,
-          "resourceSize": 28920
+          "transferSize": 48938,
+          "resourceSize": 136472
         },
         "stylesheet": {
-          "transferSize": 9023,
-          "resourceSize": 54043
+          "transferSize": 10193,
+          "resourceSize": 55047
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405394,
-          "resourceSize": 470822
+          "transferSize": 443279,
+          "resourceSize": 579835
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2652,
-          "resourceSize": 6923
+          "transferSize": 2805,
+          "resourceSize": 7380
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 12380,
-          "resourceSize": 28920
+          "transferSize": 48938,
+          "resourceSize": 136472
         },
         "stylesheet": {
-          "transferSize": 8786,
-          "resourceSize": 53970
+          "transferSize": 9956,
+          "resourceSize": 54974
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 404974,
-          "resourceSize": 469969
+          "transferSize": 442857,
+          "resourceSize": 578983
         }
       },
       "themeResources": {
@@ -425,12 +425,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 401553,
-          "resourceSize": 462851
+          "transferSize": 401554,
+          "resourceSize": 462852
         }
       }
     },
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2931,
-          "resourceSize": 7749
+          "transferSize": 3095,
+          "resourceSize": 8206
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 12380,
-          "resourceSize": 28920
+          "transferSize": 48938,
+          "resourceSize": 136472
         },
         "stylesheet": {
-          "transferSize": 8786,
-          "resourceSize": 53970
+          "transferSize": 9956,
+          "resourceSize": 54974
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405253,
-          "resourceSize": 470796
+          "transferSize": 443154,
+          "resourceSize": 579809
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3109,
-          "resourceSize": 8720
+          "transferSize": 3255,
+          "resourceSize": 9177
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 12380,
-          "resourceSize": 28920
+          "transferSize": 48938,
+          "resourceSize": 136472
         },
         "stylesheet": {
-          "transferSize": 9631,
-          "resourceSize": 54650
+          "transferSize": 10801,
+          "resourceSize": 55654
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 630459,
-          "resourceSize": 696453
+          "transferSize": 668329,
+          "resourceSize": 805466
         }
       },
       "themeResources": {
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3039,
-          "resourceSize": 7837
+          "transferSize": 3189,
+          "resourceSize": 8294
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 14391,
-          "resourceSize": 30758
+          "transferSize": 50949,
+          "resourceSize": 138310
         },
         "stylesheet": {
-          "transferSize": 8786,
-          "resourceSize": 53970
+          "transferSize": 9956,
+          "resourceSize": 54974
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 407729,
-          "resourceSize": 472722
+          "transferSize": 445605,
+          "resourceSize": 581735
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.48.1.json
+++ b/.github/page_size_audit_results/v1.48.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:51.361Z"
+    "generatedAt": "2025-12-24T18:54:00.434Z"
   },
-  "timestamp": "2025-12-24T18:08:51.361Z",
+  "timestamp": "2025-12-24T18:54:00.434Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2840,
+          "transferSize": 2837,
           "resourceSize": 8006
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 74030,
+          "transferSize": 74028,
           "resourceSize": 161858
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2818,
+          "transferSize": 2815,
           "resourceSize": 7902
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 73581,
+          "transferSize": 73576,
           "resourceSize": 161492
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5552,
+          "transferSize": 5550,
           "resourceSize": 24618
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10183,
+          "transferSize": 10174,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 89366,
+          "transferSize": 89355,
           "resourceSize": 186995
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2655,
+          "transferSize": 2653,
           "resourceSize": 7323
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 73066,
+          "transferSize": 73067,
           "resourceSize": 160566
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2818,
+          "transferSize": 2811,
           "resourceSize": 7928
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 73195,
+          "transferSize": 73179,
           "resourceSize": 161130
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2631,
+          "transferSize": 2629,
           "resourceSize": 7152
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 72761,
+          "transferSize": 72764,
           "resourceSize": 160281
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2908,
+          "transferSize": 2905,
           "resourceSize": 7974
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 73038,
+          "transferSize": 73041,
           "resourceSize": 161103
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3148,
+          "transferSize": 3147,
           "resourceSize": 9390
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 74128,
+          "transferSize": 74123,
           "resourceSize": 163199
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3017,
+          "transferSize": 3011,
           "resourceSize": 8037
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 75515,
+          "transferSize": 75509,
           "resourceSize": 163004
         }
       },

--- a/.github/page_size_audit_results/v1.48.2.json
+++ b/.github/page_size_audit_results/v1.48.2.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:57.039Z"
+    "generatedAt": "2025-12-24T18:56:39.916Z"
   },
-  "timestamp": "2025-12-24T18:08:57.039Z",
+  "timestamp": "2025-12-24T18:56:39.917Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2855,
+          "transferSize": 2859,
           "resourceSize": 8039
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 73332,
+          "transferSize": 73334,
           "resourceSize": 158144
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2879,
+          "transferSize": 2882,
           "resourceSize": 8237
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 73597,
+          "transferSize": 73606,
           "resourceSize": 158424
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5563,
+          "transferSize": 5569,
           "resourceSize": 24720
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10162,
+          "transferSize": 10177,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 89618,
+          "transferSize": 89639,
           "resourceSize": 185891
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 72228,
+          "transferSize": 72233,
           "resourceSize": 156697
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2899,
+          "transferSize": 2903,
           "resourceSize": 8261
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 73859,
+          "transferSize": 73864,
           "resourceSize": 158521
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2632,
+          "transferSize": 2634,
           "resourceSize": 7152
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 71939,
+          "transferSize": 71936,
           "resourceSize": 156412
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2991,
+          "transferSize": 2995,
           "resourceSize": 8307
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 73713,
+          "transferSize": 73715,
           "resourceSize": 158494
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3223,
+          "transferSize": 3229,
           "resourceSize": 9714
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 75553,
+          "transferSize": 75563,
           "resourceSize": 162819
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3025,
+          "transferSize": 3032,
           "resourceSize": 8139
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 75703,
+          "transferSize": 75707,
           "resourceSize": 161557
         }
       },

--- a/.github/page_size_audit_results/v1.48.3.json
+++ b/.github/page_size_audit_results/v1.48.3.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:50.007Z"
+    "generatedAt": "2025-12-24T18:53:51.821Z"
   },
-  "timestamp": "2025-12-24T18:08:50.008Z",
+  "timestamp": "2025-12-24T18:53:51.821Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2818,
+          "transferSize": 2817,
           "resourceSize": 8032
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 73792,
+          "transferSize": 73788,
           "resourceSize": 158051
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2821,
+          "transferSize": 2820,
           "resourceSize": 8098
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 74038,
+          "transferSize": 74037,
           "resourceSize": 158199
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10179,
+          "transferSize": 10165,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 90564,
+          "transferSize": 90550,
           "resourceSize": 185956
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 72719,
+          "transferSize": 72720,
           "resourceSize": 156641
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2851,
+          "transferSize": 2849,
           "resourceSize": 8241
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -387,7 +387,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 72424,
+          "transferSize": 72426,
           "resourceSize": 156350
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 74166,
+          "transferSize": 74167,
           "resourceSize": 158383
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3176,
+          "transferSize": 3178,
           "resourceSize": 9688
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 76005,
+          "transferSize": 76004,
           "resourceSize": 162707
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3006,
+          "transferSize": 3004,
           "resourceSize": 8156
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 13704
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 76186,
+          "transferSize": 76187,
           "resourceSize": 161498
         }
       },

--- a/.github/page_size_audit_results/v1.49.0.json
+++ b/.github/page_size_audit_results/v1.49.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.49.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:35.569Z"
+    "generatedAt": "2025-12-24T18:57:33.509Z"
   },
-  "timestamp": "2025-12-24T18:08:35.569Z",
+  "timestamp": "2025-12-24T18:57:33.509Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2815,
+          "transferSize": 2817,
           "resourceSize": 8010
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 76771,
+          "transferSize": 76773,
           "resourceSize": 177855
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2850,
+          "transferSize": 2851,
           "resourceSize": 8264
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 79125,
+          "transferSize": 79126,
           "resourceSize": 179927
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5434,
+          "transferSize": 5438,
           "resourceSize": 24736
         },
         "font": {
@@ -182,7 +182,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 86279,
+          "transferSize": 86283,
           "resourceSize": 194504
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2627,
+          "transferSize": 2630,
           "resourceSize": 7321
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 75697,
+          "transferSize": 75700,
           "resourceSize": 176445
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2844,
+          "transferSize": 2846,
           "resourceSize": 8219
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 77283,
+          "transferSize": 77285,
           "resourceSize": 178219
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2610,
+          "transferSize": 2613,
           "resourceSize": 7144
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 75401,
+          "transferSize": 75404,
           "resourceSize": 176154
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2943,
+          "transferSize": 2944,
           "resourceSize": 8260
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 77145,
+          "transferSize": 77146,
           "resourceSize": 178187
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3166,
+          "transferSize": 3168,
           "resourceSize": 9666
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 78976,
+          "transferSize": 78978,
           "resourceSize": 182511
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2992,
+          "transferSize": 2995,
           "resourceSize": 8134
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 79156,
+          "transferSize": 79159,
           "resourceSize": 181302
         }
       },

--- a/.github/page_size_audit_results/v1.49.1.json
+++ b/.github/page_size_audit_results/v1.49.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.49.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:51.545Z"
+    "generatedAt": "2025-12-24T18:56:46.799Z"
   },
-  "timestamp": "2025-12-24T18:05:51.545Z",
+  "timestamp": "2025-12-24T18:56:46.800Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2821,
+          "transferSize": 2823,
           "resourceSize": 8036
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 76656,
+          "transferSize": 76658,
           "resourceSize": 177261
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5435,
+          "transferSize": 5438,
           "resourceSize": 24788
         },
         "font": {
@@ -182,7 +182,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 86159,
+          "transferSize": 86162,
           "resourceSize": 193936
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2627,
+          "transferSize": 2626,
           "resourceSize": 7347
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 75576,
+          "transferSize": 75575,
           "resourceSize": 175851
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2844,
+          "transferSize": 2845,
           "resourceSize": 8245
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 77162,
+          "transferSize": 77163,
           "resourceSize": 177625
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2611,
+          "transferSize": 2613,
           "resourceSize": 7170
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 75281,
+          "transferSize": 75283,
           "resourceSize": 175560
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2944,
+          "transferSize": 2943,
           "resourceSize": 8286
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 77025,
+          "transferSize": 77024,
           "resourceSize": 177593
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3172,
+          "transferSize": 3173,
           "resourceSize": 9692
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 78861,
+          "transferSize": 78862,
           "resourceSize": 181917
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2998,
+          "transferSize": 2997,
           "resourceSize": 8160
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 79041,
+          "transferSize": 79040,
           "resourceSize": 180708
         }
       },

--- a/.github/page_size_audit_results/v1.49.2.json
+++ b/.github/page_size_audit_results/v1.49.2.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.49.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:45.217Z"
+    "generatedAt": "2025-12-24T18:53:52.144Z"
   },
-  "timestamp": "2025-12-24T18:11:45.217Z",
+  "timestamp": "2025-12-24T18:53:52.144Z",
   "results": [
     {
       "url": "/",
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5441,
+          "transferSize": 5442,
           "resourceSize": 24786
         },
         "font": {
@@ -182,7 +182,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 86173,
+          "transferSize": 86174,
           "resourceSize": 193931
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2945,
+          "transferSize": 2944,
           "resourceSize": 8284
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 77033,
+          "transferSize": 77032,
           "resourceSize": 177588
         }
       },

--- a/.github/page_size_audit_results/v1.5.0.json
+++ b/.github/page_size_audit_results/v1.5.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.5.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:56.017Z"
+    "generatedAt": "2025-12-24T18:56:47.361Z"
   },
-  "timestamp": "2025-12-24T18:08:56.018Z",
+  "timestamp": "2025-12-24T18:56:47.361Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2597,
+          "transferSize": 2598,
           "resourceSize": 5465
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2463,
+          "transferSize": 2464,
           "resourceSize": 5149
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690146,
+          "transferSize": 690141,
           "resourceSize": 1366814
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5228,
+          "transferSize": 5229,
           "resourceSize": 16795
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4975,
+          "transferSize": 4969,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479007,
+          "transferSize": 479002,
           "resourceSize": 1172340
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2284,
+          "transferSize": 2285,
           "resourceSize": 4533
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2453,
+          "transferSize": 2454,
           "resourceSize": 4959
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690130,
+          "transferSize": 690138,
           "resourceSize": 1366624
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2295,
+          "transferSize": 2296,
           "resourceSize": 4515
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689975,
+          "transferSize": 689974,
           "resourceSize": 1366180
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3193,
+          "transferSize": 3196,
           "resourceSize": 7535
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915044,
+          "transferSize": 915048,
           "resourceSize": 1593206
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3152,
+          "transferSize": 3153,
           "resourceSize": 6465
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.50.0.json
+++ b/.github/page_size_audit_results/v1.50.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.50.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:08:41.672Z"
+    "generatedAt": "2025-12-24T18:59:33.478Z"
   },
-  "timestamp": "2025-12-24T18:08:41.672Z",
+  "timestamp": "2025-12-24T18:59:33.478Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2779,
+          "transferSize": 2786,
           "resourceSize": 7571
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 75627,
+          "transferSize": 75634,
           "resourceSize": 167780
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2816,
+          "transferSize": 2822,
           "resourceSize": 7879
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 77959,
+          "transferSize": 77965,
           "resourceSize": 169882
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5389,
+          "transferSize": 5395,
           "resourceSize": 24521
         },
         "font": {
@@ -182,7 +182,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 85143,
+          "transferSize": 85149,
           "resourceSize": 184713
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2601,
+          "transferSize": 2604,
           "resourceSize": 6936
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 74592,
+          "transferSize": 74595,
           "resourceSize": 166453
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2804,
+          "transferSize": 2810,
           "resourceSize": 7824
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 76135,
+          "transferSize": 76141,
           "resourceSize": 168188
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2590,
+          "transferSize": 2594,
           "resourceSize": 6759
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 74302,
+          "transferSize": 74306,
           "resourceSize": 166162
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2882,
+          "transferSize": 2886,
           "resourceSize": 7821
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 75976,
+          "transferSize": 75980,
           "resourceSize": 168112
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3139,
+          "transferSize": 3145,
           "resourceSize": 9281
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 77834,
+          "transferSize": 77840,
           "resourceSize": 172495
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2956,
+          "transferSize": 2961,
           "resourceSize": 7695
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 13704
         },
         "total": {
-          "transferSize": 78034,
+          "transferSize": 78039,
           "resourceSize": 171261
         }
       },

--- a/.github/page_size_audit_results/v1.6.0.json
+++ b/.github/page_size_audit_results/v1.6.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.6.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:40.796Z"
+    "generatedAt": "2025-12-24T18:56:47.543Z"
   },
-  "timestamp": "2025-12-24T18:05:40.796Z",
+  "timestamp": "2025-12-24T18:56:47.543Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2599,
+          "transferSize": 2600,
           "resourceSize": 5476
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690287,
+          "transferSize": 690290,
           "resourceSize": 1367164
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2465,
+          "transferSize": 2467,
           "resourceSize": 5160
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690151,
+          "transferSize": 690157,
           "resourceSize": 1366848
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5227,
+          "transferSize": 5228,
           "resourceSize": 16806
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5004,
+          "transferSize": 4976,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479048,
+          "transferSize": 479021,
           "resourceSize": 1172374
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2288,
+          "transferSize": 2289,
           "resourceSize": 4544
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689983,
+          "transferSize": 689981,
           "resourceSize": 1366232
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2456,
+          "transferSize": 2457,
           "resourceSize": 4970
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690144,
+          "transferSize": 690150,
           "resourceSize": 1366658
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2300,
+          "transferSize": 2301,
           "resourceSize": 4526
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689989,
+          "transferSize": 689990,
           "resourceSize": 1366214
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2512,
+          "transferSize": 2513,
           "resourceSize": 5080
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690199,
+          "transferSize": 690202,
           "resourceSize": 1366768
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915066,
+          "transferSize": 915065,
           "resourceSize": 1593240
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697271,
+          "transferSize": 697270,
           "resourceSize": 1380560
         }
       },

--- a/.github/page_size_audit_results/v1.6.1.json
+++ b/.github/page_size_audit_results/v1.6.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.6.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:45.744Z"
+    "generatedAt": "2025-12-24T18:54:13.302Z"
   },
-  "timestamp": "2025-12-24T18:05:45.745Z",
+  "timestamp": "2025-12-24T18:54:13.302Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2602,
+          "transferSize": 2598,
           "resourceSize": 5477
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690298,
+          "transferSize": 690293,
           "resourceSize": 1367177
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2469,
+          "transferSize": 2465,
           "resourceSize": 5161
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690160,
+          "transferSize": 690161,
           "resourceSize": 1366861
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5228,
+          "transferSize": 5230,
           "resourceSize": 16807
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4973,
+          "transferSize": 4969,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479021,
+          "transferSize": 479019,
           "resourceSize": 1172387
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2290,
+          "transferSize": 2287,
           "resourceSize": 4545
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689982,
+          "transferSize": 689979,
           "resourceSize": 1366245
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2459,
+          "transferSize": 2455,
           "resourceSize": 4971
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690150,
+          "transferSize": 690147,
           "resourceSize": 1366671
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2302,
+          "transferSize": 2299,
           "resourceSize": 4527
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690000,
+          "transferSize": 689993,
           "resourceSize": 1366227
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2514,
+          "transferSize": 2511,
           "resourceSize": 5081
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690209,
+          "transferSize": 690204,
           "resourceSize": 1366781
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3204,
+          "transferSize": 3199,
           "resourceSize": 7547
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915073,
+          "transferSize": 915062,
           "resourceSize": 1593253
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3159,
+          "transferSize": 3155,
           "resourceSize": 6477
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697280,
+          "transferSize": 697272,
           "resourceSize": 1380573
         }
       },

--- a/.github/page_size_audit_results/v1.7.0.json
+++ b/.github/page_size_audit_results/v1.7.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.7.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:05:53.900Z"
+    "generatedAt": "2025-12-24T18:53:47.197Z"
   },
-  "timestamp": "2025-12-24T18:05:53.900Z",
+  "timestamp": "2025-12-24T18:53:47.197Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2646,
+          "transferSize": 2645,
           "resourceSize": 5549
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690758,
+          "transferSize": 690761,
           "resourceSize": 1367249
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2513,
+          "transferSize": 2512,
           "resourceSize": 5233
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690631,
+          "transferSize": 690629,
           "resourceSize": 1366933
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5228,
+          "transferSize": 5230,
           "resourceSize": 16807
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4994,
+          "transferSize": 4998,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479042,
+          "transferSize": 479048,
           "resourceSize": 1172387
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2334,
+          "transferSize": 2332,
           "resourceSize": 4617
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690447,
+          "transferSize": 690445,
           "resourceSize": 1366317
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2504,
+          "transferSize": 2500,
           "resourceSize": 5043
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690622,
+          "transferSize": 690616,
           "resourceSize": 1366743
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2348,
+          "transferSize": 2345,
           "resourceSize": 4599
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690462,
+          "transferSize": 690461,
           "resourceSize": 1366299
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2560,
+          "transferSize": 2558,
           "resourceSize": 5153
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690673,
+          "transferSize": 690675,
           "resourceSize": 1366853
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3200,
+          "transferSize": 3197,
           "resourceSize": 7472
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3203,
+          "transferSize": 3201,
           "resourceSize": 6549
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697742,
+          "transferSize": 697737,
           "resourceSize": 1380645
         }
       },

--- a/.github/page_size_audit_results/v1.8.0.json
+++ b/.github/page_size_audit_results/v1.8.0.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:40.925Z"
+    "generatedAt": "2025-12-24T18:54:03.209Z"
   },
-  "timestamp": "2025-12-24T18:11:40.926Z",
+  "timestamp": "2025-12-24T18:54:03.209Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2644,
+          "transferSize": 2647,
           "resourceSize": 5554
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690761,
+          "transferSize": 690762,
           "resourceSize": 1367254
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2511,
+          "transferSize": 2514,
           "resourceSize": 5238
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690632,
+          "transferSize": 690628,
           "resourceSize": 1366938
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4985,
+          "transferSize": 4966,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479033,
+          "transferSize": 479014,
           "resourceSize": 1172392
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2333,
+          "transferSize": 2337,
           "resourceSize": 4622
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690447,
+          "transferSize": 690457,
           "resourceSize": 1366322
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2501,
+          "transferSize": 2503,
           "resourceSize": 5048
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690613,
+          "transferSize": 690619,
           "resourceSize": 1366748
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2346,
+          "transferSize": 2350,
           "resourceSize": 4604
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690464,
+          "transferSize": 690467,
           "resourceSize": 1366304
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2559,
+          "transferSize": 2561,
           "resourceSize": 5158
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690681,
+          "transferSize": 690673,
           "resourceSize": 1366858
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3197,
+          "transferSize": 3201,
           "resourceSize": 7477
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691308,
+          "transferSize": 691319,
           "resourceSize": 1593183
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3201,
+          "transferSize": 3205,
           "resourceSize": 6554
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697739,
+          "transferSize": 697748,
           "resourceSize": 1380650
         }
       },

--- a/.github/page_size_audit_results/v1.8.1.json
+++ b/.github/page_size_audit_results/v1.8.1.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:34.377Z"
+    "generatedAt": "2025-12-24T18:53:56.555Z"
   },
-  "timestamp": "2025-12-24T18:11:34.378Z",
+  "timestamp": "2025-12-24T18:53:56.555Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2646,
+          "transferSize": 2647,
           "resourceSize": 5554
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690759,
+          "transferSize": 690761,
           "resourceSize": 1367254
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2512,
+          "transferSize": 2514,
           "resourceSize": 5238
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690624,
+          "transferSize": 690632,
           "resourceSize": 1366938
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5229,
+          "transferSize": 5227,
           "resourceSize": 16812
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4963,
+          "transferSize": 4972,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479012,
+          "transferSize": 479019,
           "resourceSize": 1172392
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2333,
+          "transferSize": 2336,
           "resourceSize": 4622
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690448,
+          "transferSize": 690450,
           "resourceSize": 1366322
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2501,
+          "transferSize": 2503,
           "resourceSize": 5048
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690615,
+          "transferSize": 690619,
           "resourceSize": 1366748
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2346,
+          "transferSize": 2349,
           "resourceSize": 4604
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690466,
+          "transferSize": 690467,
           "resourceSize": 1366304
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2559,
+          "transferSize": 2561,
           "resourceSize": 5158
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690679,
+          "transferSize": 690682,
           "resourceSize": 1366858
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3197,
+          "transferSize": 3201,
           "resourceSize": 7477
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691309,
+          "transferSize": 691312,
           "resourceSize": 1593183
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3202,
+          "transferSize": 3204,
           "resourceSize": 6554
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1128,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697739,
+          "transferSize": 697749,
           "resourceSize": 1380650
         }
       },

--- a/.github/page_size_audit_results/v1.9.0.json
+++ b/.github/page_size_audit_results/v1.9.0.json
@@ -1,31 +1,31 @@
 {
   "metadata": {
-    "haloVersion": "2.22.0",
+    "haloVersion": "2.22.1",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.9.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:11:43.206Z"
+    "generatedAt": "2025-12-24T18:57:18.613Z"
   },
-  "timestamp": "2025-12-24T18:11:43.206Z",
+  "timestamp": "2025-12-24T18:57:18.613Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2651,
-          "resourceSize": 5593
+          "transferSize": 2731,
+          "resourceSize": 5885
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 159046,
+          "resourceSize": 496369
         },
         "stylesheet": {
-          "transferSize": 317021,
-          "resourceSize": 709795
+          "transferSize": 318935,
+          "resourceSize": 711543
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690766,
-          "resourceSize": 1367293
+          "transferSize": 706440,
+          "resourceSize": 1438273
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2519,
-          "resourceSize": 5277
+          "transferSize": 2598,
+          "resourceSize": 5569
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 159046,
+          "resourceSize": 496369
         },
         "stylesheet": {
-          "transferSize": 317021,
-          "resourceSize": 709795
+          "transferSize": 318935,
+          "resourceSize": 711543
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690634,
-          "resourceSize": 1366977
+          "transferSize": 706307,
+          "resourceSize": 1437957
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5237,
-          "resourceSize": 16851
+          "transferSize": 5308,
+          "resourceSize": 17143
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 151437,
-          "resourceSize": 439825
+          "transferSize": 165117,
+          "resourceSize": 508765
         },
         "stylesheet": {
-          "transferSize": 317021,
-          "resourceSize": 709795
+          "transferSize": 318935,
+          "resourceSize": 711543
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4972,
+          "transferSize": 4998,
           "resourceSize": 5685
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479029,
-          "resourceSize": 1172431
+          "transferSize": 494720,
+          "resourceSize": 1243411
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2343,
-          "resourceSize": 4661
+          "transferSize": 2418,
+          "resourceSize": 4953
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 159046,
+          "resourceSize": 496369
         },
         "stylesheet": {
-          "transferSize": 317021,
-          "resourceSize": 709795
+          "transferSize": 318935,
+          "resourceSize": 711543
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690458,
-          "resourceSize": 1366361
+          "transferSize": 706128,
+          "resourceSize": 1437341
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2509,
-          "resourceSize": 5087
+          "transferSize": 2586,
+          "resourceSize": 5379
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 159046,
+          "resourceSize": 496369
         },
         "stylesheet": {
-          "transferSize": 317021,
-          "resourceSize": 709795
+          "transferSize": 318935,
+          "resourceSize": 711543
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690628,
-          "resourceSize": 1366787
+          "transferSize": 706294,
+          "resourceSize": 1437767
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2354,
-          "resourceSize": 4643
+          "transferSize": 2430,
+          "resourceSize": 4935
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 159046,
+          "resourceSize": 496369
         },
         "stylesheet": {
-          "transferSize": 317021,
-          "resourceSize": 709795
+          "transferSize": 318935,
+          "resourceSize": 711543
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690469,
-          "resourceSize": 1366343
+          "transferSize": 706145,
+          "resourceSize": 1437323
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2566,
-          "resourceSize": 5197
+          "transferSize": 2646,
+          "resourceSize": 5489
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 159046,
+          "resourceSize": 496369
         },
         "stylesheet": {
-          "transferSize": 317021,
-          "resourceSize": 709795
+          "transferSize": 318935,
+          "resourceSize": 711543
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690679,
-          "resourceSize": 1366897
+          "transferSize": 706352,
+          "resourceSize": 1437877
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3206,
-          "resourceSize": 7516
+          "transferSize": 3276,
+          "resourceSize": 7808
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 159046,
+          "resourceSize": 496369
         },
         "stylesheet": {
-          "transferSize": 317021,
-          "resourceSize": 709795
+          "transferSize": 318935,
+          "resourceSize": 711543
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 784,
-          "resourceSize": 275
+          "transferSize": 785,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 691324,
-          "resourceSize": 1593222
+          "transferSize": 706988,
+          "resourceSize": 1664203
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 784,
-          "resourceSize": 275
+          "transferSize": 785,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 687346,
-          "resourceSize": 1585511
+          "transferSize": 687347,
+          "resourceSize": 1585512
         }
       }
     },
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3211,
-          "resourceSize": 6593
+          "transferSize": 3288,
+          "resourceSize": 6885
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 151437,
-          "resourceSize": 439825
+          "transferSize": 165117,
+          "resourceSize": 508765
         },
         "stylesheet": {
-          "transferSize": 317021,
-          "resourceSize": 709795
+          "transferSize": 318935,
+          "resourceSize": 711543
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 784,
-          "resourceSize": 275
+          "transferSize": 785,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 697747,
-          "resourceSize": 1380689
+          "transferSize": 713422,
+          "resourceSize": 1451670
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 784,
-          "resourceSize": 275
+          "transferSize": 785,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 691406,
-          "resourceSize": 1372063
+          "transferSize": 691407,
+          "resourceSize": 1372064
         }
       }
     }


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.0.0
- **End Version:** latest

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Audit workflow*