### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.0.1.json
+++ b/.github/page_size_audit_results/v1.0.1.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.0.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:57.050Z"
+    "generatedAt": "2025-12-25T01:00:26.169Z"
   },
-  "timestamp": "2025-12-24T18:56:57.051Z",
+  "timestamp": "2025-12-25T01:00:26.169Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2300,
-          "resourceSize": 5007
+          "transferSize": 2211,
+          "resourceSize": 4726
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297147,
-          "resourceSize": 945672
+          "transferSize": 150042,
+          "resourceSize": 438367
         },
         "stylesheet": {
-          "transferSize": 317623,
-          "resourceSize": 705957
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842379,
-          "resourceSize": 1881112
+          "transferSize": 693727,
+          "resourceSize": 1372240
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2134,
-          "resourceSize": 4516
+          "transferSize": 2049,
+          "resourceSize": 4235
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297147,
-          "resourceSize": 945672
+          "transferSize": 150042,
+          "resourceSize": 438367
         },
         "stylesheet": {
-          "transferSize": 317623,
-          "resourceSize": 705957
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842209,
-          "resourceSize": 1880621
+          "transferSize": 693567,
+          "resourceSize": 1371749
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 4948,
-          "resourceSize": 16014
+          "transferSize": 4751,
+          "resourceSize": 15300
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 699134,
-          "resourceSize": 2104097
+          "transferSize": 156113,
+          "resourceSize": 450763
         },
         "stylesheet": {
-          "transferSize": 317623,
-          "resourceSize": 705957
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 6277,
-          "resourceSize": 5044
+          "transferSize": 3408,
+          "resourceSize": 3746
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 1028344,
-          "resourceSize": 2831387
+          "transferSize": 480805,
+          "resourceSize": 1174755
         }
       },
       "themeResources": {
@@ -225,20 +225,20 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1972,
-          "resourceSize": 3989
+          "transferSize": 1887,
+          "resourceSize": 3708
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297147,
-          "resourceSize": 945672
+          "transferSize": 150042,
+          "resourceSize": 438367
         },
         "stylesheet": {
-          "transferSize": 317623,
-          "resourceSize": 705957
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842048,
-          "resourceSize": 1880094
+          "transferSize": 693406,
+          "resourceSize": 1371222
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2131,
-          "resourceSize": 4415
+          "transferSize": 2046,
+          "resourceSize": 4134
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297147,
-          "resourceSize": 945672
+          "transferSize": 150042,
+          "resourceSize": 438367
         },
         "stylesheet": {
-          "transferSize": 317623,
-          "resourceSize": 705957
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842204,
-          "resourceSize": 1880520
+          "transferSize": 693562,
+          "resourceSize": 1371648
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1996,
-          "resourceSize": 4006
+          "transferSize": 1913,
+          "resourceSize": 3725
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297147,
-          "resourceSize": 945672
+          "transferSize": 150042,
+          "resourceSize": 438367
         },
         "stylesheet": {
-          "transferSize": 317623,
-          "resourceSize": 705957
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842074,
-          "resourceSize": 1880111
+          "transferSize": 693438,
+          "resourceSize": 1371239
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2203,
-          "resourceSize": 4525
+          "transferSize": 2118,
+          "resourceSize": 4244
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297147,
-          "resourceSize": 945672
+          "transferSize": 150042,
+          "resourceSize": 438367
         },
         "stylesheet": {
-          "transferSize": 317623,
-          "resourceSize": 705957
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 842281,
-          "resourceSize": 1880631
+          "transferSize": 693641,
+          "resourceSize": 1371758
         }
       },
       "themeResources": {
@@ -496,12 +496,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 690751,
-          "resourceSize": 1367320
+          "transferSize": 690750,
+          "resourceSize": 1367319
         }
       }
     },
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2898,
-          "resourceSize": 6966
+          "transferSize": 2812,
+          "resourceSize": 6685
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 297147,
-          "resourceSize": 945672
+          "transferSize": 150042,
+          "resourceSize": 438367
         },
         "stylesheet": {
-          "transferSize": 317623,
-          "resourceSize": 705957
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 1067149,
-          "resourceSize": 2107078
+          "transferSize": 918509,
+          "resourceSize": 1598205
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 914926,
-          "resourceSize": 1591326
+          "transferSize": 914925,
+          "resourceSize": 1591325
         }
       }
     },
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2930,
-          "resourceSize": 6302
+          "transferSize": 2735,
+          "resourceSize": 5570
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 699134,
-          "resourceSize": 2104097
+          "transferSize": 156113,
+          "resourceSize": 450763
         },
         "stylesheet": {
-          "transferSize": 317623,
-          "resourceSize": 705957
+          "transferSize": 316171,
+          "resourceSize": 704671
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3996,
-          "resourceSize": 1493
+          "transferSize": 1124,
+          "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 1248221,
-          "resourceSize": 3042131
+          "transferSize": 700680,
+          "resourceSize": 1385480
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 694811,
-          "resourceSize": 1377878
+          "transferSize": 694810,
+          "resourceSize": 1377877
         }
       }
     }

--- a/.github/page_size_audit_results/v1.1.0.json
+++ b/.github/page_size_audit_results/v1.1.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:58.147Z"
+    "generatedAt": "2025-12-25T01:05:56.207Z"
   },
-  "timestamp": "2025-12-24T18:53:58.147Z",
+  "timestamp": "2025-12-25T01:05:56.207Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2180,
+          "transferSize": 2183,
           "resourceSize": 4642
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693695,
+          "transferSize": 693702,
           "resourceSize": 1372156
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2037,
+          "transferSize": 2041,
           "resourceSize": 4219
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693560,
+          "transferSize": 693561,
           "resourceSize": 1371733
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 4742,
+          "transferSize": 4745,
           "resourceSize": 15284
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 3413,
+          "transferSize": 3418,
           "resourceSize": 3746
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480801,
+          "transferSize": 480809,
           "resourceSize": 1174739
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1876,
+          "transferSize": 1879,
           "resourceSize": 3692
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693400,
+          "transferSize": 693397,
           "resourceSize": 1371206
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2035,
+          "transferSize": 2037,
           "resourceSize": 4118
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693554,
+          "transferSize": 693558,
           "resourceSize": 1371632
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1902,
+          "transferSize": 1904,
           "resourceSize": 3709
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693426,
+          "transferSize": 693423,
           "resourceSize": 1371223
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2106,
+          "transferSize": 2109,
           "resourceSize": 4228
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693622,
+          "transferSize": 693632,
           "resourceSize": 1371742
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2804,
+          "transferSize": 2805,
           "resourceSize": 6669
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918501,
+          "transferSize": 918498,
           "resourceSize": 1598189
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2725,
+          "transferSize": 2730,
           "resourceSize": 5554
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 700669,
+          "transferSize": 700674,
           "resourceSize": 1385464
         }
       },

--- a/.github/page_size_audit_results/v1.1.1.json
+++ b/.github/page_size_audit_results/v1.1.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:51.482Z"
+    "generatedAt": "2025-12-25T01:03:16.561Z"
   },
-  "timestamp": "2025-12-24T18:56:51.482Z",
+  "timestamp": "2025-12-25T01:03:16.561Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2182,
+          "transferSize": 2175,
           "resourceSize": 4642
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693646,
+          "transferSize": 693636,
           "resourceSize": 1372123
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2040,
+          "transferSize": 2035,
           "resourceSize": 4219
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693507,
+          "transferSize": 693501,
           "resourceSize": 1371700
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 4804,
+          "transferSize": 4800,
           "resourceSize": 15812
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4400,
+          "transferSize": 4405,
           "resourceSize": 5113
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481795,
+          "transferSize": 481796,
           "resourceSize": 1176601
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1879,
+          "transferSize": 1872,
           "resourceSize": 3692
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693343,
+          "transferSize": 693337,
           "resourceSize": 1371173
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2036,
+          "transferSize": 2032,
           "resourceSize": 4118
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693505,
+          "transferSize": 693501,
           "resourceSize": 1371599
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1900,
+          "transferSize": 1898,
           "resourceSize": 3709
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693366,
+          "transferSize": 693363,
           "resourceSize": 1371190
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2109,
+          "transferSize": 2104,
           "resourceSize": 4228
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693574,
+          "transferSize": 693570,
           "resourceSize": 1371709
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2804,
+          "transferSize": 2800,
           "resourceSize": 6669
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918448,
+          "transferSize": 918441,
           "resourceSize": 1598156
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2731,
+          "transferSize": 2725,
           "resourceSize": 5554
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1129,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 700626,
+          "transferSize": 700614,
           "resourceSize": 1385431
         }
       },

--- a/.github/page_size_audit_results/v1.1.2.json
+++ b/.github/page_size_audit_results/v1.1.2.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:54:01.720Z"
+    "generatedAt": "2025-12-25T01:00:13.886Z"
   },
-  "timestamp": "2025-12-24T18:54:01.721Z",
+  "timestamp": "2025-12-25T01:00:13.886Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 780,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692040,
+          "transferSize": 692038,
           "resourceSize": 1370026
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2711,
+          "transferSize": 2710,
           "resourceSize": 5743
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691898,
+          "transferSize": 691897,
           "resourceSize": 1369751
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4967,
+          "transferSize": 5025,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480745,
+          "transferSize": 480803,
           "resourceSize": 1175245
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691727,
+          "transferSize": 691721,
           "resourceSize": 1369135
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691886,
+          "transferSize": 691885,
           "resourceSize": 1369561
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 916796,
+          "transferSize": 916795,
           "resourceSize": 1596121
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1118,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 698980,
+          "transferSize": 698984,
           "resourceSize": 1383393
         }
       },

--- a/.github/page_size_audit_results/v1.1.3.json
+++ b/.github/page_size_audit_results/v1.1.3.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:54:01.792Z"
+    "generatedAt": "2025-12-25T01:03:13.692Z"
   },
-  "timestamp": "2025-12-24T18:54:01.792Z",
+  "timestamp": "2025-12-25T01:03:13.693Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2816,
+          "transferSize": 2814,
           "resourceSize": 5971
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691998,
+          "transferSize": 692004,
           "resourceSize": 1369979
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2686,
+          "transferSize": 2684,
           "resourceSize": 5683
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691879,
+          "transferSize": 691873,
           "resourceSize": 1369691
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5441,
+          "transferSize": 5438,
           "resourceSize": 17297
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4968,
+          "transferSize": 5021,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480721,
+          "transferSize": 480771,
           "resourceSize": 1175185
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2510,
+          "transferSize": 2508,
           "resourceSize": 5067
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691696,
+          "transferSize": 691693,
           "resourceSize": 1369075
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2674,
+          "transferSize": 2672,
           "resourceSize": 5493
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691857,
+          "transferSize": 691860,
           "resourceSize": 1369501
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2531,
+          "transferSize": 2528,
           "resourceSize": 5084
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691714,
+          "transferSize": 691708,
           "resourceSize": 1369092
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2731,
+          "transferSize": 2730,
           "resourceSize": 5603
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691915,
+          "transferSize": 691914,
           "resourceSize": 1369611
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3414,
+          "transferSize": 3411,
           "resourceSize": 8062
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 916776,
+          "transferSize": 916771,
           "resourceSize": 1596076
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3353,
+          "transferSize": 3349,
           "resourceSize": 6929
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 698964,
+          "transferSize": 698960,
           "resourceSize": 1383333
         }
       },

--- a/.github/page_size_audit_results/v1.1.4.json
+++ b/.github/page_size_audit_results/v1.1.4.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.1.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:41.568Z"
+    "generatedAt": "2025-12-25T01:03:05.222Z"
   },
-  "timestamp": "2025-12-24T18:56:41.568Z",
+  "timestamp": "2025-12-25T01:03:05.223Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2814,
+          "transferSize": 2815,
           "resourceSize": 5977
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692001,
+          "transferSize": 692007,
           "resourceSize": 1369985
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5437,
+          "transferSize": 5438,
           "resourceSize": 17303
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4992,
+          "transferSize": 5025,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480741,
+          "transferSize": 480775,
           "resourceSize": 1175191
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691699,
+          "transferSize": 691691,
           "resourceSize": 1369081
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2673,
+          "transferSize": 2674,
           "resourceSize": 5499
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691856,
+          "transferSize": 691857,
           "resourceSize": 1369507
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691709,
+          "transferSize": 691714,
           "resourceSize": 1369098
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2731,
+          "transferSize": 2733,
           "resourceSize": 5609
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691913,
+          "transferSize": 691921,
           "resourceSize": 1369617
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3415,
+          "transferSize": 3412,
           "resourceSize": 8068
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 916775,
+          "transferSize": 916771,
           "resourceSize": 1596082
         }
       },

--- a/.github/page_size_audit_results/v1.10.0.json
+++ b/.github/page_size_audit_results/v1.10.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:54.968Z"
+    "generatedAt": "2025-12-25T01:00:16.312Z"
   },
-  "timestamp": "2025-12-24T18:59:54.968Z",
+  "timestamp": "2025-12-25T01:00:16.312Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2701,
+          "transferSize": 2700,
           "resourceSize": 5945
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690814,
+          "transferSize": 690819,
           "resourceSize": 1367645
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690712,
+          "transferSize": 690719,
           "resourceSize": 1367413
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4993,
+          "transferSize": 5025,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479117,
+          "transferSize": 479149,
           "resourceSize": 1173082
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690527,
+          "transferSize": 690533,
           "resourceSize": 1366787
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690704,
+          "transferSize": 690712,
           "resourceSize": 1367223
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690543,
+          "transferSize": 690548,
           "resourceSize": 1366769
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2646,
+          "transferSize": 2645,
           "resourceSize": 5633
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690761,
+          "transferSize": 690767,
           "resourceSize": 1367333
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3258,
+          "transferSize": 3256,
           "resourceSize": 7788
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 762,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691366,
+          "transferSize": 691369,
           "resourceSize": 1593494
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697833,
+          "transferSize": 697835,
           "resourceSize": 1381081
         }
       },

--- a/.github/page_size_audit_results/v1.10.1.json
+++ b/.github/page_size_audit_results/v1.10.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:49.940Z"
+    "generatedAt": "2025-12-25T01:05:59.809Z"
   },
-  "timestamp": "2025-12-24T18:56:49.940Z",
+  "timestamp": "2025-12-25T01:05:59.809Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2734,
+          "transferSize": 2732,
           "resourceSize": 6013
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690717,
+          "transferSize": 690724,
           "resourceSize": 1367413
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4958,
+          "transferSize": 4968,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479082,
+          "transferSize": 479092,
           "resourceSize": 1173082
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690532,
+          "transferSize": 690527,
           "resourceSize": 1366787
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2591,
+          "transferSize": 2588,
           "resourceSize": 5523
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690713,
+          "transferSize": 690703,
           "resourceSize": 1367223
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690547,
+          "transferSize": 690546,
           "resourceSize": 1366769
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2647,
+          "transferSize": 2645,
           "resourceSize": 5633
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690763,
+          "transferSize": 690757,
           "resourceSize": 1367333
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697842,
+          "transferSize": 697836,
           "resourceSize": 1381081
         }
       },

--- a/.github/page_size_audit_results/v1.10.2.json
+++ b/.github/page_size_audit_results/v1.10.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:46.634Z"
+    "generatedAt": "2025-12-25T01:00:20.062Z"
   },
-  "timestamp": "2025-12-24T18:56:46.634Z",
+  "timestamp": "2025-12-25T01:00:20.062Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2734,
+          "transferSize": 2730,
           "resourceSize": 6013
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690851,
+          "transferSize": 690847,
           "resourceSize": 1367713
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2602,
+          "transferSize": 2599,
           "resourceSize": 5713
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690716,
+          "transferSize": 690713,
           "resourceSize": 1367413
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4964,
+          "transferSize": 4966,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479091,
+          "transferSize": 479093,
           "resourceSize": 1173094
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2416,
+          "transferSize": 2414,
           "resourceSize": 5087
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690534,
+          "transferSize": 690533,
           "resourceSize": 1366787
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2591,
+          "transferSize": 2588,
           "resourceSize": 5523
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690705,
+          "transferSize": 690701,
           "resourceSize": 1367223
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2431,
+          "transferSize": 2428,
           "resourceSize": 5069
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690548,
+          "transferSize": 690542,
           "resourceSize": 1366769
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2647,
+          "transferSize": 2645,
           "resourceSize": 5633
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690760,
+          "transferSize": 690757,
           "resourceSize": 1367333
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3296,
+          "transferSize": 3293,
           "resourceSize": 7951
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691412,
+          "transferSize": 691409,
           "resourceSize": 1593657
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3299,
+          "transferSize": 3297,
           "resourceSize": 6985
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697839,
+          "transferSize": 697837,
           "resourceSize": 1381081
         }
       },

--- a/.github/page_size_audit_results/v1.11.0.json
+++ b/.github/page_size_audit_results/v1.11.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.11.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:53.620Z"
+    "generatedAt": "2025-12-25T01:00:18.481Z"
   },
-  "timestamp": "2025-12-24T18:53:53.620Z",
+  "timestamp": "2025-12-25T01:00:18.481Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2634,
+          "transferSize": 2637,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690659,
+          "transferSize": 690663,
           "resourceSize": 1367123
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2596,
+          "transferSize": 2601,
           "resourceSize": 5713
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690619,
+          "transferSize": 690627,
           "resourceSize": 1367120
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5307,
+          "transferSize": 5306,
           "resourceSize": 17514
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4992,
+          "transferSize": 4960,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479027,
+          "transferSize": 478994,
           "resourceSize": 1172801
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2411,
+          "transferSize": 2413,
           "resourceSize": 5087
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690440,
+          "transferSize": 690435,
           "resourceSize": 1366494
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2586,
+          "transferSize": 2590,
           "resourceSize": 5523
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690608,
+          "transferSize": 690613,
           "resourceSize": 1366930
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2426,
+          "transferSize": 2430,
           "resourceSize": 5069
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690450,
+          "transferSize": 690452,
           "resourceSize": 1366476
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2644,
+          "transferSize": 2647,
           "resourceSize": 5633
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3293,
+          "transferSize": 3295,
           "resourceSize": 7951
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691321,
+          "transferSize": 691318,
           "resourceSize": 1593364
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3296,
+          "transferSize": 3299,
           "resourceSize": 6985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697742,
+          "transferSize": 697746,
           "resourceSize": 1380788
         }
       },

--- a/.github/page_size_audit_results/v1.12.0.json
+++ b/.github/page_size_audit_results/v1.12.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:59.692Z"
+    "generatedAt": "2025-12-25T01:03:11.702Z"
   },
-  "timestamp": "2025-12-24T18:59:59.693Z",
+  "timestamp": "2025-12-25T01:03:11.702Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2649,
+          "transferSize": 2647,
           "resourceSize": 5757
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690716,
+          "transferSize": 690712,
           "resourceSize": 1367305
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690677,
+          "transferSize": 690680,
           "resourceSize": 1367302
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5314,
+          "transferSize": 5315,
           "resourceSize": 17555
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4969,
+          "transferSize": 4968,
           "resourceSize": 5685
         },
         "other": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690497,
+          "transferSize": 690499,
           "resourceSize": 1366688
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2599,
+          "transferSize": 2598,
           "resourceSize": 5564
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690663,
+          "transferSize": 690665,
           "resourceSize": 1367112
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690506,
+          "transferSize": 690509,
           "resourceSize": 1366670
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2657,
+          "transferSize": 2656,
           "resourceSize": 5674
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690726,
+          "transferSize": 690724,
           "resourceSize": 1367222
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3309,
+          "transferSize": 3307,
           "resourceSize": 7992
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691378,
+          "transferSize": 691369,
           "resourceSize": 1593546
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697802,
+          "transferSize": 697798,
           "resourceSize": 1380986
         }
       },

--- a/.github/page_size_audit_results/v1.12.1.json
+++ b/.github/page_size_audit_results/v1.12.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:37.579Z"
+    "generatedAt": "2025-12-25T01:03:32.941Z"
   },
-  "timestamp": "2025-12-24T18:59:37.579Z",
+  "timestamp": "2025-12-25T01:03:32.941Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2653,
+          "transferSize": 2651,
           "resourceSize": 5941
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691696,
+          "transferSize": 691690,
           "resourceSize": 1369939
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2616,
+          "transferSize": 2614,
           "resourceSize": 5938
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691659,
+          "transferSize": 691653,
           "resourceSize": 1369936
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5321,
+          "transferSize": 5320,
           "resourceSize": 17831
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4973,
+          "transferSize": 4993,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479766,
+          "transferSize": 479785,
           "resourceSize": 1174311
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691482,
+          "transferSize": 691475,
           "resourceSize": 1369322
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2604,
+          "transferSize": 2602,
           "resourceSize": 5748
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691643,
+          "transferSize": 691645,
           "resourceSize": 1369746
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691489,
+          "transferSize": 691486,
           "resourceSize": 1369304
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2662,
+          "transferSize": 2660,
           "resourceSize": 5858
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691703,
+          "transferSize": 691701,
           "resourceSize": 1369856
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3313,
+          "transferSize": 3310,
           "resourceSize": 8176
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692361,
+          "transferSize": 692356,
           "resourceSize": 1596180
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 698508,
+          "transferSize": 698504,
           "resourceSize": 1382222
         }
       },

--- a/.github/page_size_audit_results/v1.12.2.json
+++ b/.github/page_size_audit_results/v1.12.2.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:31.055Z"
+    "generatedAt": "2025-12-25T01:06:13.318Z"
   },
-  "timestamp": "2025-12-24T18:59:31.056Z",
+  "timestamp": "2025-12-25T01:06:13.318Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2704,
-          "resourceSize": 6131
+          "transferSize": 2834,
+          "resourceSize": 6526
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147815,
-          "resourceSize": 432562
+          "transferSize": 184373,
+          "resourceSize": 540114
         },
         "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
+          "transferSize": 318276,
+          "resourceSize": 711015
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693350,
-          "resourceSize": 1373180
+          "transferSize": 731216,
+          "resourceSize": 1482131
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2666,
-          "resourceSize": 6128
+          "transferSize": 2794,
+          "resourceSize": 6523
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147815,
-          "resourceSize": 432562
+          "transferSize": 184373,
+          "resourceSize": 540114
         },
         "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
+          "transferSize": 318276,
+          "resourceSize": 711015
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693315,
-          "resourceSize": 1373177
+          "transferSize": 731171,
+          "resourceSize": 1482128
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5379,
-          "resourceSize": 18021
+          "transferSize": 5507,
+          "resourceSize": 18538
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 153612,
-          "resourceSize": 443560
+          "transferSize": 190170,
+          "resourceSize": 551112
         },
         "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
+          "transferSize": 318276,
+          "resourceSize": 711015
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4976,
+          "transferSize": 4968,
           "resourceSize": 5685
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481435,
-          "resourceSize": 1177552
+          "transferSize": 519283,
+          "resourceSize": 1286625
         }
       },
       "themeResources": {
@@ -225,20 +225,20 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2492,
-          "resourceSize": 5514
+          "transferSize": 2617,
+          "resourceSize": 5909
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147815,
-          "resourceSize": 432562
+          "transferSize": 184373,
+          "resourceSize": 540114
         },
         "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
+          "transferSize": 318276,
+          "resourceSize": 711015
         },
         "image": {
           "transferSize": 224175,
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693143,
-          "resourceSize": 1372563
+          "transferSize": 730996,
+          "resourceSize": 1481514
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2654,
-          "resourceSize": 5938
+          "transferSize": 2782,
+          "resourceSize": 6333
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147815,
-          "resourceSize": 432562
+          "transferSize": 184373,
+          "resourceSize": 540114
         },
         "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
+          "transferSize": 318276,
+          "resourceSize": 711015
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693305,
-          "resourceSize": 1372987
+          "transferSize": 731156,
+          "resourceSize": 1481938
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2495,
-          "resourceSize": 5496
+          "transferSize": 2627,
+          "resourceSize": 5891
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147815,
-          "resourceSize": 432562
+          "transferSize": 184373,
+          "resourceSize": 540114
         },
         "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
+          "transferSize": 318276,
+          "resourceSize": 711015
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693148,
-          "resourceSize": 1372545
+          "transferSize": 731002,
+          "resourceSize": 1481496
         }
       },
       "themeResources": {
@@ -438,169 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2713,
-          "resourceSize": 6048
+          "transferSize": 2842,
+          "resourceSize": 6443
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147815,
-          "resourceSize": 432562
+          "transferSize": 184373,
+          "resourceSize": 540114
         },
         "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
+          "transferSize": 318276,
+          "resourceSize": 711015
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
-          "resourceSize": 195
-        },
-        "other": {
-          "transferSize": 784,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 693363,
-          "resourceSize": 1373097
-        }
-      },
-      "themeResources": {
-        "document": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 147815,
-          "resourceSize": 432562
-        },
-        "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "other": {
-          "transferSize": 784,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 689880,
-          "resourceSize": 1366854
-        }
-      }
-    },
-    {
-      "url": "/authors/admin",
-      "resources": {
-        "document": {
-          "transferSize": 3377,
-          "resourceSize": 8366
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 147815,
-          "resourceSize": 432562
-        },
-        "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 448012
-        },
-        "fetch": {
-          "transferSize": 770,
-          "resourceSize": 195
-        },
-        "other": {
-          "transferSize": 784,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 694027,
-          "resourceSize": 1599421
-        }
-      },
-      "themeResources": {
-        "document": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 147815,
-          "resourceSize": 432562
-        },
-        "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 448012
-        },
-        "fetch": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "other": {
-          "transferSize": 784,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 689880,
-          "resourceSize": 1590860
-        }
-      }
-    },
-    {
-      "url": "/about",
-      "resources": {
-        "document": {
-          "transferSize": 3358,
-          "resourceSize": 7416
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 153612,
-          "resourceSize": 443560
-        },
-        "stylesheet": {
-          "transferSize": 317106,
-          "resourceSize": 710011
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 1124,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +466,150 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700160,
-          "resourceSize": 1385464
+          "transferSize": 731228,
+          "resourceSize": 1482049
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 147815,
+          "resourceSize": 432562
+        },
+        "stylesheet": {
+          "transferSize": 317106,
+          "resourceSize": 710011
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 785,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 689881,
+          "resourceSize": 1366855
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3500,
+          "resourceSize": 8761
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 184373,
+          "resourceSize": 540114
+        },
+        "stylesheet": {
+          "transferSize": 318276,
+          "resourceSize": 711015
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 448012
+        },
+        "fetch": {
+          "transferSize": 771,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 785,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 731880,
+          "resourceSize": 1708373
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 147815,
+          "resourceSize": 432562
+        },
+        "stylesheet": {
+          "transferSize": 317106,
+          "resourceSize": 710011
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 448012
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 785,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 689881,
+          "resourceSize": 1590861
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3479,
+          "resourceSize": 7811
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 190170,
+          "resourceSize": 551112
+        },
+        "stylesheet": {
+          "transferSize": 318276,
+          "resourceSize": 711015
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 1123,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 785,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 738008,
+          "resourceSize": 1494415
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.12.3.json
+++ b/.github/page_size_audit_results/v1.12.3.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:54.452Z"
+    "generatedAt": "2025-12-25T01:03:16.854Z"
   },
-  "timestamp": "2025-12-24T18:56:54.452Z",
+  "timestamp": "2025-12-25T01:03:16.855Z",
   "results": [
     {
       "url": "/",
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693334,
+          "transferSize": 693329,
           "resourceSize": 1373200
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5390,
+          "transferSize": 5389,
           "resourceSize": 18027
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4967,
+          "transferSize": 5026,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481436,
+          "transferSize": 481494,
           "resourceSize": 1177575
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693157,
+          "transferSize": 693158,
           "resourceSize": 1372586
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2669,
+          "transferSize": 2668,
           "resourceSize": 5944
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693318,
+          "transferSize": 693313,
           "resourceSize": 1373010
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693164,
+          "transferSize": 693170,
           "resourceSize": 1372568
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693375,
+          "transferSize": 693378,
           "resourceSize": 1373120
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3395,
+          "transferSize": 3392,
           "resourceSize": 8372
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694046,
+          "transferSize": 694040,
           "resourceSize": 1599444
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700179,
+          "transferSize": 700174,
           "resourceSize": 1385487
         }
       },

--- a/.github/page_size_audit_results/v1.13.0.json
+++ b/.github/page_size_audit_results/v1.13.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:46.234Z"
+    "generatedAt": "2025-12-25T01:03:14.243Z"
   },
-  "timestamp": "2025-12-24T18:56:46.234Z",
+  "timestamp": "2025-12-25T01:03:14.243Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693369,
+          "transferSize": 693373,
           "resourceSize": 1373203
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693328,
+          "transferSize": 693330,
           "resourceSize": 1373200
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5391,
+          "transferSize": 5390,
           "resourceSize": 18027
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4973,
+          "transferSize": 4966,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481443,
+          "transferSize": 481435,
           "resourceSize": 1177575
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2670,
+          "transferSize": 2669,
           "resourceSize": 5944
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693320,
+          "transferSize": 693313,
           "resourceSize": 1373010
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693162,
+          "transferSize": 693160,
           "resourceSize": 1372568
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693381,
+          "transferSize": 693376,
           "resourceSize": 1373120
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3394,
+          "transferSize": 3392,
           "resourceSize": 8372
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694043,
+          "transferSize": 694040,
           "resourceSize": 1599444
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1117,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700169,
+          "transferSize": 700171,
           "resourceSize": 1385487
         }
       },

--- a/.github/page_size_audit_results/v1.13.1.json
+++ b/.github/page_size_audit_results/v1.13.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:45.727Z"
+    "generatedAt": "2025-12-25T01:00:19.407Z"
   },
-  "timestamp": "2025-12-24T18:53:45.728Z",
+  "timestamp": "2025-12-25T01:00:19.407Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2726,
+          "transferSize": 2724,
           "resourceSize": 6155
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693433,
+          "transferSize": 693440,
           "resourceSize": 1373874
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2691,
+          "transferSize": 2687,
           "resourceSize": 6152
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693399,
+          "transferSize": 693402,
           "resourceSize": 1373871
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5398,
+          "transferSize": 5399,
           "resourceSize": 18045
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4991,
+          "transferSize": 4968,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481529,
+          "transferSize": 481507,
           "resourceSize": 1178246
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2516,
+          "transferSize": 2513,
           "resourceSize": 5538
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693231,
+          "transferSize": 693226,
           "resourceSize": 1373257
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2681,
+          "transferSize": 2677,
           "resourceSize": 5962
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693390,
+          "transferSize": 693385,
           "resourceSize": 1373681
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2525,
+          "transferSize": 2522,
           "resourceSize": 5520
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693236,
+          "transferSize": 693235,
           "resourceSize": 1373239
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2737,
+          "transferSize": 2734,
           "resourceSize": 6072
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693446,
+          "transferSize": 693448,
           "resourceSize": 1373791
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3399,
+          "transferSize": 3393,
           "resourceSize": 8390
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 781,
           "resourceSize": 195
         },
         "other": {
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3384,
+          "transferSize": 3380,
           "resourceSize": 7440
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1130,
+          "transferSize": 1132,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700252,
+          "transferSize": 700250,
           "resourceSize": 1386158
         }
       },

--- a/.github/page_size_audit_results/v1.14.0.json
+++ b/.github/page_size_audit_results/v1.14.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.14.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:32.766Z"
+    "generatedAt": "2025-12-25T01:05:57.091Z"
   },
-  "timestamp": "2025-12-24T18:59:32.767Z",
+  "timestamp": "2025-12-25T01:05:57.091Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2693,
+          "transferSize": 2696,
           "resourceSize": 6083
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693397,
+          "transferSize": 693407,
           "resourceSize": 1373802
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2658,
+          "transferSize": 2660,
           "resourceSize": 6080
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693365,
+          "transferSize": 693370,
           "resourceSize": 1373799
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4986,
+          "transferSize": 5028,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481525,
+          "transferSize": 481567,
           "resourceSize": 1178246
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2512,
+          "transferSize": 2515,
           "resourceSize": 5538
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2648,
+          "transferSize": 2649,
           "resourceSize": 5890
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2523,
+          "transferSize": 2526,
           "resourceSize": 5520
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693237,
+          "transferSize": 693235,
           "resourceSize": 1373239
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2703,
+          "transferSize": 2705,
           "resourceSize": 6000
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693409,
+          "transferSize": 693415,
           "resourceSize": 1373719
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3363,
+          "transferSize": 3366,
           "resourceSize": 8318
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694070,
+          "transferSize": 694074,
           "resourceSize": 1600043
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3381,
+          "transferSize": 3385,
           "resourceSize": 7440
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700239,
+          "transferSize": 700249,
           "resourceSize": 1386158
         }
       },

--- a/.github/page_size_audit_results/v1.15.0.json
+++ b/.github/page_size_audit_results/v1.15.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:52.981Z"
+    "generatedAt": "2025-12-25T01:00:13.939Z"
   },
-  "timestamp": "2025-12-24T18:56:52.982Z",
+  "timestamp": "2025-12-25T01:00:13.939Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693546,
+          "transferSize": 693547,
           "resourceSize": 1374456
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5582,
+          "transferSize": 5583,
           "resourceSize": 18349
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4967,
+          "transferSize": 4975,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481821,
+          "transferSize": 481830,
           "resourceSize": 1179186
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693368,
+          "transferSize": 693370,
           "resourceSize": 1373911
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693503,
+          "transferSize": 693497,
           "resourceSize": 1374263
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693378,
+          "transferSize": 693380,
           "resourceSize": 1373893
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693559,
+          "transferSize": 693561,
           "resourceSize": 1374373
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3374,
+          "transferSize": 3373,
           "resourceSize": 8336
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694215,
+          "transferSize": 694216,
           "resourceSize": 1600697
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700385,
+          "transferSize": 700386,
           "resourceSize": 1386812
         }
       },

--- a/.github/page_size_audit_results/v1.15.1.json
+++ b/.github/page_size_audit_results/v1.15.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T19:00:05.106Z"
+    "generatedAt": "2025-12-25T01:00:18.996Z"
   },
-  "timestamp": "2025-12-24T19:00:05.106Z",
+  "timestamp": "2025-12-25T01:00:18.996Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2061,
+          "transferSize": 2058,
           "resourceSize": 4959
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692437,
+          "transferSize": 692426,
           "resourceSize": 1372340
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2026,
+          "transferSize": 2025,
           "resourceSize": 4956
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692402,
+          "transferSize": 692398,
           "resourceSize": 1372337
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5032,
+          "transferSize": 5031,
           "resourceSize": 17245
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4960,
+          "transferSize": 4972,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480794,
+          "transferSize": 480805,
           "resourceSize": 1177108
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1897,
+          "transferSize": 1895,
           "resourceSize": 4414
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2031,
+          "transferSize": 2026,
           "resourceSize": 4766
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692400,
+          "transferSize": 692394,
           "resourceSize": 1372147
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1912,
+          "transferSize": 1909,
           "resourceSize": 4396
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692280,
+          "transferSize": 692289,
           "resourceSize": 1371777
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2104,
+          "transferSize": 2101,
           "resourceSize": 4876
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692477,
+          "transferSize": 692474,
           "resourceSize": 1372257
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2755,
+          "transferSize": 2750,
           "resourceSize": 7194
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693130,
+          "transferSize": 693131,
           "resourceSize": 1598581
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2795,
+          "transferSize": 2789,
           "resourceSize": 6298
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699318,
+          "transferSize": 699313,
           "resourceSize": 1384678
         }
       },

--- a/.github/page_size_audit_results/v1.16.0.json
+++ b/.github/page_size_audit_results/v1.16.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:54.031Z"
+    "generatedAt": "2025-12-25T01:00:18.419Z"
   },
-  "timestamp": "2025-12-24T18:56:54.031Z",
+  "timestamp": "2025-12-25T01:00:18.419Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2063,
+          "transferSize": 2059,
           "resourceSize": 4969
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692529,
+          "transferSize": 692524,
           "resourceSize": 1372886
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2029,
+          "transferSize": 2025,
           "resourceSize": 4966
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692500,
+          "transferSize": 692496,
           "resourceSize": 1372883
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5034,
+          "transferSize": 5031,
           "resourceSize": 17255
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4963,
+          "transferSize": 5017,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480897,
+          "transferSize": 480948,
           "resourceSize": 1177654
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1900,
+          "transferSize": 1897,
           "resourceSize": 4424
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692368,
+          "transferSize": 692366,
           "resourceSize": 1372341
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2030,
+          "transferSize": 2027,
           "resourceSize": 4776
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692495,
+          "transferSize": 692498,
           "resourceSize": 1372693
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1913,
+          "transferSize": 1911,
           "resourceSize": 4406
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692386,
+          "transferSize": 692378,
           "resourceSize": 1372323
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2106,
+          "transferSize": 2102,
           "resourceSize": 4886
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692576,
+          "transferSize": 692570,
           "resourceSize": 1372803
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2757,
+          "transferSize": 2753,
           "resourceSize": 7204
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693231,
+          "transferSize": 693226,
           "resourceSize": 1599127
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2798,
+          "transferSize": 2792,
           "resourceSize": 6308
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699419,
+          "transferSize": 699412,
           "resourceSize": 1385224
         }
       },

--- a/.github/page_size_audit_results/v1.16.1.json
+++ b/.github/page_size_audit_results/v1.16.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:46.720Z"
+    "generatedAt": "2025-12-25T01:03:13.339Z"
   },
-  "timestamp": "2025-12-24T18:56:46.720Z",
+  "timestamp": "2025-12-25T01:03:13.340Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2060,
+          "transferSize": 2058,
           "resourceSize": 4969
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692532,
+          "transferSize": 692530,
           "resourceSize": 1372886
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2027,
+          "transferSize": 2024,
           "resourceSize": 4966
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692492,
+          "transferSize": 692489,
           "resourceSize": 1372883
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5031,
+          "transferSize": 5029,
           "resourceSize": 17255
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4971,
+          "transferSize": 5017,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480902,
+          "transferSize": 480946,
           "resourceSize": 1177654
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692366,
+          "transferSize": 692364,
           "resourceSize": 1372341
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2029,
+          "transferSize": 2027,
           "resourceSize": 4776
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692496,
+          "transferSize": 692499,
           "resourceSize": 1372693
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692376,
+          "transferSize": 692380,
           "resourceSize": 1372323
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2104,
+          "transferSize": 2101,
           "resourceSize": 4886
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692570,
+          "transferSize": 692569,
           "resourceSize": 1372803
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2753,
+          "transferSize": 2752,
           "resourceSize": 7204
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693220,
+          "transferSize": 693222,
           "resourceSize": 1599127
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699408,
+          "transferSize": 699416,
           "resourceSize": 1385224
         }
       },

--- a/.github/page_size_audit_results/v1.17.0.json
+++ b/.github/page_size_audit_results/v1.17.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.17.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:45.392Z"
+    "generatedAt": "2025-12-25T01:03:21.248Z"
   },
-  "timestamp": "2025-12-24T18:59:45.393Z",
+  "timestamp": "2025-12-25T01:03:21.248Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2155,
+          "transferSize": 2151,
           "resourceSize": 5445
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692171,
+          "transferSize": 692163,
           "resourceSize": 1373215
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2120,
+          "transferSize": 2117,
           "resourceSize": 5442
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692139,
+          "transferSize": 692134,
           "resourceSize": 1373212
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5174,
+          "transferSize": 5170,
           "resourceSize": 17803
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4987,
+          "transferSize": 4977,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481026,
+          "transferSize": 481012,
           "resourceSize": 1178055
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692000,
+          "transferSize": 692008,
           "resourceSize": 1372670
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2125,
+          "transferSize": 2121,
           "resourceSize": 5252
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692139,
+          "transferSize": 692135,
           "resourceSize": 1373022
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692017,
+          "transferSize": 692015,
           "resourceSize": 1372652
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2199,
+          "transferSize": 2196,
           "resourceSize": 5362
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692210,
+          "transferSize": 692207,
           "resourceSize": 1373132
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2845,
+          "transferSize": 2844,
           "resourceSize": 7680
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917032,
+          "transferSize": 917033,
           "resourceSize": 1599456
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699044,
+          "transferSize": 699052,
           "resourceSize": 1385553
         }
       },

--- a/.github/page_size_audit_results/v1.18.0.json
+++ b/.github/page_size_audit_results/v1.18.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.18.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:46.783Z"
+    "generatedAt": "2025-12-25T01:00:15.668Z"
   },
-  "timestamp": "2025-12-24T18:53:46.784Z",
+  "timestamp": "2025-12-25T01:00:15.668Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692322,
+          "transferSize": 692329,
           "resourceSize": 1376572
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2080,
+          "transferSize": 2079,
           "resourceSize": 5150
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692291,
+          "transferSize": 692289,
           "resourceSize": 1376569
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5118,
+          "transferSize": 5116,
           "resourceSize": 17511
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4964,
+          "transferSize": 4969,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481144,
+          "transferSize": 481147,
           "resourceSize": 1181412
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692166,
+          "transferSize": 692159,
           "resourceSize": 1376027
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2084,
+          "transferSize": 2081,
           "resourceSize": 4960
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692292,
+          "transferSize": 692290,
           "resourceSize": 1376379
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692175,
+          "transferSize": 692172,
           "resourceSize": 1376009
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2157,
+          "transferSize": 2156,
           "resourceSize": 5070
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692369,
+          "transferSize": 692363,
           "resourceSize": 1376489
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2801,
+          "transferSize": 2800,
           "resourceSize": 7388
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917183,
+          "transferSize": 917188,
           "resourceSize": 1602813
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699200,
+          "transferSize": 699202,
           "resourceSize": 1388910
         }
       },

--- a/.github/page_size_audit_results/v1.19.0.json
+++ b/.github/page_size_audit_results/v1.19.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.19.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:12.297Z"
+    "generatedAt": "2025-12-25T01:00:10.706Z"
   },
-  "timestamp": "2025-12-24T18:56:12.297Z",
+  "timestamp": "2025-12-25T01:00:10.706Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2118,
+          "transferSize": 2117,
           "resourceSize": 5153
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692332,
+          "transferSize": 692322,
           "resourceSize": 1376572
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692297,
+          "transferSize": 692290,
           "resourceSize": 1376569
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5382,
+          "transferSize": 5381,
           "resourceSize": 20616
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7775,
+          "transferSize": 7899,
           "resourceSize": 8841
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484219,
+          "transferSize": 484342,
           "resourceSize": 1187673
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692170,
+          "transferSize": 692164,
           "resourceSize": 1376027
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2088,
+          "transferSize": 2087,
           "resourceSize": 4960
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692294,
+          "transferSize": 692302,
           "resourceSize": 1376379
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692175,
+          "transferSize": 692180,
           "resourceSize": 1376009
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2162,
+          "transferSize": 2161,
           "resourceSize": 5070
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692375,
+          "transferSize": 692367,
           "resourceSize": 1376489
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2804,
+          "transferSize": 2803,
           "resourceSize": 7388
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917188,
+          "transferSize": 917189,
           "resourceSize": 1602813
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699202,
+          "transferSize": 699203,
           "resourceSize": 1388910
         }
       },

--- a/.github/page_size_audit_results/v1.2.0.json
+++ b/.github/page_size_audit_results/v1.2.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.2.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:38.166Z"
+    "generatedAt": "2025-12-25T01:03:17.232Z"
   },
-  "timestamp": "2025-12-24T18:59:38.166Z",
+  "timestamp": "2025-12-25T01:03:17.232Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2588,
+          "transferSize": 2587,
           "resourceSize": 5452
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689872,
+          "transferSize": 689867,
           "resourceSize": 1364320
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2454,
+          "transferSize": 2453,
           "resourceSize": 5136
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689736,
+          "transferSize": 689740,
           "resourceSize": 1364004
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5209,
+          "transferSize": 5207,
           "resourceSize": 16750
         },
         "font": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478579,
+          "transferSize": 478577,
           "resourceSize": 1169498
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689563,
+          "transferSize": 689559,
           "resourceSize": 1363388
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2442,
+          "transferSize": 2443,
           "resourceSize": 4946
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689723,
+          "transferSize": 689721,
           "resourceSize": 1363814
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689578,
+          "transferSize": 689576,
           "resourceSize": 1363405
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2499,
+          "transferSize": 2498,
           "resourceSize": 5056
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689777,
+          "transferSize": 689788,
           "resourceSize": 1363924
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3182,
+          "transferSize": 3180,
           "resourceSize": 7528
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 914633,
+          "transferSize": 914632,
           "resourceSize": 1590402
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 696827,
+          "transferSize": 696826,
           "resourceSize": 1377646
         }
       },

--- a/.github/page_size_audit_results/v1.2.1.json
+++ b/.github/page_size_audit_results/v1.2.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.2.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:52.646Z"
+    "generatedAt": "2025-12-25T01:00:18.544Z"
   },
-  "timestamp": "2025-12-24T18:56:52.646Z",
+  "timestamp": "2025-12-25T01:00:18.545Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2594,
+          "transferSize": 2593,
           "resourceSize": 5460
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689658,
+          "transferSize": 689646,
           "resourceSize": 1363611
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2457,
+          "transferSize": 2459,
           "resourceSize": 5144
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689512,
+          "transferSize": 689509,
           "resourceSize": 1363295
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5219,
+          "transferSize": 5218,
           "resourceSize": 16758
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4971,
+          "transferSize": 4968,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478373,
+          "transferSize": 478369,
           "resourceSize": 1168789
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689336,
+          "transferSize": 689339,
           "resourceSize": 1362679
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2450,
+          "transferSize": 2448,
           "resourceSize": 4954
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689505,
+          "transferSize": 689508,
           "resourceSize": 1363105
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689359,
+          "transferSize": 689362,
           "resourceSize": 1362696
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689563,
+          "transferSize": 689566,
           "resourceSize": 1363215
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3191,
+          "transferSize": 3188,
           "resourceSize": 7530
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 914422,
+          "transferSize": 914423,
           "resourceSize": 1589687
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 696606,
+          "transferSize": 696608,
           "resourceSize": 1376937
         }
       },

--- a/.github/page_size_audit_results/v1.20.0.json
+++ b/.github/page_size_audit_results/v1.20.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.20.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:58.212Z"
+    "generatedAt": "2025-12-25T01:06:11.529Z"
   },
-  "timestamp": "2025-12-24T18:53:58.212Z",
+  "timestamp": "2025-12-25T01:06:11.529Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2114,
           "resourceSize": 5153
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692363,
+          "transferSize": 692356,
           "resourceSize": 1377138
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2082,
+          "transferSize": 2081,
           "resourceSize": 5150
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692326,
+          "transferSize": 692319,
           "resourceSize": 1377135
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5381,
+          "transferSize": 5378,
           "resourceSize": 20616
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7792,
+          "transferSize": 7777,
           "resourceSize": 8841
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484267,
+          "transferSize": 484249,
           "resourceSize": 1188239
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1956,
+          "transferSize": 1953,
           "resourceSize": 4608
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692196,
+          "transferSize": 692195,
           "resourceSize": 1376593
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2086,
+          "transferSize": 2084,
           "resourceSize": 4960
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692323,
+          "transferSize": 692328,
           "resourceSize": 1376945
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1967,
+          "transferSize": 1965,
           "resourceSize": 4590
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692209,
+          "transferSize": 692206,
           "resourceSize": 1376575
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2160,
+          "transferSize": 2158,
           "resourceSize": 5070
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692402,
+          "transferSize": 692395,
           "resourceSize": 1377055
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2804,
+          "transferSize": 2800,
           "resourceSize": 7388
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917223,
+          "transferSize": 917220,
           "resourceSize": 1603379
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2841,
+          "transferSize": 2837,
           "resourceSize": 6492
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699233,
+          "transferSize": 699228,
           "resourceSize": 1389476
         }
       },

--- a/.github/page_size_audit_results/v1.21.0.json
+++ b/.github/page_size_audit_results/v1.21.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.21.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:45.709Z"
+    "generatedAt": "2025-12-25T01:00:25.868Z"
   },
-  "timestamp": "2025-12-24T18:56:45.710Z",
+  "timestamp": "2025-12-25T01:00:25.868Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2179,
+          "transferSize": 2175,
           "resourceSize": 5477
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692567,
+          "transferSize": 692569,
           "resourceSize": 1378420
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2144,
+          "transferSize": 2140,
           "resourceSize": 5474
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692533,
+          "transferSize": 692527,
           "resourceSize": 1378417
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5747,
+          "transferSize": 5743,
           "resourceSize": 23921
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9082,
+          "transferSize": 9095,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486071,
+          "transferSize": 486080,
           "resourceSize": 1195590
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2016,
+          "transferSize": 2011,
           "resourceSize": 4932
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692405,
+          "transferSize": 692397,
           "resourceSize": 1377875
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2145,
+          "transferSize": 2141,
           "resourceSize": 5284
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692538,
+          "transferSize": 692530,
           "resourceSize": 1378227
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2027,
+          "transferSize": 2024,
           "resourceSize": 4914
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692412,
+          "transferSize": 692416,
           "resourceSize": 1377857
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2221,
+          "transferSize": 2218,
           "resourceSize": 5394
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692617,
+          "transferSize": 692611,
           "resourceSize": 1378337
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3058,
+          "transferSize": 3054,
           "resourceSize": 8872
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1318,
+          "transferSize": 1322,
           "resourceSize": 604
         },
         "other": {
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2907,
+          "transferSize": 2903,
           "resourceSize": 6816
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1118,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699445,
+          "transferSize": 699439,
           "resourceSize": 1390758
         }
       },

--- a/.github/page_size_audit_results/v1.22.0.json
+++ b/.github/page_size_audit_results/v1.22.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.22.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:59.698Z"
+    "generatedAt": "2025-12-25T01:03:21.370Z"
   },
-  "timestamp": "2025-12-24T18:53:59.698Z",
+  "timestamp": "2025-12-25T01:03:21.370Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2139,
+          "transferSize": 2137,
           "resourceSize": 5448
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692666,
+          "transferSize": 692669,
           "resourceSize": 1379006
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2101,
+          "transferSize": 2100,
           "resourceSize": 5438
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692635,
+          "transferSize": 692634,
           "resourceSize": 1378996
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5704,
+          "transferSize": 5703,
           "resourceSize": 23900
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9079,
+          "transferSize": 9088,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486165,
+          "transferSize": 486173,
           "resourceSize": 1196184
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692506,
+          "transferSize": 692511,
           "resourceSize": 1378454
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2103,
+          "transferSize": 2101,
           "resourceSize": 5248
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692629,
+          "transferSize": 692632,
           "resourceSize": 1378806
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692523,
+          "transferSize": 692519,
           "resourceSize": 1378436
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2179,
+          "transferSize": 2177,
           "resourceSize": 5358
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692711,
+          "transferSize": 692709,
           "resourceSize": 1378916
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3025,
+          "transferSize": 3024,
           "resourceSize": 8888
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1316,
+          "transferSize": 1320,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918276,
+          "transferSize": 918279,
           "resourceSize": 1606861
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699545,
+          "transferSize": 699551,
           "resourceSize": 1391337
         }
       },

--- a/.github/page_size_audit_results/v1.23.0.json
+++ b/.github/page_size_audit_results/v1.23.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.23.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:46.086Z"
+    "generatedAt": "2025-12-25T01:03:11.500Z"
   },
-  "timestamp": "2025-12-24T18:59:46.087Z",
+  "timestamp": "2025-12-25T01:03:11.500Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2231,
-          "resourceSize": 5742
+          "transferSize": 2140,
+          "resourceSize": 5461
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295090,
-          "resourceSize": 940626
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 318722,
-          "resourceSize": 717131
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841350,
-          "resourceSize": 1887975
+          "transferSize": 692704,
+          "resourceSize": 1379103
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2194,
-          "resourceSize": 5719
+          "transferSize": 2103,
+          "resourceSize": 5438
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295090,
-          "resourceSize": 940626
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 318722,
-          "resourceSize": 717131
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841313,
-          "resourceSize": 1887952
+          "transferSize": 692666,
+          "resourceSize": 1379080
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5915,
-          "resourceSize": 24630
+          "transferSize": 5708,
+          "resourceSize": 23900
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 696803,
-          "resourceSize": 2097653
+          "transferSize": 153782,
+          "resourceSize": 444319
         },
         "stylesheet": {
-          "transferSize": 318722,
-          "resourceSize": 717131
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 11952,
-          "resourceSize": 13227
+          "transferSize": 9487,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 1033754,
-          "resourceSize": 2852916
+          "transferSize": 486609,
+          "resourceSize": 1196268
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2064,
-          "resourceSize": 5177
+          "transferSize": 1976,
+          "resourceSize": 4896
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295090,
-          "resourceSize": 940626
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 318722,
-          "resourceSize": 717131
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841182,
-          "resourceSize": 1887410
+          "transferSize": 692534,
+          "resourceSize": 1378538
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2196,
-          "resourceSize": 5529
+          "transferSize": 2106,
+          "resourceSize": 5248
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295090,
-          "resourceSize": 940626
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 318722,
-          "resourceSize": 717131
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841316,
-          "resourceSize": 1887762
+          "transferSize": 692670,
+          "resourceSize": 1378890
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2077,
-          "resourceSize": 5159
+          "transferSize": 1991,
+          "resourceSize": 4878
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295090,
-          "resourceSize": 940626
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 318722,
-          "resourceSize": 717131
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 359,
+          "resourceSize": 272
         },
         "total": {
-          "transferSize": 841204,
-          "resourceSize": 1887393
+          "transferSize": 692552,
+          "resourceSize": 1378517
         }
       },
       "themeResources": {
@@ -425,12 +425,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 359,
+          "resourceSize": 272
         },
         "total": {
-          "transferSize": 689793,
-          "resourceSize": 1373448
+          "transferSize": 689789,
+          "resourceSize": 1373444
         }
       }
     },
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2272,
-          "resourceSize": 5639
+          "transferSize": 2181,
+          "resourceSize": 5358
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295090,
-          "resourceSize": 940626
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 318722,
-          "resourceSize": 717131
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 841393,
-          "resourceSize": 1887873
+          "transferSize": 692745,
+          "resourceSize": 1379000
         }
       },
       "themeResources": {
@@ -496,12 +496,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 689793,
-          "resourceSize": 1373448
+          "transferSize": 689792,
+          "resourceSize": 1373447
         }
       }
     },
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3114,
-          "resourceSize": 9240
+          "transferSize": 3027,
+          "resourceSize": 8959
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295090,
-          "resourceSize": 940626
+          "transferSize": 147985,
+          "resourceSize": 433321
         },
         "stylesheet": {
-          "transferSize": 318722,
-          "resourceSize": 717131
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1313,
+          "transferSize": 1322,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 1066952,
-          "resourceSize": 2115889
+          "transferSize": 918316,
+          "resourceSize": 1607016
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 913968,
-          "resourceSize": 1597454
+          "transferSize": 913967,
+          "resourceSize": 1597453
         }
       }
     },
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3071,
-          "resourceSize": 7564
+          "transferSize": 2869,
+          "resourceSize": 6780
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 696803,
-          "resourceSize": 2097653
+          "transferSize": 153782,
+          "resourceSize": 444319
         },
         "stylesheet": {
-          "transferSize": 318722,
-          "resourceSize": 717131
+          "transferSize": 317270,
+          "resourceSize": 715845
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 4000,
-          "resourceSize": 1493
+          "transferSize": 1126,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 363,
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 1247134,
-          "resourceSize": 3048123
+          "transferSize": 699585,
+          "resourceSize": 1391421
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.24.0.json
+++ b/.github/page_size_audit_results/v1.24.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.24.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:42.129Z"
+    "generatedAt": "2025-12-25T01:00:12.170Z"
   },
-  "timestamp": "2025-12-24T18:53:42.130Z",
+  "timestamp": "2025-12-25T01:00:12.170Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692699,
+          "transferSize": 692705,
           "resourceSize": 1379103
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692666,
+          "transferSize": 692669,
           "resourceSize": 1379080
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5705,
+          "transferSize": 5707,
           "resourceSize": 23900
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9489,
+          "transferSize": 9094,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486608,
+          "transferSize": 486215,
           "resourceSize": 1196268
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692675,
+          "transferSize": 692674,
           "resourceSize": 1378931
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692556,
+          "transferSize": 692560,
           "resourceSize": 1378520
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692746,
+          "transferSize": 692750,
           "resourceSize": 1379041
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3028,
+          "transferSize": 3027,
           "resourceSize": 8959
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1330,
+          "transferSize": 1333,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918325,
+          "transferSize": 918327,
           "resourceSize": 1607016
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699587,
+          "transferSize": 699582,
           "resourceSize": 1391421
         }
       },

--- a/.github/page_size_audit_results/v1.25.0.json
+++ b/.github/page_size_audit_results/v1.25.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.25.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:50.496Z"
+    "generatedAt": "2025-12-25T01:00:26.528Z"
   },
-  "timestamp": "2025-12-24T18:53:50.497Z",
+  "timestamp": "2025-12-25T01:00:26.528Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2137,
+          "transferSize": 2135,
           "resourceSize": 5461
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2106,
+          "transferSize": 2103,
           "resourceSize": 5457
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692822,
+          "transferSize": 692810,
           "resourceSize": 1379462
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5704,
+          "transferSize": 5702,
           "resourceSize": 23900
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9088,
+          "transferSize": 9497,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486353,
+          "transferSize": 486760,
           "resourceSize": 1196631
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692682,
+          "transferSize": 692677,
           "resourceSize": 1378901
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2108,
+          "transferSize": 2105,
           "resourceSize": 5289
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2181,
+          "transferSize": 2179,
           "resourceSize": 5399
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692892,
+          "transferSize": 692889,
           "resourceSize": 1379404
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3024,
+          "transferSize": 3023,
           "resourceSize": 8959
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1329,
+          "transferSize": 1315,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918467,
+          "transferSize": 918452,
           "resourceSize": 1607379
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1118,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699720,
+          "transferSize": 699727,
           "resourceSize": 1391784
         }
       },

--- a/.github/page_size_audit_results/v1.26.0.json
+++ b/.github/page_size_audit_results/v1.26.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.26.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:57.479Z"
+    "generatedAt": "2025-12-25T01:03:16.809Z"
   },
-  "timestamp": "2025-12-24T18:53:57.479Z",
+  "timestamp": "2025-12-25T01:03:16.809Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2220,
-          "resourceSize": 5753
+          "transferSize": 2136,
+          "resourceSize": 5461
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161770,
-          "resourceSize": 502487
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319226,
-          "resourceSize": 717730
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 708526,
-          "resourceSize": 1450446
+          "transferSize": 692842,
+          "resourceSize": 1379466
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2187,
-          "resourceSize": 5749
+          "transferSize": 2105,
+          "resourceSize": 5457
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161770,
-          "resourceSize": 502487
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319226,
-          "resourceSize": 717730
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 708487,
-          "resourceSize": 1450442
+          "transferSize": 692812,
+          "resourceSize": 1379462
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5785,
-          "resourceSize": 24192
+          "transferSize": 5704,
+          "resourceSize": 23900
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 167567,
-          "resourceSize": 513485
+          "transferSize": 153887,
+          "resourceSize": 444545
         },
         "stylesheet": {
-          "transferSize": 319226,
-          "resourceSize": 717730
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9081,
+          "transferSize": 9073,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 502021,
-          "resourceSize": 1267611
+          "transferSize": 486338,
+          "resourceSize": 1196631
         }
       },
       "themeResources": {
@@ -225,20 +225,20 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2053,
-          "resourceSize": 5188
+          "transferSize": 1974,
+          "resourceSize": 4896
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161770,
-          "resourceSize": 502487
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319226,
-          "resourceSize": 717730
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 708354,
-          "resourceSize": 1449881
+          "transferSize": 692681,
+          "resourceSize": 1378901
         }
       },
       "themeResources": {
@@ -296,20 +296,20 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2189,
-          "resourceSize": 5581
+          "transferSize": 2107,
+          "resourceSize": 5289
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161770,
-          "resourceSize": 502487
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319226,
-          "resourceSize": 717730
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 708493,
-          "resourceSize": 1450274
+          "transferSize": 692817,
+          "resourceSize": 1379294
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2067,
-          "resourceSize": 5170
+          "transferSize": 1989,
+          "resourceSize": 4878
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161770,
-          "resourceSize": 502487
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319226,
-          "resourceSize": 717730
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 708368,
-          "resourceSize": 1449863
+          "transferSize": 692697,
+          "resourceSize": 1378883
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2264,
-          "resourceSize": 5691
+          "transferSize": 2181,
+          "resourceSize": 5399
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161770,
-          "resourceSize": 502487
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319226,
-          "resourceSize": 717730
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 708567,
-          "resourceSize": 1450384
+          "transferSize": 692891,
+          "resourceSize": 1379404
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3105,
-          "resourceSize": 9264
+          "transferSize": 3035,
+          "resourceSize": 8972
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161770,
-          "resourceSize": 502487
+          "transferSize": 148090,
+          "resourceSize": 433547
         },
         "stylesheet": {
-          "transferSize": 319226,
-          "resourceSize": 717730
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1324,
+          "transferSize": 1318,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 934138,
-          "resourceSize": 1678373
+          "transferSize": 918467,
+          "resourceSize": 1607392
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 914115,
-          "resourceSize": 1597817
+          "transferSize": 914114,
+          "resourceSize": 1597816
         }
       }
     },
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2941,
-          "resourceSize": 7072
+          "transferSize": 2866,
+          "resourceSize": 6780
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 167567,
-          "resourceSize": 513485
+          "transferSize": 153887,
+          "resourceSize": 444545
         },
         "stylesheet": {
-          "transferSize": 319226,
-          "resourceSize": 717730
+          "transferSize": 317312,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 715394,
-          "resourceSize": 1462764
+          "transferSize": 699726,
+          "resourceSize": 1391784
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.27.0.json
+++ b/.github/page_size_audit_results/v1.27.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.27.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:53.811Z"
+    "generatedAt": "2025-12-25T01:02:53.328Z"
   },
-  "timestamp": "2025-12-24T18:53:53.812Z",
+  "timestamp": "2025-12-25T01:02:53.328Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2151,
-          "resourceSize": 5621
+          "transferSize": 2244,
+          "resourceSize": 5902
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 148631,
-          "resourceSize": 433122
+          "transferSize": 295736,
+          "resourceSize": 940427
         },
         "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
+          "transferSize": 318748,
+          "resourceSize": 717268
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693384,
-          "resourceSize": 1379201
+          "transferSize": 842037,
+          "resourceSize": 1888073
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2115,
-          "resourceSize": 5617
+          "transferSize": 2208,
+          "resourceSize": 5898
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 148631,
-          "resourceSize": 433122
+          "transferSize": 295736,
+          "resourceSize": 940427
         },
         "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
+          "transferSize": 318748,
+          "resourceSize": 717268
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693350,
-          "resourceSize": 1379197
+          "transferSize": 841997,
+          "resourceSize": 1888069
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5713,
-          "resourceSize": 24060
+          "transferSize": 5931,
+          "resourceSize": 24790
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 154428,
-          "resourceSize": 444120
+          "transferSize": 697449,
+          "resourceSize": 2097454
         },
         "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
+          "transferSize": 318748,
+          "resourceSize": 717268
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9079,
-          "resourceSize": 11929
+          "transferSize": 11959,
+          "resourceSize": 13227
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486878,
-          "resourceSize": 1196366
+          "transferSize": 1034449,
+          "resourceSize": 2853014
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1985,
-          "resourceSize": 5056
+          "transferSize": 2077,
+          "resourceSize": 5337
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 148631,
-          "resourceSize": 433122
+          "transferSize": 295736,
+          "resourceSize": 940427
         },
         "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
+          "transferSize": 318748,
+          "resourceSize": 717268
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693216,
-          "resourceSize": 1378636
+          "transferSize": 841867,
+          "resourceSize": 1887508
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2119,
-          "resourceSize": 5449
+          "transferSize": 2210,
+          "resourceSize": 5730
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 148631,
-          "resourceSize": 433122
+          "transferSize": 295736,
+          "resourceSize": 940427
         },
         "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
+          "transferSize": 318748,
+          "resourceSize": 717268
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693353,
-          "resourceSize": 1379029
+          "transferSize": 842006,
+          "resourceSize": 1887901
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1999,
-          "resourceSize": 5038
+          "transferSize": 2089,
+          "resourceSize": 5319
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 148631,
-          "resourceSize": 433122
+          "transferSize": 295736,
+          "resourceSize": 940427
         },
         "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
+          "transferSize": 318748,
+          "resourceSize": 717268
         },
         "image": {
           "transferSize": 224175,
@@ -391,12 +391,12 @@
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 693233,
-          "resourceSize": 1378618
+          "transferSize": 841881,
+          "resourceSize": 1887491
         }
       },
       "themeResources": {
@@ -425,12 +425,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 690464,
-          "resourceSize": 1373385
+          "transferSize": 690465,
+          "resourceSize": 1373386
         }
       }
     },
@@ -438,169 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2194,
-          "resourceSize": 5559
+          "transferSize": 2285,
+          "resourceSize": 5840
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 148631,
-          "resourceSize": 433122
+          "transferSize": 295736,
+          "resourceSize": 940427
         },
         "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
+          "transferSize": 318748,
+          "resourceSize": 717268
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
-          "resourceSize": 195
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 693427,
-          "resourceSize": 1379139
-        }
-      },
-      "themeResources": {
-        "document": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 148631,
-          "resourceSize": 433122
-        },
-        "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 690464,
-          "resourceSize": 1373385
-        }
-      }
-    },
-    {
-      "url": "/authors/admin",
-      "resources": {
-        "document": {
-          "transferSize": 3039,
-          "resourceSize": 9132
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 148631,
-          "resourceSize": 433122
-        },
-        "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
-        },
-        "image": {
-          "transferSize": 448350,
-          "resourceSize": 448012
-        },
-        "fetch": {
-          "transferSize": 1322,
-          "resourceSize": 604
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 919000,
-          "resourceSize": 1607127
-        }
-      },
-      "themeResources": {
-        "document": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 148631,
-          "resourceSize": 433122
-        },
-        "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
-        },
-        "image": {
-          "transferSize": 448350,
-          "resourceSize": 448012
-        },
-        "fetch": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 914639,
-          "resourceSize": 1597391
-        }
-      }
-    },
-    {
-      "url": "/about",
-      "resources": {
-        "document": {
-          "transferSize": 2872,
-          "resourceSize": 6940
-        },
-        "font": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "script": {
-          "transferSize": 154428,
-          "resourceSize": 444120
-        },
-        "stylesheet": {
-          "transferSize": 317296,
-          "resourceSize": 715982
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 1127,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +466,150 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700261,
-          "resourceSize": 1391519
+          "transferSize": 842077,
+          "resourceSize": 1888012
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 148631,
+          "resourceSize": 433122
+        },
+        "stylesheet": {
+          "transferSize": 317296,
+          "resourceSize": 715982
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 690465,
+          "resourceSize": 1373386
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3129,
+          "resourceSize": 9413
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 295736,
+          "resourceSize": 940427
+        },
+        "stylesheet": {
+          "transferSize": 318748,
+          "resourceSize": 717268
+        },
+        "image": {
+          "transferSize": 448350,
+          "resourceSize": 448012
+        },
+        "fetch": {
+          "transferSize": 1320,
+          "resourceSize": 604
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 1067646,
+          "resourceSize": 2116000
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 148631,
+          "resourceSize": 433122
+        },
+        "stylesheet": {
+          "transferSize": 317296,
+          "resourceSize": 715982
+        },
+        "image": {
+          "transferSize": 448350,
+          "resourceSize": 448012
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 914640,
+          "resourceSize": 1597392
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3084,
+          "resourceSize": 7724
+        },
+        "font": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "script": {
+          "transferSize": 697449,
+          "resourceSize": 2097454
+        },
+        "stylesheet": {
+          "transferSize": 318748,
+          "resourceSize": 717268
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 3996,
+          "resourceSize": 1493
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 1247815,
+          "resourceSize": 3048221
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.28.0.json
+++ b/.github/page_size_audit_results/v1.28.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.28.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:58:51.311Z"
+    "generatedAt": "2025-12-25T01:00:23.401Z"
   },
-  "timestamp": "2025-12-24T18:58:51.311Z",
+  "timestamp": "2025-12-25T01:00:23.402Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2146,
-          "resourceSize": 5628
+          "transferSize": 2231,
+          "resourceSize": 5920
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 159166,
+          "resourceSize": 471497
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 319207,
+          "resourceSize": 717733
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690228,
-          "resourceSize": 1348646
+          "transferSize": 705915,
+          "resourceSize": 1419626
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2111,
-          "resourceSize": 5617
+          "transferSize": 2196,
+          "resourceSize": 5909
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 159166,
+          "resourceSize": 471497
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 319207,
+          "resourceSize": 717733
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690193,
-          "resourceSize": 1348635
+          "transferSize": 705879,
+          "resourceSize": 1419615
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5709,
-          "resourceSize": 24062
+          "transferSize": 5792,
+          "resourceSize": 24354
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 151283,
-          "resourceSize": 413555
+          "transferSize": 164963,
+          "resourceSize": 482495
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 319207,
+          "resourceSize": 717733
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9101,
+          "transferSize": 9096,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483748,
-          "resourceSize": 1165806
+          "transferSize": 499420,
+          "resourceSize": 1236786
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1980,
-          "resourceSize": 5056
+          "transferSize": 2064,
+          "resourceSize": 5348
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 159166,
+          "resourceSize": 471497
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 319207,
+          "resourceSize": 717733
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690065,
-          "resourceSize": 1348074
+          "transferSize": 705742,
+          "resourceSize": 1419054
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2113,
-          "resourceSize": 5449
+          "transferSize": 2196,
+          "resourceSize": 5741
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 159166,
+          "resourceSize": 471497
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 319207,
+          "resourceSize": 717733
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690198,
-          "resourceSize": 1348467
+          "transferSize": 705878,
+          "resourceSize": 1419447
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1994,
-          "resourceSize": 5038
+          "transferSize": 2078,
+          "resourceSize": 5330
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 159166,
+          "resourceSize": 471497
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 319207,
+          "resourceSize": 717733
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690084,
-          "resourceSize": 1348056
+          "transferSize": 705759,
+          "resourceSize": 1419036
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2188,
-          "resourceSize": 5559
+          "transferSize": 2273,
+          "resourceSize": 5851
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 159166,
+          "resourceSize": 471497
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 319207,
+          "resourceSize": 717733
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690273,
-          "resourceSize": 1348577
+          "transferSize": 705954,
+          "resourceSize": 1419557
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3034,
-          "resourceSize": 9132
+          "transferSize": 3118,
+          "resourceSize": 9424
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145486,
-          "resourceSize": 402557
+          "transferSize": 159166,
+          "resourceSize": 471497
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 319207,
+          "resourceSize": 717733
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1319,
+          "transferSize": 1324,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 915844,
-          "resourceSize": 1576565
+          "transferSize": 931528,
+          "resourceSize": 1647546
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 911491,
-          "resourceSize": 1566829
+          "transferSize": 911492,
+          "resourceSize": 1566830
         }
       }
     },
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2868,
-          "resourceSize": 6942
+          "transferSize": 2949,
+          "resourceSize": 7234
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 151283,
-          "resourceSize": 413555
+          "transferSize": 164963,
+          "resourceSize": 482495
         },
         "stylesheet": {
-          "transferSize": 317293,
-          "resourceSize": 715985
+          "transferSize": 319207,
+          "resourceSize": 717733
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697108,
-          "resourceSize": 1360959
+          "transferSize": 712784,
+          "resourceSize": 1431939
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.29.0.json
+++ b/.github/page_size_audit_results/v1.29.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.29.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:59.133Z"
+    "generatedAt": "2025-12-25T01:00:19.293Z"
   },
-  "timestamp": "2025-12-24T18:56:59.133Z",
+  "timestamp": "2025-12-25T01:00:19.293Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2148,
+          "transferSize": 2145,
           "resourceSize": 5633
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690230,
+          "transferSize": 690232,
           "resourceSize": 1348651
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2113,
+          "transferSize": 2110,
           "resourceSize": 5622
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690201,
+          "transferSize": 690199,
           "resourceSize": 1348640
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5710,
+          "transferSize": 5708,
           "resourceSize": 24067
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9071,
+          "transferSize": 9493,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483719,
+          "transferSize": 484139,
           "resourceSize": 1165811
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1983,
+          "transferSize": 1980,
           "resourceSize": 5061
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690068,
+          "transferSize": 690065,
           "resourceSize": 1348079
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2114,
+          "transferSize": 2112,
           "resourceSize": 5454
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690199,
+          "transferSize": 690197,
           "resourceSize": 1348472
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1996,
+          "transferSize": 1994,
           "resourceSize": 5043
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690085,
+          "transferSize": 690078,
           "resourceSize": 1348061
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2189,
+          "transferSize": 2187,
           "resourceSize": 5564
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690277,
+          "transferSize": 690271,
           "resourceSize": 1348582
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3035,
+          "transferSize": 3031,
           "resourceSize": 9137
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1327,
+          "transferSize": 1316,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915853,
+          "transferSize": 915838,
           "resourceSize": 1576570
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2872,
+          "transferSize": 2868,
           "resourceSize": 6947
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697109,
+          "transferSize": 697107,
           "resourceSize": 1360964
         }
       },

--- a/.github/page_size_audit_results/v1.29.1.json
+++ b/.github/page_size_audit_results/v1.29.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.29.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:36.311Z"
+    "generatedAt": "2025-12-25T01:00:13.331Z"
   },
-  "timestamp": "2025-12-24T18:56:36.311Z",
+  "timestamp": "2025-12-25T01:00:13.331Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690234,
+          "transferSize": 690230,
           "resourceSize": 1348669
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2110,
+          "transferSize": 2109,
           "resourceSize": 5622
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690201,
+          "transferSize": 690197,
           "resourceSize": 1348658
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9123,
+          "transferSize": 9099,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483774,
+          "transferSize": 483750,
           "resourceSize": 1165829
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690073,
+          "transferSize": 690071,
           "resourceSize": 1348097
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690200,
+          "transferSize": 690203,
           "resourceSize": 1348490
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690089,
+          "transferSize": 690084,
           "resourceSize": 1348079
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2188,
+          "transferSize": 2187,
           "resourceSize": 5564
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690276,
+          "transferSize": 690272,
           "resourceSize": 1348600
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3032,
+          "transferSize": 3031,
           "resourceSize": 9137
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1319,
+          "transferSize": 1317,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915847,
+          "transferSize": 915844,
           "resourceSize": 1576588
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697112,
+          "transferSize": 697108,
           "resourceSize": 1360982
         }
       },

--- a/.github/page_size_audit_results/v1.3.0.json
+++ b/.github/page_size_audit_results/v1.3.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.3.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:32.453Z"
+    "generatedAt": "2025-12-25T01:00:08.735Z"
   },
-  "timestamp": "2025-12-24T18:56:32.453Z",
+  "timestamp": "2025-12-25T01:00:08.735Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2595,
+          "transferSize": 2596,
           "resourceSize": 5460
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690273,
+          "transferSize": 690278,
           "resourceSize": 1367125
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2456,
+          "transferSize": 2460,
           "resourceSize": 5144
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 779,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690143,
+          "transferSize": 690134,
           "resourceSize": 1366809
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5227,
+          "transferSize": 5229,
           "resourceSize": 16790
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5007,
+          "transferSize": 5028,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479038,
+          "transferSize": 479061,
           "resourceSize": 1172335
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2451,
+          "transferSize": 2452,
           "resourceSize": 4954
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690127,
+          "transferSize": 690130,
           "resourceSize": 1366619
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689976,
+          "transferSize": 689982,
           "resourceSize": 1366210
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2506,
+          "transferSize": 2507,
           "resourceSize": 5064
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690183,
+          "transferSize": 690189,
           "resourceSize": 1366729
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3192,
+          "transferSize": 3191,
           "resourceSize": 7530
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915045,
+          "transferSize": 915046,
           "resourceSize": 1593201
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697250,
+          "transferSize": 697253,
           "resourceSize": 1380521
         }
       },

--- a/.github/page_size_audit_results/v1.30.0.json
+++ b/.github/page_size_audit_results/v1.30.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.30.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:59.192Z"
+    "generatedAt": "2025-12-25T01:03:07.341Z"
   },
-  "timestamp": "2025-12-24T18:53:59.193Z",
+  "timestamp": "2025-12-25T01:03:07.342Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2151,
+          "transferSize": 2153,
           "resourceSize": 5712
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690255,
+          "transferSize": 690258,
           "resourceSize": 1348699
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2114,
+          "transferSize": 2115,
           "resourceSize": 5701
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690211,
+          "transferSize": 690217,
           "resourceSize": 1348688
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5717,
+          "transferSize": 5720,
           "resourceSize": 24162
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9094,
+          "transferSize": 9075,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483763,
+          "transferSize": 483747,
           "resourceSize": 1165875
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1984,
+          "transferSize": 1986,
           "resourceSize": 5140
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690084,
+          "transferSize": 690087,
           "resourceSize": 1348127
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2118,
           "resourceSize": 5533
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690217,
+          "transferSize": 690218,
           "resourceSize": 1348520
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1996,
+          "transferSize": 1998,
           "resourceSize": 5122
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690096,
+          "transferSize": 690100,
           "resourceSize": 1348109
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690293,
+          "transferSize": 690295,
           "resourceSize": 1348630
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3039,
+          "transferSize": 3041,
           "resourceSize": 9216
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1322,
+          "transferSize": 1315,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915866,
+          "transferSize": 915861,
           "resourceSize": 1576618
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2878,
+          "transferSize": 2882,
           "resourceSize": 7048
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697133,
+          "transferSize": 697136,
           "resourceSize": 1361034
         }
       },

--- a/.github/page_size_audit_results/v1.31.0.json
+++ b/.github/page_size_audit_results/v1.31.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.31.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:55:52.320Z"
+    "generatedAt": "2025-12-25T01:03:12.761Z"
   },
-  "timestamp": "2025-12-24T18:55:52.321Z",
+  "timestamp": "2025-12-25T01:03:12.761Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2152,
+          "transferSize": 2148,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690253,
+          "transferSize": 690244,
           "resourceSize": 1348703
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2113,
           "resourceSize": 5705
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690217,
+          "transferSize": 690218,
           "resourceSize": 1348692
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5714,
+          "transferSize": 5712,
           "resourceSize": 24170
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9434,
+          "transferSize": 9510,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484100,
+          "transferSize": 484174,
           "resourceSize": 1165883
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1982,
+          "transferSize": 1978,
           "resourceSize": 5144
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690080,
+          "transferSize": 690082,
           "resourceSize": 1348131
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2113,
           "resourceSize": 5537
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690224,
+          "transferSize": 690214,
           "resourceSize": 1348524
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1994,
+          "transferSize": 1991,
           "resourceSize": 5126
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690093,
+          "transferSize": 690094,
           "resourceSize": 1348113
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2190,
+          "transferSize": 2188,
           "resourceSize": 5647
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690288,
+          "transferSize": 690292,
           "resourceSize": 1348634
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3038,
+          "transferSize": 3034,
           "resourceSize": 9220
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1324,
+          "transferSize": 1322,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915867,
+          "transferSize": 915861,
           "resourceSize": 1576622
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2878,
+          "transferSize": 2874,
           "resourceSize": 7052
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697128,
+          "transferSize": 697122,
           "resourceSize": 1361038
         }
       },

--- a/.github/page_size_audit_results/v1.32.0.json
+++ b/.github/page_size_audit_results/v1.32.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.32.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:54:05.361Z"
+    "generatedAt": "2025-12-25T01:00:19.151Z"
   },
-  "timestamp": "2025-12-24T18:54:05.361Z",
+  "timestamp": "2025-12-25T01:00:19.151Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2149,
+          "transferSize": 2151,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2113,
+          "transferSize": 2116,
           "resourceSize": 5705
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690235,
+          "transferSize": 690236,
           "resourceSize": 1348805
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5732,
+          "transferSize": 5734,
           "resourceSize": 24244
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9083,
+          "transferSize": 9536,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483790,
+          "transferSize": 484245,
           "resourceSize": 1166070
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1978,
+          "transferSize": 1982,
           "resourceSize": 5144
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690107,
+          "transferSize": 690103,
           "resourceSize": 1348244
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2114,
+          "transferSize": 2116,
           "resourceSize": 5537
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690235,
+          "transferSize": 690237,
           "resourceSize": 1348637
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1991,
+          "transferSize": 1994,
           "resourceSize": 5126
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690111,
+          "transferSize": 690117,
           "resourceSize": 1348226
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2188,
+          "transferSize": 2189,
           "resourceSize": 5647
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3035,
+          "transferSize": 3037,
           "resourceSize": 9220
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1325,
+          "transferSize": 1323,
           "resourceSize": 604
         },
         "other": {
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2874,
+          "transferSize": 2877,
           "resourceSize": 7052
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1129,
+          "transferSize": 1116,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697154,
+          "transferSize": 697144,
           "resourceSize": 1361151
         }
       },

--- a/.github/page_size_audit_results/v1.32.1.json
+++ b/.github/page_size_audit_results/v1.32.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.32.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:48.188Z"
+    "generatedAt": "2025-12-25T01:03:09.159Z"
   },
-  "timestamp": "2025-12-24T18:53:48.188Z",
+  "timestamp": "2025-12-25T01:03:09.160Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690308,
+          "transferSize": 690309,
           "resourceSize": 1348953
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690276,
+          "transferSize": 690272,
           "resourceSize": 1348942
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5730,
+          "transferSize": 5729,
           "resourceSize": 24290
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9097,
+          "transferSize": 9071,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483839,
+          "transferSize": 483812,
           "resourceSize": 1166253
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690277,
+          "transferSize": 690273,
           "resourceSize": 1348774
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690155,
+          "transferSize": 690152,
           "resourceSize": 1348363
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690346,
+          "transferSize": 690351,
           "resourceSize": 1348884
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3037,
+          "transferSize": 3036,
           "resourceSize": 9220
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1318,
+          "transferSize": 1317,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915920,
+          "transferSize": 915918,
           "resourceSize": 1576872
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697187,
+          "transferSize": 697190,
           "resourceSize": 1361288
         }
       },

--- a/.github/page_size_audit_results/v1.33.0.json
+++ b/.github/page_size_audit_results/v1.33.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.33.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:48.875Z"
+    "generatedAt": "2025-12-25T01:00:20.810Z"
   },
-  "timestamp": "2025-12-24T18:53:48.875Z",
+  "timestamp": "2025-12-25T01:00:20.811Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2152,
+          "transferSize": 2153,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690313,
+          "transferSize": 690312,
           "resourceSize": 1348953
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2116,
+          "transferSize": 2117,
           "resourceSize": 5705
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690275,
+          "transferSize": 690281,
           "resourceSize": 1348942
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690146,
+          "transferSize": 690143,
           "resourceSize": 1348381
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690274,
+          "transferSize": 690277,
           "resourceSize": 1348774
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690156,
+          "transferSize": 690153,
           "resourceSize": 1348363
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690345,
+          "transferSize": 690358,
           "resourceSize": 1348884
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3039,
+          "transferSize": 3038,
           "resourceSize": 9220
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1319,
+          "transferSize": 1320,
           "resourceSize": 604
         },
         "other": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697192,
+          "transferSize": 697193,
           "resourceSize": 1361288
         }
       },

--- a/.github/page_size_audit_results/v1.34.0.json
+++ b/.github/page_size_audit_results/v1.34.0.json
@@ -4,24 +4,24 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.34.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:57:01.332Z"
+    "generatedAt": "2025-12-25T01:00:10.929Z"
   },
-  "timestamp": "2025-12-24T18:57:01.332Z",
+  "timestamp": "2025-12-25T01:00:10.929Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2153,
-          "resourceSize": 5716
+          "transferSize": 2214,
+          "resourceSize": 5866
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145511,
-          "resourceSize": 402563
+          "transferSize": 158125,
+          "resourceSize": 447133
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690313,
-          "resourceSize": 1348953
+          "transferSize": 702993,
+          "resourceSize": 1393673
         }
       },
       "themeResources": {
@@ -83,16 +83,16 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2117,
-          "resourceSize": 5705
+          "transferSize": 2179,
+          "resourceSize": 5855
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145511,
-          "resourceSize": 402563
+          "transferSize": 158125,
+          "resourceSize": 447133
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690275,
-          "resourceSize": 1348942
+          "transferSize": 702950,
+          "resourceSize": 1393662
         }
       },
       "themeResources": {
@@ -154,16 +154,16 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5442,
-          "resourceSize": 23874
+          "transferSize": 5574,
+          "resourceSize": 24171
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 151308,
-          "resourceSize": 413561
+          "transferSize": 163922,
+          "resourceSize": 458131
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9100,
+          "transferSize": 9082,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483554,
-          "resourceSize": 1165837
+          "transferSize": 496282,
+          "resourceSize": 1210704
         }
       },
       "themeResources": {
@@ -225,16 +225,16 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1983,
-          "resourceSize": 5144
+          "transferSize": 2044,
+          "resourceSize": 5294
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145511,
-          "resourceSize": 402563
+          "transferSize": 158125,
+          "resourceSize": 447133
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690140,
-          "resourceSize": 1348381
+          "transferSize": 702823,
+          "resourceSize": 1393101
         }
       },
       "themeResources": {
@@ -296,16 +296,16 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2118,
-          "resourceSize": 5537
+          "transferSize": 2180,
+          "resourceSize": 5687
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145511,
-          "resourceSize": 402563
+          "transferSize": 158125,
+          "resourceSize": 447133
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690276,
-          "resourceSize": 1348774
+          "transferSize": 702949,
+          "resourceSize": 1393494
         }
       },
       "themeResources": {
@@ -367,16 +367,16 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1995,
-          "resourceSize": 5126
+          "transferSize": 2058,
+          "resourceSize": 5276
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145511,
-          "resourceSize": 402563
+          "transferSize": 158125,
+          "resourceSize": 447133
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690152,
-          "resourceSize": 1348363
+          "transferSize": 702835,
+          "resourceSize": 1393083
         }
       },
       "themeResources": {
@@ -438,16 +438,16 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2191,
-          "resourceSize": 5647
+          "transferSize": 2255,
+          "resourceSize": 5797
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145511,
-          "resourceSize": 402563
+          "transferSize": 158125,
+          "resourceSize": 447133
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690351,
-          "resourceSize": 1348884
+          "transferSize": 703029,
+          "resourceSize": 1393604
         }
       },
       "themeResources": {
@@ -509,16 +509,16 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3039,
-          "resourceSize": 9220
+          "transferSize": 3096,
+          "resourceSize": 9370
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145511,
-          "resourceSize": 402563
+          "transferSize": 158125,
+          "resourceSize": 447133
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -537,8 +537,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915923,
-          "resourceSize": 1576872
+          "transferSize": 928594,
+          "resourceSize": 1621592
         }
       },
       "themeResources": {
@@ -580,16 +580,16 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2871,
-          "resourceSize": 7050
+          "transferSize": 2988,
+          "resourceSize": 7347
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 151308,
-          "resourceSize": 413561
+          "transferSize": 163922,
+          "resourceSize": 458131
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1131,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697190,
-          "resourceSize": 1361286
+          "transferSize": 709909,
+          "resourceSize": 1406153
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.34.1.json
+++ b/.github/page_size_audit_results/v1.34.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.34.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:53.299Z"
+    "generatedAt": "2025-12-25T01:00:20.537Z"
   },
-  "timestamp": "2025-12-24T18:53:53.300Z",
+  "timestamp": "2025-12-25T01:00:20.538Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2167,
+          "transferSize": 2166,
           "resourceSize": 5770
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690446,
+          "transferSize": 690445,
           "resourceSize": 1350739
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690410,
+          "transferSize": 690408,
           "resourceSize": 1350728
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5460,
+          "transferSize": 5459,
           "resourceSize": 23928
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9101,
+          "transferSize": 9088,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483696,
+          "transferSize": 483682,
           "resourceSize": 1167623
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690275,
+          "transferSize": 690280,
           "resourceSize": 1350167
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2130,
+          "transferSize": 2131,
           "resourceSize": 5591
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690412,
+          "transferSize": 690414,
           "resourceSize": 1350560
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690289,
+          "transferSize": 690291,
           "resourceSize": 1350149
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690490,
+          "transferSize": 690488,
           "resourceSize": 1350670
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3070,
+          "transferSize": 3069,
           "resourceSize": 9266
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1312,
+          "transferSize": 1317,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 916070,
+          "transferSize": 916074,
           "resourceSize": 1578650
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697315,
+          "transferSize": 697316,
           "resourceSize": 1363072
         }
       },

--- a/.github/page_size_audit_results/v1.35.0.json
+++ b/.github/page_size_audit_results/v1.35.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.35.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:48.447Z"
+    "generatedAt": "2025-12-25T01:06:20.161Z"
   },
-  "timestamp": "2025-12-24T18:53:48.448Z",
+  "timestamp": "2025-12-25T01:06:20.162Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689423,
+          "transferSize": 689419,
           "resourceSize": 1345673
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689379,
+          "transferSize": 689380,
           "resourceSize": 1345658
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9101,
+          "transferSize": 9089,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478663,
+          "transferSize": 478651,
           "resourceSize": 1153244
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689248,
+          "transferSize": 689253,
           "resourceSize": 1345097
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2129,
+          "transferSize": 2130,
           "resourceSize": 5600
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689379,
+          "transferSize": 689390,
           "resourceSize": 1345490
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689267,
+          "transferSize": 689261,
           "resourceSize": 1345079
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2203,
+          "transferSize": 2204,
           "resourceSize": 5710
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689458,
+          "transferSize": 689462,
           "resourceSize": 1345600
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3081,
+          "transferSize": 3080,
           "resourceSize": 9307
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1277,
+          "transferSize": 1283,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915018,
+          "transferSize": 915023,
           "resourceSize": 1573565
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691981,
+          "transferSize": 691978,
           "resourceSize": 1347704
         }
       },

--- a/.github/page_size_audit_results/v1.36.0.json
+++ b/.github/page_size_audit_results/v1.36.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.36.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:47.857Z"
+    "generatedAt": "2025-12-25T01:00:15.533Z"
   },
-  "timestamp": "2025-12-24T18:59:47.858Z",
+  "timestamp": "2025-12-25T01:00:15.533Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2167,
+          "transferSize": 2170,
           "resourceSize": 5788
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689262,
+          "transferSize": 689270,
           "resourceSize": 1345259
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2126,
+          "transferSize": 2129,
           "resourceSize": 5768
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689219,
+          "transferSize": 689232,
           "resourceSize": 1345239
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5241,
+          "transferSize": 5244,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9109,
+          "transferSize": 9513,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478515,
+          "transferSize": 478922,
           "resourceSize": 1152825
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1995,
+          "transferSize": 1997,
           "resourceSize": 5207
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689092,
+          "transferSize": 689098,
           "resourceSize": 1344678
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2130,
+          "transferSize": 2132,
           "resourceSize": 5600
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 763,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689230,
+          "transferSize": 689224,
           "resourceSize": 1345071
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2009,
+          "transferSize": 2011,
           "resourceSize": 5189
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689104,
+          "transferSize": 689105,
           "resourceSize": 1344660
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2204,
+          "transferSize": 2207,
           "resourceSize": 5710
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689305,
+          "transferSize": 689302,
           "resourceSize": 1345181
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3081,
+          "transferSize": 3084,
           "resourceSize": 9307
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1280,
+          "transferSize": 1290,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 914865,
+          "transferSize": 914878,
           "resourceSize": 1573146
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2361,
+          "transferSize": 2365,
           "resourceSize": 5976
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691825,
+          "transferSize": 691827,
           "resourceSize": 1347285
         }
       },

--- a/.github/page_size_audit_results/v1.37.0.json
+++ b/.github/page_size_audit_results/v1.37.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.37.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:37.502Z"
+    "generatedAt": "2025-12-25T01:03:07.477Z"
   },
-  "timestamp": "2025-12-24T18:59:37.502Z",
+  "timestamp": "2025-12-25T01:03:07.478Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2170,
+          "transferSize": 2169,
           "resourceSize": 5788
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689971,
+          "transferSize": 689962,
           "resourceSize": 1363050
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9073,
+          "transferSize": 9498,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479180,
+          "transferSize": 479605,
           "resourceSize": 1170616
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689799,
+          "transferSize": 689793,
           "resourceSize": 1362469
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689930,
+          "transferSize": 689932,
           "resourceSize": 1362862
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689809,
+          "transferSize": 689806,
           "resourceSize": 1362451
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689998,
+          "transferSize": 690003,
           "resourceSize": 1362972
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1281,
+          "transferSize": 1282,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915638,
+          "transferSize": 915639,
           "resourceSize": 1591268
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692530,
+          "transferSize": 692524,
           "resourceSize": 1365076
         }
       },

--- a/.github/page_size_audit_results/v1.38.0.json
+++ b/.github/page_size_audit_results/v1.38.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.38.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:49.189Z"
+    "generatedAt": "2025-12-25T01:03:23.003Z"
   },
-  "timestamp": "2025-12-24T18:56:49.189Z",
+  "timestamp": "2025-12-25T01:03:23.003Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2167,
+          "transferSize": 2168,
           "resourceSize": 5788
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690140,
+          "transferSize": 690135,
           "resourceSize": 1363343
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2127,
+          "transferSize": 2128,
           "resourceSize": 5768
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690097,
+          "transferSize": 690093,
           "resourceSize": 1363323
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5241,
+          "transferSize": 5242,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9097,
+          "transferSize": 9065,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479374,
+          "transferSize": 479343,
           "resourceSize": 1170909
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2007,
+          "transferSize": 2009,
           "resourceSize": 5262
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689974,
+          "transferSize": 689976,
           "resourceSize": 1362817
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690108,
+          "transferSize": 690111,
           "resourceSize": 1363193
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2009,
+          "transferSize": 2011,
           "resourceSize": 5189
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2210,
+          "transferSize": 2212,
           "resourceSize": 5748
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3167,
+          "transferSize": 3170,
           "resourceSize": 9706
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1279,
+          "transferSize": 1278,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915821,
+          "transferSize": 915823,
           "resourceSize": 1591629
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2361,
+          "transferSize": 2365,
           "resourceSize": 5976
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692698,
+          "transferSize": 692699,
           "resourceSize": 1365369
         }
       },

--- a/.github/page_size_audit_results/v1.39.0.json
+++ b/.github/page_size_audit_results/v1.39.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.39.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:50.387Z"
+    "generatedAt": "2025-12-25T01:00:01.263Z"
   },
-  "timestamp": "2025-12-24T18:56:50.388Z",
+  "timestamp": "2025-12-25T01:00:01.264Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690167,
+          "transferSize": 690155,
           "resourceSize": 1363368
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690122,
+          "transferSize": 690116,
           "resourceSize": 1363348
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5271,
+          "transferSize": 5269,
           "resourceSize": 23873
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9092,
+          "transferSize": 9479,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479399,
+          "transferSize": 479784,
           "resourceSize": 1170934
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689995,
+          "transferSize": 689996,
           "resourceSize": 1362842
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690127,
+          "transferSize": 690126,
           "resourceSize": 1363218
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689999,
+          "transferSize": 690002,
           "resourceSize": 1362769
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2233,
+          "transferSize": 2232,
           "resourceSize": 5833
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690205,
+          "transferSize": 690201,
           "resourceSize": 1363328
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1290,
+          "transferSize": 1282,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915858,
+          "transferSize": 915850,
           "resourceSize": 1591654
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692721,
+          "transferSize": 692719,
           "resourceSize": 1365394
         }
       },

--- a/.github/page_size_audit_results/v1.4.0.json
+++ b/.github/page_size_audit_results/v1.4.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.4.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:59.057Z"
+    "generatedAt": "2025-12-25T01:03:20.218Z"
   },
-  "timestamp": "2025-12-24T18:53:59.057Z",
+  "timestamp": "2025-12-25T01:03:20.219Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2598,
+          "transferSize": 2597,
           "resourceSize": 5465
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690276,
+          "transferSize": 690277,
           "resourceSize": 1367130
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2463,
+          "transferSize": 2462,
           "resourceSize": 5149
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690138,
+          "transferSize": 690143,
           "resourceSize": 1366814
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5228,
+          "transferSize": 5225,
           "resourceSize": 16795
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4954,
+          "transferSize": 4972,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478986,
+          "transferSize": 479001,
           "resourceSize": 1172340
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2285,
+          "transferSize": 2288,
           "resourceSize": 4533
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689965,
+          "transferSize": 689966,
           "resourceSize": 1366198
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2453,
+          "transferSize": 2452,
           "resourceSize": 4959
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690129,
+          "transferSize": 690126,
           "resourceSize": 1366624
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2306,
+          "transferSize": 2308,
           "resourceSize": 4550
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689985,
+          "transferSize": 689988,
           "resourceSize": 1366215
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690189,
+          "transferSize": 690190,
           "resourceSize": 1366734
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3195,
+          "transferSize": 3198,
           "resourceSize": 7535
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915046,
+          "transferSize": 915053,
           "resourceSize": 1593206
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3153,
+          "transferSize": 3156,
           "resourceSize": 6465
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697254,
+          "transferSize": 697258,
           "resourceSize": 1380526
         }
       },

--- a/.github/page_size_audit_results/v1.40.0.json
+++ b/.github/page_size_audit_results/v1.40.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.40.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:57:04.386Z"
+    "generatedAt": "2025-12-25T01:03:02.941Z"
   },
-  "timestamp": "2025-12-24T18:57:04.386Z",
+  "timestamp": "2025-12-25T01:03:02.941Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2271,
-          "resourceSize": 6072
+          "transferSize": 2291,
+          "resourceSize": 6214
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158831,
-          "resourceSize": 449626
+          "transferSize": 159897,
+          "resourceSize": 473996
         },
         "stylesheet": {
-          "transferSize": 317128,
-          "resourceSize": 730428
+          "transferSize": 319042,
+          "resourceSize": 732176
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703537,
-          "resourceSize": 1410602
+          "transferSize": 706536,
+          "resourceSize": 1436862
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2229,
-          "resourceSize": 6052
+          "transferSize": 2248,
+          "resourceSize": 6194
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158831,
-          "resourceSize": 449626
+          "transferSize": 159897,
+          "resourceSize": 473996
         },
         "stylesheet": {
-          "transferSize": 317128,
-          "resourceSize": 730428
+          "transferSize": 319042,
+          "resourceSize": 732176
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 779,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703504,
-          "resourceSize": 1410582
+          "transferSize": 706490,
+          "resourceSize": 1436842
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5378,
-          "resourceSize": 24191
+          "transferSize": 5329,
+          "resourceSize": 24186
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 160842,
-          "resourceSize": 451464
+          "transferSize": 161908,
+          "resourceSize": 475834
         },
         "stylesheet": {
-          "transferSize": 317128,
-          "resourceSize": 730428
+          "transferSize": 319042,
+          "resourceSize": 732176
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9078,
+          "transferSize": 9486,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 492788,
-          "resourceSize": 1218287
+          "transferSize": 496127,
+          "resourceSize": 1244400
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2110,
-          "resourceSize": 5546
+          "transferSize": 2129,
+          "resourceSize": 5688
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158831,
-          "resourceSize": 449626
+          "transferSize": 159897,
+          "resourceSize": 473996
         },
         "stylesheet": {
-          "transferSize": 317128,
-          "resourceSize": 730428
+          "transferSize": 319042,
+          "resourceSize": 732176
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703376,
-          "resourceSize": 1410076
+          "transferSize": 706381,
+          "resourceSize": 1436336
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2239,
-          "resourceSize": 5922
+          "transferSize": 2259,
+          "resourceSize": 6064
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158831,
-          "resourceSize": 449626
+          "transferSize": 159897,
+          "resourceSize": 473996
         },
         "stylesheet": {
-          "transferSize": 317128,
-          "resourceSize": 730428
+          "transferSize": 319042,
+          "resourceSize": 732176
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703504,
-          "resourceSize": 1410452
+          "transferSize": 706506,
+          "resourceSize": 1436712
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2110,
-          "resourceSize": 5473
+          "transferSize": 2130,
+          "resourceSize": 5615
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158831,
-          "resourceSize": 449626
+          "transferSize": 159897,
+          "resourceSize": 473996
         },
         "stylesheet": {
-          "transferSize": 317128,
-          "resourceSize": 730428
+          "transferSize": 319042,
+          "resourceSize": 732176
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703377,
-          "resourceSize": 1410003
+          "transferSize": 706376,
+          "resourceSize": 1436263
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2313,
-          "resourceSize": 6032
+          "transferSize": 2335,
+          "resourceSize": 6174
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158831,
-          "resourceSize": 449626
+          "transferSize": 159897,
+          "resourceSize": 473996
         },
         "stylesheet": {
-          "transferSize": 317128,
-          "resourceSize": 730428
+          "transferSize": 319042,
+          "resourceSize": 732176
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703577,
-          "resourceSize": 1410562
+          "transferSize": 706580,
+          "resourceSize": 1436822
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3274,
-          "resourceSize": 9990
+          "transferSize": 3288,
+          "resourceSize": 10132
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158831,
-          "resourceSize": 449626
+          "transferSize": 159897,
+          "resourceSize": 473996
         },
         "stylesheet": {
-          "transferSize": 317128,
-          "resourceSize": 730428
+          "transferSize": 319042,
+          "resourceSize": 732176
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1274,
+          "transferSize": 1281,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 929219,
-          "resourceSize": 1638888
+          "transferSize": 932221,
+          "resourceSize": 1665149
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 912057,
-          "resourceSize": 1583771
+          "transferSize": 912058,
+          "resourceSize": 1583772
         }
       }
     },
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2530,
-          "resourceSize": 6417
+          "transferSize": 2483,
+          "resourceSize": 6412
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 160842,
-          "resourceSize": 451464
+          "transferSize": 161908,
+          "resourceSize": 475834
         },
         "stylesheet": {
-          "transferSize": 317128,
-          "resourceSize": 730428
+          "transferSize": 319042,
+          "resourceSize": 732176
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 706162,
-          "resourceSize": 1412786
+          "transferSize": 709093,
+          "resourceSize": 1438899
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.40.1.json
+++ b/.github/page_size_audit_results/v1.40.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.40.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:42.196Z"
+    "generatedAt": "2025-12-25T01:03:09.737Z"
   },
-  "timestamp": "2025-12-24T18:59:42.196Z",
+  "timestamp": "2025-12-25T01:03:09.738Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2188,
+          "transferSize": 2190,
           "resourceSize": 5810
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656890,
+          "transferSize": 656882,
           "resourceSize": 1280081
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2145,
+          "transferSize": 2147,
           "resourceSize": 5790
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5235,
+          "transferSize": 5239,
           "resourceSize": 23782
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9079,
+          "transferSize": 9494,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 446075,
+          "transferSize": 446494,
           "resourceSize": 1087619
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2030,
+          "transferSize": 2032,
           "resourceSize": 5284
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656723,
+          "transferSize": 656728,
           "resourceSize": 1279555
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2157,
+          "transferSize": 2160,
           "resourceSize": 5660
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656847,
+          "transferSize": 656852,
           "resourceSize": 1279931
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2030,
+          "transferSize": 2032,
           "resourceSize": 5211
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2232,
+          "transferSize": 2234,
           "resourceSize": 5770
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656923,
+          "transferSize": 656927,
           "resourceSize": 1280041
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1277,
+          "transferSize": 1280,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 882566,
+          "transferSize": 882569,
           "resourceSize": 1508367
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2383,
+          "transferSize": 2386,
           "resourceSize": 6008
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 659439,
+          "transferSize": 659445,
           "resourceSize": 1282117
         }
       },

--- a/.github/page_size_audit_results/v1.41.0.json
+++ b/.github/page_size_audit_results/v1.41.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:39.015Z"
+    "generatedAt": "2025-12-25T01:05:54.019Z"
   },
-  "timestamp": "2025-12-24T18:56:39.015Z",
+  "timestamp": "2025-12-25T01:05:54.019Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656887,
+          "transferSize": 656884,
           "resourceSize": 1280087
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2149,
+          "transferSize": 2151,
           "resourceSize": 5796
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5240,
+          "transferSize": 5243,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9083,
+          "transferSize": 9504,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 446084,
+          "transferSize": 446508,
           "resourceSize": 1087625
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2031,
+          "transferSize": 2033,
           "resourceSize": 5290
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656725,
+          "transferSize": 656732,
           "resourceSize": 1279561
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2160,
+          "transferSize": 2162,
           "resourceSize": 5666
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656852,
+          "transferSize": 656860,
           "resourceSize": 1279937
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2032,
+          "transferSize": 2033,
           "resourceSize": 5217
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656724,
+          "transferSize": 656735,
           "resourceSize": 1279488
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2234,
+          "transferSize": 2236,
           "resourceSize": 5776
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656928,
+          "transferSize": 656929,
           "resourceSize": 1280047
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3188,
+          "transferSize": 3190,
           "resourceSize": 9734
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1287,
+          "transferSize": 1279,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 882575,
+          "transferSize": 882569,
           "resourceSize": 1508373
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2385,
+          "transferSize": 2388,
           "resourceSize": 6014
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 659445,
+          "transferSize": 659450,
           "resourceSize": 1282123
         }
       },

--- a/.github/page_size_audit_results/v1.41.1.json
+++ b/.github/page_size_audit_results/v1.41.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:49.001Z"
+    "generatedAt": "2025-12-25T01:03:07.745Z"
   },
-  "timestamp": "2025-12-24T18:53:49.002Z",
+  "timestamp": "2025-12-25T01:03:07.746Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2194,
+          "transferSize": 2190,
           "resourceSize": 5816
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656888,
+          "transferSize": 656883,
           "resourceSize": 1280087
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2152,
+          "transferSize": 2149,
           "resourceSize": 5796
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656848,
+          "transferSize": 656842,
           "resourceSize": 1280067
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5244,
+          "transferSize": 5240,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9099,
+          "transferSize": 9080,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 446104,
+          "transferSize": 446081,
           "resourceSize": 1087625
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2034,
+          "transferSize": 2032,
           "resourceSize": 5290
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656730,
+          "transferSize": 656723,
           "resourceSize": 1279561
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2163,
+          "transferSize": 2159,
           "resourceSize": 5666
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656858,
+          "transferSize": 656853,
           "resourceSize": 1279937
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2034,
+          "transferSize": 2032,
           "resourceSize": 5217
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656731,
+          "transferSize": 656729,
           "resourceSize": 1279488
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2237,
+          "transferSize": 2234,
           "resourceSize": 5776
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656933,
+          "transferSize": 656929,
           "resourceSize": 1280047
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3190,
+          "transferSize": 3188,
           "resourceSize": 9734
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1280,
+          "transferSize": 1285,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 882570,
+          "transferSize": 882573,
           "resourceSize": 1508373
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2389,
+          "transferSize": 2385,
           "resourceSize": 6014
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 659450,
+          "transferSize": 659444,
           "resourceSize": 1282123
         }
       },

--- a/.github/page_size_audit_results/v1.41.2.json
+++ b/.github/page_size_audit_results/v1.41.2.json
@@ -4,28 +4,28 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:53.356Z"
+    "generatedAt": "2025-12-25T01:03:07.679Z"
   },
-  "timestamp": "2025-12-24T18:53:53.356Z",
+  "timestamp": "2025-12-25T01:03:07.680Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2195,
-          "resourceSize": 5816
+          "transferSize": 2328,
+          "resourceSize": 6211
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 110440,
-          "resourceSize": 317136
+          "transferSize": 146998,
+          "resourceSize": 424688
         },
         "stylesheet": {
-          "transferSize": 316943,
-          "resourceSize": 728202
+          "transferSize": 318113,
+          "resourceSize": 729206
         },
         "image": {
           "transferSize": 224175,
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654888,
-          "resourceSize": 1275630
+          "transferSize": 692749,
+          "resourceSize": 1384581
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2153,
-          "resourceSize": 5796
+          "transferSize": 2288,
+          "resourceSize": 6191
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 110440,
-          "resourceSize": 317136
+          "transferSize": 146998,
+          "resourceSize": 424688
         },
         "stylesheet": {
-          "transferSize": 316943,
-          "resourceSize": 728202
+          "transferSize": 318113,
+          "resourceSize": 729206
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654842,
-          "resourceSize": 1275610
+          "transferSize": 692703,
+          "resourceSize": 1384561
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5245,
-          "resourceSize": 23793
+          "transferSize": 5366,
+          "resourceSize": 24310
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 112451,
-          "resourceSize": 318974
+          "transferSize": 149009,
+          "resourceSize": 426526
         },
         "stylesheet": {
-          "transferSize": 316943,
-          "resourceSize": 728202
+          "transferSize": 318113,
+          "resourceSize": 729206
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9478,
+          "transferSize": 9088,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 444479,
-          "resourceSize": 1083173
+          "transferSize": 481938,
+          "resourceSize": 1192246
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2034,
-          "resourceSize": 5290
+          "transferSize": 2168,
+          "resourceSize": 5685
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 110440,
-          "resourceSize": 317136
+          "transferSize": 146998,
+          "resourceSize": 424688
         },
         "stylesheet": {
-          "transferSize": 316943,
-          "resourceSize": 728202
+          "transferSize": 318113,
+          "resourceSize": 729206
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654721,
-          "resourceSize": 1275104
+          "transferSize": 692588,
+          "resourceSize": 1384055
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2163,
-          "resourceSize": 5666
+          "transferSize": 2296,
+          "resourceSize": 6061
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 110440,
-          "resourceSize": 317136
+          "transferSize": 146998,
+          "resourceSize": 424688
         },
         "stylesheet": {
-          "transferSize": 316943,
-          "resourceSize": 728202
+          "transferSize": 318113,
+          "resourceSize": 729206
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654850,
-          "resourceSize": 1275480
+          "transferSize": 692716,
+          "resourceSize": 1384431
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2035,
-          "resourceSize": 5217
+          "transferSize": 2170,
+          "resourceSize": 5612
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 110440,
-          "resourceSize": 317136
+          "transferSize": 146998,
+          "resourceSize": 424688
         },
         "stylesheet": {
-          "transferSize": 316943,
-          "resourceSize": 728202
+          "transferSize": 318113,
+          "resourceSize": 729206
         },
         "image": {
           "transferSize": 224175,
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654724,
-          "resourceSize": 1275031
+          "transferSize": 692587,
+          "resourceSize": 1383982
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2238,
-          "resourceSize": 5776
+          "transferSize": 2370,
+          "resourceSize": 6171
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 110440,
-          "resourceSize": 317136
+          "transferSize": 146998,
+          "resourceSize": 424688
         },
         "stylesheet": {
-          "transferSize": 316943,
-          "resourceSize": 728202
+          "transferSize": 318113,
+          "resourceSize": 729206
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 654931,
-          "resourceSize": 1275590
+          "transferSize": 692787,
+          "resourceSize": 1384541
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3191,
-          "resourceSize": 9734
+          "transferSize": 3326,
+          "resourceSize": 10129
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 110440,
-          "resourceSize": 317136
+          "transferSize": 146998,
+          "resourceSize": 424688
         },
         "stylesheet": {
-          "transferSize": 316943,
-          "resourceSize": 728202
+          "transferSize": 318113,
+          "resourceSize": 729206
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1279,
+          "transferSize": 1275,
           "resourceSize": 557
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 880565,
-          "resourceSize": 1503916
+          "transferSize": 918424,
+          "resourceSize": 1612867
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2389,
-          "resourceSize": 6019
+          "transferSize": 2521,
+          "resourceSize": 6414
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 112451,
-          "resourceSize": 318974
+          "transferSize": 149009,
+          "resourceSize": 426526
         },
         "stylesheet": {
-          "transferSize": 316943,
-          "resourceSize": 728202
+          "transferSize": 318113,
+          "resourceSize": 729206
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 657444,
-          "resourceSize": 1277671
+          "transferSize": 695307,
+          "resourceSize": 1386623
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 651920,
-          "resourceSize": 1269619
+          "transferSize": 651921,
+          "resourceSize": 1269620
         }
       }
     }

--- a/.github/page_size_audit_results/v1.42.0.json
+++ b/.github/page_size_audit_results/v1.42.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:36.651Z"
+    "generatedAt": "2025-12-25T01:03:07.823Z"
   },
-  "timestamp": "2025-12-24T18:56:36.651Z",
+  "timestamp": "2025-12-25T01:03:07.824Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2334,
+          "transferSize": 2330,
           "resourceSize": 6309
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408120,
+          "transferSize": 408116,
           "resourceSize": 477464
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2271,
+          "transferSize": 2267,
           "resourceSize": 6191
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407507,
+          "transferSize": 407504,
           "resourceSize": 476968
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5376,
+          "transferSize": 5371,
           "resourceSize": 24295
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10205,
+          "transferSize": 10163,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 277599,
+          "transferSize": 277552,
           "resourceSize": 524677
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2131,
+          "transferSize": 2128,
           "resourceSize": 5578
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405603,
+          "transferSize": 405597,
           "resourceSize": 473039
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2261,
+          "transferSize": 2258,
           "resourceSize": 5954
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405731,
+          "transferSize": 405730,
           "resourceSize": 473415
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2134,
+          "transferSize": 2131,
           "resourceSize": 5505
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405604,
+          "transferSize": 405599,
           "resourceSize": 472966
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2337,
+          "transferSize": 2333,
           "resourceSize": 6064
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405804,
+          "transferSize": 405803,
           "resourceSize": 473525
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1926,
+          "transferSize": 1912,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632813,
+          "transferSize": 632799,
           "resourceSize": 703242
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2529,
+          "transferSize": 2525,
           "resourceSize": 6519
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 489846,
+          "transferSize": 489845,
           "resourceSize": 718149
         }
       },

--- a/.github/page_size_audit_results/v1.42.1.json
+++ b/.github/page_size_audit_results/v1.42.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:38.684Z"
+    "generatedAt": "2025-12-25T01:00:19.718Z"
   },
-  "timestamp": "2025-12-24T18:56:38.685Z",
+  "timestamp": "2025-12-25T01:00:19.718Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2834,
+          "transferSize": 2831,
           "resourceSize": 7581
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408246,
+          "transferSize": 408249,
           "resourceSize": 476789
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2795,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407890,
+          "transferSize": 407892,
           "resourceSize": 476458
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5913,
+          "transferSize": 5907,
           "resourceSize": 25659
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10209,
+          "transferSize": 10210,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 277776,
+          "transferSize": 277771,
           "resourceSize": 523718
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2658,
+          "transferSize": 2657,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2795,
+          "transferSize": 2793,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406124,
+          "transferSize": 406126,
           "resourceSize": 472894
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2660,
+          "transferSize": 2658,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405991,
+          "transferSize": 405990,
           "resourceSize": 472459
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2876,
+          "transferSize": 2873,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406203,
+          "transferSize": 406205,
           "resourceSize": 473015
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1913,
+          "transferSize": 1916,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633145,
+          "transferSize": 633148,
           "resourceSize": 702666
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3050,
+          "transferSize": 3046,
           "resourceSize": 7883
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 489999,
+          "transferSize": 489997,
           "resourceSize": 717190
         }
       },

--- a/.github/page_size_audit_results/v1.42.10.json
+++ b/.github/page_size_audit_results/v1.42.10.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.10",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:51.723Z"
+    "generatedAt": "2025-12-25T01:00:15.782Z"
   },
-  "timestamp": "2025-12-24T18:53:51.723Z",
+  "timestamp": "2025-12-25T01:00:15.782Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2853,
+          "transferSize": 2854,
           "resourceSize": 7690
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2803,
+          "transferSize": 2802,
           "resourceSize": 7574
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407477,
+          "transferSize": 407487,
           "resourceSize": 475879
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10164,
+          "transferSize": 10180,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 201317,
+          "transferSize": 201333,
           "resourceSize": 294503
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2664,
+          "transferSize": 2663,
           "resourceSize": 6954
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405550,
+          "transferSize": 405555,
           "resourceSize": 471793
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2798,
+          "transferSize": 2797,
           "resourceSize": 7328
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405683,
+          "transferSize": 405684,
           "resourceSize": 472167
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2880,
+          "transferSize": 2877,
           "resourceSize": 7448
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405771,
+          "transferSize": 405768,
           "resourceSize": 472288
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3853,
+          "transferSize": 3852,
           "resourceSize": 11399
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1910,
+          "transferSize": 1915,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632704,
+          "transferSize": 632708,
           "resourceSize": 701939
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3086,
+          "transferSize": 3084,
           "resourceSize": 8091
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 414418,
+          "transferSize": 414413,
           "resourceSize": 489273
         }
       },

--- a/.github/page_size_audit_results/v1.42.11.json
+++ b/.github/page_size_audit_results/v1.42.11.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.11",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:51.006Z"
+    "generatedAt": "2025-12-25T01:00:16.130Z"
   },
-  "timestamp": "2025-12-24T18:56:51.006Z",
+  "timestamp": "2025-12-25T01:00:16.131Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2860,
+          "transferSize": 2855,
           "resourceSize": 7690
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408054,
+          "transferSize": 408051,
           "resourceSize": 476340
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2805,
+          "transferSize": 2803,
           "resourceSize": 7574
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407483,
+          "transferSize": 407481,
           "resourceSize": 475879
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5646,
+          "transferSize": 5640,
           "resourceSize": 24914
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10158,
+          "transferSize": 10215,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 201317,
+          "transferSize": 201368,
           "resourceSize": 294503
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2666,
+          "transferSize": 2664,
           "resourceSize": 6954
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405552,
+          "transferSize": 405555,
           "resourceSize": 471793
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2800,
+          "transferSize": 2797,
           "resourceSize": 7328
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405690,
+          "transferSize": 405689,
           "resourceSize": 472167
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2668,
+          "transferSize": 2666,
           "resourceSize": 6893
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405556,
+          "transferSize": 405558,
           "resourceSize": 471732
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2882,
+          "transferSize": 2879,
           "resourceSize": 7448
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405773,
+          "transferSize": 405769,
           "resourceSize": 472288
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3856,
+          "transferSize": 3852,
           "resourceSize": 11399
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1947,
+          "transferSize": 1912,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632744,
+          "transferSize": 632705,
           "resourceSize": 701939
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3090,
+          "transferSize": 3086,
           "resourceSize": 8091
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 414419,
+          "transferSize": 414415,
           "resourceSize": 489273
         }
       },

--- a/.github/page_size_audit_results/v1.42.12.json
+++ b/.github/page_size_audit_results/v1.42.12.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.12",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:40.282Z"
+    "generatedAt": "2025-12-25T01:03:14.392Z"
   },
-  "timestamp": "2025-12-24T18:56:40.282Z",
+  "timestamp": "2025-12-25T01:03:14.392Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2829,
+          "transferSize": 2827,
           "resourceSize": 7491
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406972,
+          "transferSize": 406973,
           "resourceSize": 476139
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5614,
+          "transferSize": 5615,
           "resourceSize": 24706
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10166,
+          "transferSize": 10213,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200230,
+          "transferSize": 200278,
           "resourceSize": 294284
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2666,
+          "transferSize": 2669,
           "resourceSize": 6963
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406812,
+          "transferSize": 406813,
           "resourceSize": 475611
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406938,
+          "transferSize": 406940,
           "resourceSize": 475985
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2665,
+          "transferSize": 2667,
           "resourceSize": 6902
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406806,
+          "transferSize": 406805,
           "resourceSize": 475550
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2878,
+          "transferSize": 2879,
           "resourceSize": 7457
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407021,
+          "transferSize": 407024,
           "resourceSize": 476105
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3868,
+          "transferSize": 3871,
           "resourceSize": 11512
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 634176,
+          "transferSize": 634179,
           "resourceSize": 705891
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3058,
+          "transferSize": 3062,
           "resourceSize": 7892
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413330,
+          "transferSize": 413341,
           "resourceSize": 489072
         }
       },

--- a/.github/page_size_audit_results/v1.42.13.json
+++ b/.github/page_size_audit_results/v1.42.13.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.13",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:55.982Z"
+    "generatedAt": "2025-12-25T01:00:21.002Z"
   },
-  "timestamp": "2025-12-24T18:53:55.982Z",
+  "timestamp": "2025-12-25T01:00:21.002Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2852,
+          "transferSize": 2854,
           "resourceSize": 7687
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407596,
+          "transferSize": 407603,
           "resourceSize": 476400
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2814,
+          "transferSize": 2816,
           "resourceSize": 7675
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407562,
+          "transferSize": 407558,
           "resourceSize": 476388
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5546,
+          "transferSize": 5554,
           "resourceSize": 24731
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10191,
+          "transferSize": 10163,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200788,
+          "transferSize": 200768,
           "resourceSize": 294374
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2691,
+          "transferSize": 2693,
           "resourceSize": 7166
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407437,
+          "transferSize": 407436,
           "resourceSize": 475879
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2824,
+          "transferSize": 2828,
           "resourceSize": 7540
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407568,
+          "transferSize": 407572,
           "resourceSize": 476253
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2691,
+          "transferSize": 2694,
           "resourceSize": 7105
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407435,
+          "transferSize": 407444,
           "resourceSize": 475818
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2909,
+          "transferSize": 2912,
           "resourceSize": 7660
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 407653,
+          "transferSize": 407659,
           "resourceSize": 476374
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3766,
+          "transferSize": 3769,
           "resourceSize": 11474
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1917,
+          "transferSize": 1941,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 634679,
+          "transferSize": 634706,
           "resourceSize": 705918
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3077,
+          "transferSize": 3080,
           "resourceSize": 8115
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1128,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413954,
+          "transferSize": 413961,
           "resourceSize": 489360
         }
       },

--- a/.github/page_size_audit_results/v1.42.14.json
+++ b/.github/page_size_audit_results/v1.42.14.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.14",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:42.233Z"
+    "generatedAt": "2025-12-25T01:00:13.796Z"
   },
-  "timestamp": "2025-12-24T18:56:42.234Z",
+  "timestamp": "2025-12-25T01:00:13.797Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2879,
+          "transferSize": 2877,
           "resourceSize": 7686
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2837,
+          "transferSize": 2838,
           "resourceSize": 7674
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406617,
+          "transferSize": 406627,
           "resourceSize": 475447
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5691,
+          "transferSize": 5688,
           "resourceSize": 25437
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10157,
+          "transferSize": 10232,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199935,
+          "transferSize": 200007,
           "resourceSize": 294123
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2718,
+          "transferSize": 2717,
           "resourceSize": 7165
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406503,
+          "transferSize": 406502,
           "resourceSize": 474938
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2882,
+          "transferSize": 2881,
           "resourceSize": 7676
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406665,
+          "transferSize": 406666,
           "resourceSize": 475449
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2717,
+          "transferSize": 2716,
           "resourceSize": 7104
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406498,
+          "transferSize": 406499,
           "resourceSize": 474877
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2974,
+          "transferSize": 2972,
           "resourceSize": 7818
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406759,
+          "transferSize": 406761,
           "resourceSize": 475591
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3822,
+          "transferSize": 3820,
           "resourceSize": 11626
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1912,
+          "transferSize": 1917,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633771,
+          "transferSize": 633774,
           "resourceSize": 705130
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3111,
+          "transferSize": 3109,
           "resourceSize": 8114
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413023,
+          "transferSize": 413019,
           "resourceSize": 488402
         }
       },

--- a/.github/page_size_audit_results/v1.42.2.json
+++ b/.github/page_size_audit_results/v1.42.2.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:41.920Z"
+    "generatedAt": "2025-12-25T01:00:19.275Z"
   },
-  "timestamp": "2025-12-24T18:53:41.920Z",
+  "timestamp": "2025-12-25T01:00:19.275Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408265,
+          "transferSize": 408271,
           "resourceSize": 476838
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407909,
+          "transferSize": 407915,
           "resourceSize": 476507
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5594,
+          "transferSize": 5593,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10178,
+          "transferSize": 10183,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200007,
+          "transferSize": 200011,
           "resourceSize": 288729
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2660,
+          "transferSize": 2658,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406012,
+          "transferSize": 406005,
           "resourceSize": 472569
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406144,
+          "transferSize": 406142,
           "resourceSize": 472943
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2659,
+          "transferSize": 2658,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406012,
+          "transferSize": 406006,
           "resourceSize": 472508
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406225,
+          "transferSize": 406230,
           "resourceSize": 473064
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1923,
+          "transferSize": 1917,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633177,
+          "transferSize": 633171,
           "resourceSize": 702715
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3052,
+          "transferSize": 3048,
           "resourceSize": 7883
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412586,
+          "transferSize": 412581,
           "resourceSize": 483197
         }
       },

--- a/.github/page_size_audit_results/v1.42.3.json
+++ b/.github/page_size_audit_results/v1.42.3.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:40.004Z"
+    "generatedAt": "2025-12-25T01:03:30.624Z"
   },
-  "timestamp": "2025-12-24T18:59:40.005Z",
+  "timestamp": "2025-12-25T01:03:30.625Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2837,
+          "transferSize": 2836,
           "resourceSize": 7581
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408273,
+          "transferSize": 408269,
           "resourceSize": 476838
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2797,
+          "transferSize": 2796,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407915,
+          "transferSize": 407911,
           "resourceSize": 476507
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5595,
+          "transferSize": 5594,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10162,
+          "transferSize": 10178,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199976,
+          "transferSize": 199991,
           "resourceSize": 288700
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2794,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406013,
+          "transferSize": 406011,
           "resourceSize": 472508
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2876,
+          "transferSize": 2875,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1944,
+          "transferSize": 1921,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633200,
+          "transferSize": 633177,
           "resourceSize": 702715
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412568,
+          "transferSize": 412571,
           "resourceSize": 483168
         }
       },

--- a/.github/page_size_audit_results/v1.42.4.json
+++ b/.github/page_size_audit_results/v1.42.4.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:57:06.056Z"
+    "generatedAt": "2025-12-25T01:03:14.375Z"
   },
-  "timestamp": "2025-12-24T18:57:06.056Z",
+  "timestamp": "2025-12-25T01:03:14.375Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2839,
+          "transferSize": 2830,
           "resourceSize": 7581
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408271,
+          "transferSize": 408266,
           "resourceSize": 476838
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2798,
+          "transferSize": 2791,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407912,
+          "transferSize": 407910,
           "resourceSize": 476507
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5598,
+          "transferSize": 5586,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10184,
+          "transferSize": 10176,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200001,
+          "transferSize": 199981,
           "resourceSize": 288700
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2662,
+          "transferSize": 2657,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406013,
+          "transferSize": 406012,
           "resourceSize": 472569
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2797,
+          "transferSize": 2789,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406144,
+          "transferSize": 406146,
           "resourceSize": 472943
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2662,
+          "transferSize": 2656,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406014,
+          "transferSize": 406005,
           "resourceSize": 472508
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2878,
+          "transferSize": 2871,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406229,
+          "transferSize": 406227,
           "resourceSize": 473064
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3857,
+          "transferSize": 3851,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1913,
+          "transferSize": 1937,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633171,
+          "transferSize": 633189,
           "resourceSize": 702715
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3053,
+          "transferSize": 3046,
           "resourceSize": 7883
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412572,
+          "transferSize": 412566,
           "resourceSize": 483168
         }
       },

--- a/.github/page_size_audit_results/v1.42.5.json
+++ b/.github/page_size_audit_results/v1.42.5.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.5",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:43.116Z"
+    "generatedAt": "2025-12-25T01:00:15.069Z"
   },
-  "timestamp": "2025-12-24T18:53:43.117Z",
+  "timestamp": "2025-12-25T01:00:15.070Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2849,
+          "transferSize": 2846,
           "resourceSize": 7683
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2794,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5588,
+          "transferSize": 5586,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10180,
+          "transferSize": 10261,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199989,
+          "transferSize": 200068,
           "resourceSize": 288702
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2659,
+          "transferSize": 2658,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406011,
+          "transferSize": 406009,
           "resourceSize": 472571
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2794,
+          "transferSize": 2792,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406146,
+          "transferSize": 406145,
           "resourceSize": 472945
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2659,
+          "transferSize": 2657,
           "resourceSize": 6886
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406010,
+          "transferSize": 406008,
           "resourceSize": 472510
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2875,
+          "transferSize": 2872,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406228,
+          "transferSize": 406223,
           "resourceSize": 473066
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3853,
+          "transferSize": 3851,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1911,
+          "transferSize": 1916,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633167,
+          "transferSize": 633170,
           "resourceSize": 702717
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3064,
+          "transferSize": 3063,
           "resourceSize": 7985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1118,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413099,
+          "transferSize": 413095,
           "resourceSize": 483617
         }
       },

--- a/.github/page_size_audit_results/v1.42.6.json
+++ b/.github/page_size_audit_results/v1.42.6.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.6",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:55.930Z"
+    "generatedAt": "2025-12-25T01:03:12.465Z"
   },
-  "timestamp": "2025-12-24T18:56:55.930Z",
+  "timestamp": "2025-12-25T01:03:12.465Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2854,
+          "transferSize": 2855,
           "resourceSize": 7683
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408541,
+          "transferSize": 408542,
           "resourceSize": 477020
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2800,
+          "transferSize": 2802,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407961,
+          "transferSize": 407973,
           "resourceSize": 476559
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5593,
+          "transferSize": 5596,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10162,
+          "transferSize": 10185,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200023,
+          "transferSize": 200049,
           "resourceSize": 288752
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406064,
+          "transferSize": 406068,
           "resourceSize": 472621
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2797,
+          "transferSize": 2798,
           "resourceSize": 7321
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406196,
+          "transferSize": 406197,
           "resourceSize": 472995
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2662,
+          "transferSize": 2666,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406061,
+          "transferSize": 406071,
           "resourceSize": 472560
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2875,
+          "transferSize": 2877,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406278,
+          "transferSize": 406281,
           "resourceSize": 473116
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3856,
+          "transferSize": 3859,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1915,
+          "transferSize": 1941,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633222,
+          "transferSize": 633251,
           "resourceSize": 702767
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3068,
+          "transferSize": 3072,
           "resourceSize": 7985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413148,
+          "transferSize": 413158,
           "resourceSize": 483667
         }
       },

--- a/.github/page_size_audit_results/v1.42.7.json
+++ b/.github/page_size_audit_results/v1.42.7.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.7",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:48.194Z"
+    "generatedAt": "2025-12-25T01:03:12.984Z"
   },
-  "timestamp": "2025-12-24T18:56:48.195Z",
+  "timestamp": "2025-12-25T01:03:12.984Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2861,
-          "resourceSize": 7689
+          "transferSize": 2940,
+          "resourceSize": 7970
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 14697,
-          "resourceSize": 32476
+          "transferSize": 161802,
+          "resourceSize": 539781
         },
         "stylesheet": {
-          "transferSize": 9159,
-          "resourceSize": 51697
+          "transferSize": 10611,
+          "resourceSize": 52983
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407880,
-          "resourceSize": 472018
+          "transferSize": 556505,
+          "resourceSize": 980890
         }
       },
       "themeResources": {
@@ -83,20 +83,20 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2805,
-          "resourceSize": 7573
+          "transferSize": 2882,
+          "resourceSize": 7854
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 14180,
-          "resourceSize": 32131
+          "transferSize": 161285,
+          "resourceSize": 539436
         },
         "stylesheet": {
-          "transferSize": 9159,
-          "resourceSize": 51697
+          "transferSize": 10611,
+          "resourceSize": 52983
         },
         "image": {
           "transferSize": 224175,
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407300,
-          "resourceSize": 471557
+          "transferSize": 555934,
+          "resourceSize": 980429
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5645,
-          "resourceSize": 24913
+          "transferSize": 5846,
+          "resourceSize": 25683
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 18264,
-          "resourceSize": 38632
+          "transferSize": 561285,
+          "resourceSize": 1691966
         },
         "stylesheet": {
-          "transferSize": 10727,
-          "resourceSize": 57557
+          "transferSize": 12179,
+          "resourceSize": 58843
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10205,
-          "resourceSize": 12954
+          "transferSize": 13055,
+          "resourceSize": 14252
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 201053,
-          "resourceSize": 290011
+          "transferSize": 748577,
+          "resourceSize": 1946699
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2668,
-          "resourceSize": 6953
+          "transferSize": 2750,
+          "resourceSize": 7234
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 13084,
-          "resourceSize": 29195
+          "transferSize": 160189,
+          "resourceSize": 536500
         },
         "stylesheet": {
-          "transferSize": 8464,
-          "resourceSize": 51167
+          "transferSize": 9916,
+          "resourceSize": 52453
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405375,
-          "resourceSize": 467471
+          "transferSize": 554011,
+          "resourceSize": 976343
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2803,
-          "resourceSize": 7327
+          "transferSize": 2880,
+          "resourceSize": 7608
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 13084,
-          "resourceSize": 29195
+          "transferSize": 160189,
+          "resourceSize": 536500
         },
         "stylesheet": {
-          "transferSize": 8464,
-          "resourceSize": 51167
+          "transferSize": 9916,
+          "resourceSize": 52453
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 405510,
-          "resourceSize": 467845
+          "transferSize": 554147,
+          "resourceSize": 976718
         }
       },
       "themeResources": {
@@ -354,12 +354,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 401935,
-          "resourceSize": 460323
+          "transferSize": 401936,
+          "resourceSize": 460324
         }
       }
     },
@@ -367,91 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2669,
-          "resourceSize": 6892
+          "transferSize": 2752,
+          "resourceSize": 7173
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 13084,
-          "resourceSize": 29195
+          "transferSize": 160189,
+          "resourceSize": 536500
         },
         "stylesheet": {
-          "transferSize": 8464,
-          "resourceSize": 51167
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 769,
-          "resourceSize": 195
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 405373,
-          "resourceSize": 467410
-        }
-      },
-      "themeResources": {
-        "document": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "font": {
-          "transferSize": 155850,
-          "resourceSize": 155680
-        },
-        "script": {
-          "transferSize": 13084,
-          "resourceSize": 29195
-        },
-        "stylesheet": {
-          "transferSize": 8464,
-          "resourceSize": 51167
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "other": {
-          "transferSize": 362,
-          "resourceSize": 275
-        },
-        "total": {
-          "transferSize": 401935,
-          "resourceSize": 460323
-        }
-      }
-    },
-    {
-      "url": "/categories/default",
-      "resources": {
-        "document": {
-          "transferSize": 2884,
-          "resourceSize": 7447
-        },
-        "font": {
-          "transferSize": 155850,
-          "resourceSize": 155680
-        },
-        "script": {
-          "transferSize": 13084,
-          "resourceSize": 29195
-        },
-        "stylesheet": {
-          "transferSize": 8464,
-          "resourceSize": 51167
+          "transferSize": 9916,
+          "resourceSize": 52453
         },
         "image": {
           "transferSize": 224175,
@@ -466,8 +395,79 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405593,
-          "resourceSize": 467966
+          "transferSize": 554018,
+          "resourceSize": 976283
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 155850,
+          "resourceSize": 155680
+        },
+        "script": {
+          "transferSize": 13084,
+          "resourceSize": 29195
+        },
+        "stylesheet": {
+          "transferSize": 8464,
+          "resourceSize": 51167
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 401936,
+          "resourceSize": 460324
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 2961,
+          "resourceSize": 7728
+        },
+        "font": {
+          "transferSize": 155850,
+          "resourceSize": 155680
+        },
+        "script": {
+          "transferSize": 160189,
+          "resourceSize": 536500
+        },
+        "stylesheet": {
+          "transferSize": 9916,
+          "resourceSize": 52453
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 765,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 363,
+          "resourceSize": 276
+        },
+        "total": {
+          "transferSize": 554219,
+          "resourceSize": 976838
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3857,
-          "resourceSize": 11398
+          "transferSize": 3933,
+          "resourceSize": 11679
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 12884,
-          "resourceSize": 29165
+          "transferSize": 159989,
+          "resourceSize": 536470
         },
         "stylesheet": {
-          "transferSize": 9309,
-          "resourceSize": 51847
+          "transferSize": 10761,
+          "resourceSize": 53133
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1908,
+          "transferSize": 1912,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632521,
-          "resourceSize": 697617
+          "transferSize": 781158,
+          "resourceSize": 1206489
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3092,
-          "resourceSize": 8090
+          "transferSize": 3317,
+          "resourceSize": 8874
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 18781,
-          "resourceSize": 38977
+          "transferSize": 561802,
+          "resourceSize": 1692311
         },
         "stylesheet": {
-          "transferSize": 10727,
-          "resourceSize": 57557
+          "transferSize": 12179,
+          "resourceSize": 58843
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
-          "resourceSize": 195
+          "transferSize": 4000,
+          "resourceSize": 1493
         },
         "other": {
           "transferSize": 363,
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 414116,
-          "resourceSize": 484781
+          "transferSize": 961686,
+          "resourceSize": 2141483
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.42.8.json
+++ b/.github/page_size_audit_results/v1.42.8.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.8",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:34.064Z"
+    "generatedAt": "2025-12-25T01:00:24.599Z"
   },
-  "timestamp": "2025-12-24T18:56:34.064Z",
+  "timestamp": "2025-12-25T01:00:24.599Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2857,
+          "transferSize": 2854,
           "resourceSize": 7689
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408063,
+          "transferSize": 408054,
           "resourceSize": 476383
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2804,
+          "transferSize": 2802,
           "resourceSize": 7573
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407490,
+          "transferSize": 407485,
           "resourceSize": 475922
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5641,
+          "transferSize": 5637,
           "resourceSize": 24913
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10178,
+          "transferSize": 10172,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 201212,
+          "transferSize": 201202,
           "resourceSize": 294376
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2667,
+          "transferSize": 2665,
           "resourceSize": 6953
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405567,
+          "transferSize": 405560,
           "resourceSize": 471836
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2799,
+          "transferSize": 2795,
           "resourceSize": 7327
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405696,
+          "transferSize": 405691,
           "resourceSize": 472210
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2667,
+          "transferSize": 2665,
           "resourceSize": 6892
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405569,
+          "transferSize": 405561,
           "resourceSize": 471775
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2883,
+          "transferSize": 2879,
           "resourceSize": 7447
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405786,
+          "transferSize": 405779,
           "resourceSize": 472331
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3855,
+          "transferSize": 3854,
           "resourceSize": 11398
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1911,
+          "transferSize": 1937,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632712,
+          "transferSize": 632737,
           "resourceSize": 701982
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3091,
+          "transferSize": 3087,
           "resourceSize": 8090
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 414302,
+          "transferSize": 414297,
           "resourceSize": 489146
         }
       },

--- a/.github/page_size_audit_results/v1.42.9.json
+++ b/.github/page_size_audit_results/v1.42.9.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.9",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:49.799Z"
+    "generatedAt": "2025-12-25T01:00:24.519Z"
   },
-  "timestamp": "2025-12-24T18:53:49.800Z",
+  "timestamp": "2025-12-25T01:00:24.520Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2854,
+          "transferSize": 2858,
           "resourceSize": 7689
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408053,
+          "transferSize": 408060,
           "resourceSize": 476339
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2801,
+          "transferSize": 2806,
           "resourceSize": 7573
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407480,
+          "transferSize": 407491,
           "resourceSize": 475878
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5636,
+          "transferSize": 5641,
           "resourceSize": 24913
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10171,
+          "transferSize": 10169,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 201299,
+          "transferSize": 201302,
           "resourceSize": 294617
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2664,
+          "transferSize": 2666,
           "resourceSize": 6953
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405555,
+          "transferSize": 405560,
           "resourceSize": 471792
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2800,
           "resourceSize": 7327
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405682,
+          "transferSize": 405693,
           "resourceSize": 472166
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2665,
+          "transferSize": 2667,
           "resourceSize": 6892
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405555,
+          "transferSize": 405556,
           "resourceSize": 471731
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2877,
+          "transferSize": 2880,
           "resourceSize": 7447
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 405765,
+          "transferSize": 405768,
           "resourceSize": 472287
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3854,
+          "transferSize": 3855,
           "resourceSize": 11398
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1907,
+          "transferSize": 1913,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632702,
+          "transferSize": 632709,
           "resourceSize": 701938
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3083,
+          "transferSize": 3085,
           "resourceSize": 8090
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.43.0.json
+++ b/.github/page_size_audit_results/v1.43.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.43.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:45.651Z"
+    "generatedAt": "2025-12-25T01:03:16.128Z"
   },
-  "timestamp": "2025-12-24T18:56:45.652Z",
+  "timestamp": "2025-12-25T01:03:16.128Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2878,
+          "transferSize": 2876,
           "resourceSize": 7685
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406674,
+          "transferSize": 406672,
           "resourceSize": 475489
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2839,
+          "transferSize": 2837,
           "resourceSize": 7673
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406640,
+          "transferSize": 406635,
           "resourceSize": 475477
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5689,
+          "transferSize": 5687,
           "resourceSize": 25436
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10194,
+          "transferSize": 10205,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199979,
+          "transferSize": 199988,
           "resourceSize": 294153
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406512,
+          "transferSize": 406507,
           "resourceSize": 474968
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2883,
+          "transferSize": 2880,
           "resourceSize": 7675
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406677,
+          "transferSize": 406678,
           "resourceSize": 475479
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406515,
+          "transferSize": 406510,
           "resourceSize": 474907
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2972,
+          "transferSize": 2971,
           "resourceSize": 7817
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3821,
+          "transferSize": 3823,
           "resourceSize": 11625
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1919,
+          "transferSize": 1916,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633786,
+          "transferSize": 633785,
           "resourceSize": 705160
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3110,
+          "transferSize": 3112,
           "resourceSize": 8113
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413031,
+          "transferSize": 413034,
           "resourceSize": 488432
         }
       },

--- a/.github/page_size_audit_results/v1.43.1.json
+++ b/.github/page_size_audit_results/v1.43.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.43.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:54.361Z"
+    "generatedAt": "2025-12-25T01:00:19.428Z"
   },
-  "timestamp": "2025-12-24T18:53:54.361Z",
+  "timestamp": "2025-12-25T01:00:19.428Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2875,
+          "transferSize": 2876,
           "resourceSize": 7579
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406668,
+          "transferSize": 406676,
           "resourceSize": 475383
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2835,
+          "transferSize": 2836,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406627,
+          "transferSize": 406632,
           "resourceSize": 475371
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10177,
+          "transferSize": 10152,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199966,
+          "transferSize": 199941,
           "resourceSize": 293994
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2714,
+          "transferSize": 2718,
           "resourceSize": 7058
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406513,
+          "transferSize": 406512,
           "resourceSize": 474862
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2877,
+          "transferSize": 2878,
           "resourceSize": 7569
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406673,
+          "transferSize": 406675,
           "resourceSize": 475373
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2710,
+          "transferSize": 2713,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406505,
+          "transferSize": 406504,
           "resourceSize": 474801
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2968,
+          "transferSize": 2970,
           "resourceSize": 7711
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406757,
+          "transferSize": 406763,
           "resourceSize": 475515
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3821,
+          "transferSize": 3818,
           "resourceSize": 11519
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1915,
+          "transferSize": 1919,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633782,
+          "transferSize": 633783,
           "resourceSize": 705054
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3104,
+          "transferSize": 3108,
           "resourceSize": 8007
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413023,
+          "transferSize": 413029,
           "resourceSize": 488326
         }
       },

--- a/.github/page_size_audit_results/v1.44.0.json
+++ b/.github/page_size_audit_results/v1.44.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.44.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:47.723Z"
+    "generatedAt": "2025-12-25T01:00:20.998Z"
   },
-  "timestamp": "2025-12-24T18:53:47.723Z",
+  "timestamp": "2025-12-25T01:00:20.998Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2872,
+          "transferSize": 2871,
           "resourceSize": 7579
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406666,
+          "transferSize": 406665,
           "resourceSize": 475363
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406629,
+          "transferSize": 406628,
           "resourceSize": 475351
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5685,
+          "transferSize": 5688,
           "resourceSize": 25299
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10203,
+          "transferSize": 10163,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199987,
+          "transferSize": 199950,
           "resourceSize": 293996
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406515,
+          "transferSize": 406514,
           "resourceSize": 474842
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406672,
+          "transferSize": 406673,
           "resourceSize": 475353
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2709,
+          "transferSize": 2710,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406763,
+          "transferSize": 406759,
           "resourceSize": 475495
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3819,
+          "transferSize": 3820,
           "resourceSize": 11532
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1915,
+          "transferSize": 1911,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633783,
+          "transferSize": 633780,
           "resourceSize": 705047
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1118,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413040,
+          "transferSize": 413039,
           "resourceSize": 488430
         }
       },

--- a/.github/page_size_audit_results/v1.45.0.json
+++ b/.github/page_size_audit_results/v1.45.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:52.371Z"
+    "generatedAt": "2025-12-25T01:00:19.361Z"
   },
-  "timestamp": "2025-12-24T18:53:52.372Z",
+  "timestamp": "2025-12-25T01:00:19.361Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2876,
+          "transferSize": 2873,
           "resourceSize": 7621
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406674,
+          "transferSize": 406672,
           "resourceSize": 475405
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2867,
+          "transferSize": 2862,
           "resourceSize": 7616
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406666,
+          "transferSize": 406664,
           "resourceSize": 475400
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5691,
+          "transferSize": 5686,
           "resourceSize": 25299
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10172,
+          "transferSize": 10215,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199962,
+          "transferSize": 200000,
           "resourceSize": 293996
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2716,
+          "transferSize": 2713,
           "resourceSize": 7058
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406516,
+          "transferSize": 406519,
           "resourceSize": 474842
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2884,
+          "transferSize": 2881,
           "resourceSize": 7657
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406685,
+          "transferSize": 406679,
           "resourceSize": 475441
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2712,
+          "transferSize": 2710,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406507,
+          "transferSize": 406504,
           "resourceSize": 474781
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2978,
+          "transferSize": 2976,
           "resourceSize": 7799
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406781,
+          "transferSize": 406775,
           "resourceSize": 475583
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3159,
+          "transferSize": 3157,
           "resourceSize": 8770
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3123,
+          "transferSize": 3121,
           "resourceSize": 8131
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1128,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413045,
+          "transferSize": 413050,
           "resourceSize": 488430
         }
       },

--- a/.github/page_size_audit_results/v1.45.1.json
+++ b/.github/page_size_audit_results/v1.45.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:38.608Z"
+    "generatedAt": "2025-12-25T01:03:03.932Z"
   },
-  "timestamp": "2025-12-24T18:59:38.609Z",
+  "timestamp": "2025-12-25T01:03:03.933Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2877,
+          "transferSize": 2873,
           "resourceSize": 7621
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406665,
+          "transferSize": 406663,
           "resourceSize": 475418
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2866,
+          "transferSize": 2862,
           "resourceSize": 7616
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406655,
+          "transferSize": 406653,
           "resourceSize": 475413
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5692,
+          "transferSize": 5686,
           "resourceSize": 25299
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10163,
+          "transferSize": 10178,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199989,
+          "transferSize": 199998,
           "resourceSize": 294130
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2717,
+          "transferSize": 2714,
           "resourceSize": 7058
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406509,
+          "transferSize": 406510,
           "resourceSize": 474855
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2884,
+          "transferSize": 2881,
           "resourceSize": 7657
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406672,
+          "transferSize": 406671,
           "resourceSize": 475454
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2710,
+          "transferSize": 2708,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406506,
+          "transferSize": 406500,
           "resourceSize": 474794
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2981,
+          "transferSize": 2979,
           "resourceSize": 7799
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406769,
+          "transferSize": 406770,
           "resourceSize": 475596
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3157,
+          "transferSize": 3154,
           "resourceSize": 8770
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631967,
+          "transferSize": 631964,
           "resourceSize": 701254
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3121,
+          "transferSize": 3118,
           "resourceSize": 8131
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.45.2.json
+++ b/.github/page_size_audit_results/v1.45.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:53.387Z"
+    "generatedAt": "2025-12-25T01:03:17.367Z"
   },
-  "timestamp": "2025-12-24T18:56:53.387Z",
+  "timestamp": "2025-12-25T01:03:17.367Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2876,
+          "transferSize": 2869,
           "resourceSize": 7621
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406668,
+          "transferSize": 406660,
           "resourceSize": 475418
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2865,
+          "transferSize": 2858,
           "resourceSize": 7616
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406656,
+          "transferSize": 406646,
           "resourceSize": 475413
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5691,
+          "transferSize": 5683,
           "resourceSize": 25299
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10176,
+          "transferSize": 10174,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200001,
+          "transferSize": 199991,
           "resourceSize": 294130
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2717,
+          "transferSize": 2714,
           "resourceSize": 7058
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406509,
+          "transferSize": 406504,
           "resourceSize": 474855
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2883,
+          "transferSize": 2876,
           "resourceSize": 7657
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406674,
+          "transferSize": 406672,
           "resourceSize": 475454
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2710,
+          "transferSize": 2707,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2980,
+          "transferSize": 2972,
           "resourceSize": 7799
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406772,
+          "transferSize": 406762,
           "resourceSize": 475596
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3156,
+          "transferSize": 3150,
           "resourceSize": 8770
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631965,
+          "transferSize": 631966,
           "resourceSize": 701254
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3120,
+          "transferSize": 3117,
           "resourceSize": 8131
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413085,
+          "transferSize": 413082,
           "resourceSize": 488572
         }
       },

--- a/.github/page_size_audit_results/v1.45.3.json
+++ b/.github/page_size_audit_results/v1.45.3.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:55.215Z"
+    "generatedAt": "2025-12-25T01:03:35.771Z"
   },
-  "timestamp": "2025-12-24T18:53:55.215Z",
+  "timestamp": "2025-12-25T01:03:35.771Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2874,
+          "transferSize": 2875,
           "resourceSize": 7621
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406690,
+          "transferSize": 406688,
           "resourceSize": 475459
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2861,
+          "transferSize": 2863,
           "resourceSize": 7616
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406673,
+          "transferSize": 406678,
           "resourceSize": 475454
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5698,
+          "transferSize": 5701,
           "resourceSize": 25352
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10198,
+          "transferSize": 10185,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200052,
+          "transferSize": 200042,
           "resourceSize": 294224
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2728,
+          "transferSize": 2732,
           "resourceSize": 7168
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406821,
+          "transferSize": 406828,
           "resourceSize": 475120
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2882,
+          "transferSize": 2883,
           "resourceSize": 7753
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406935,
+          "transferSize": 406933,
           "resourceSize": 475664
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2708,
+          "transferSize": 2711,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406526,
+          "transferSize": 406525,
           "resourceSize": 474835
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2974,
+          "transferSize": 2976,
           "resourceSize": 7799
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631987,
+          "transferSize": 631985,
           "resourceSize": 701295
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3117,
+          "transferSize": 3120,
           "resourceSize": 8131
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413104,
+          "transferSize": 413110,
           "resourceSize": 488613
         }
       },

--- a/.github/page_size_audit_results/v1.45.4.json
+++ b/.github/page_size_audit_results/v1.45.4.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.45.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:37.066Z"
+    "generatedAt": "2025-12-25T01:03:06.563Z"
   },
-  "timestamp": "2025-12-24T18:59:37.066Z",
+  "timestamp": "2025-12-25T01:03:06.563Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2873,
+          "transferSize": 2878,
           "resourceSize": 7621
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406689,
+          "transferSize": 406686,
           "resourceSize": 475459
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2860,
+          "transferSize": 2865,
           "resourceSize": 7616
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406679,
+          "transferSize": 406676,
           "resourceSize": 475454
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5699,
+          "transferSize": 5703,
           "resourceSize": 25352
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10220,
+          "transferSize": 10215,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200075,
+          "transferSize": 200074,
           "resourceSize": 294224
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2729,
+          "transferSize": 2731,
           "resourceSize": 7168
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406819,
+          "transferSize": 406824,
           "resourceSize": 475120
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2881,
+          "transferSize": 2886,
           "resourceSize": 7753
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2709,
+          "transferSize": 2711,
           "resourceSize": 6997
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406521,
+          "transferSize": 406526,
           "resourceSize": 474835
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2974,
+          "transferSize": 2979,
           "resourceSize": 7799
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406793,
+          "transferSize": 406796,
           "resourceSize": 475637
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3155,
+          "transferSize": 3159,
           "resourceSize": 8770
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631988,
+          "transferSize": 631993,
           "resourceSize": 701295
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3118,
+          "transferSize": 3122,
           "resourceSize": 8131
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.46.0.json
+++ b/.github/page_size_audit_results/v1.46.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.46.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:52.213Z"
+    "generatedAt": "2025-12-25T01:03:22.917Z"
   },
-  "timestamp": "2025-12-24T18:53:52.214Z",
+  "timestamp": "2025-12-25T01:03:22.918Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2899,
+          "transferSize": 2894,
           "resourceSize": 7807
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407287,
+          "transferSize": 407281,
           "resourceSize": 474626
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2871,
+          "transferSize": 2868,
           "resourceSize": 7702
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406831,
+          "transferSize": 406827,
           "resourceSize": 474259
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5705,
+          "transferSize": 5699,
           "resourceSize": 25303
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10173,
+          "transferSize": 10179,
           "resourceSize": 12954
         },
         "other": {
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2705,
+          "transferSize": 2703,
           "resourceSize": 7119
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406318,
+          "transferSize": 406316,
           "resourceSize": 473329
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2873,
+          "transferSize": 2869,
           "resourceSize": 7728
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406446,
+          "transferSize": 406437,
           "resourceSize": 473897
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2693,
+          "transferSize": 2691,
           "resourceSize": 6948
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406031,
+          "transferSize": 406026,
           "resourceSize": 473044
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2967,
+          "transferSize": 2962,
           "resourceSize": 7774
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406309,
+          "transferSize": 406295,
           "resourceSize": 473871
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3147,
+          "transferSize": 3144,
           "resourceSize": 8745
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631501,
+          "transferSize": 631505,
           "resourceSize": 699528
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3106,
+          "transferSize": 3103,
           "resourceSize": 8082
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412623,
+          "transferSize": 412612,
           "resourceSize": 486832
         }
       },

--- a/.github/page_size_audit_results/v1.47.0.json
+++ b/.github/page_size_audit_results/v1.47.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.47.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:41.650Z"
+    "generatedAt": "2025-12-25T01:03:13.214Z"
   },
-  "timestamp": "2025-12-24T18:56:41.650Z",
+  "timestamp": "2025-12-25T01:03:13.214Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407292,
+          "transferSize": 407286,
           "resourceSize": 474621
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2872,
+          "transferSize": 2871,
           "resourceSize": 7697
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406834,
+          "transferSize": 406832,
           "resourceSize": 474254
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5693,
+          "transferSize": 5691,
           "resourceSize": 25293
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10195,
+          "transferSize": 10196,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199568,
+          "transferSize": 199567,
           "resourceSize": 292433
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2711,
+          "transferSize": 2709,
           "resourceSize": 7114
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406320,
+          "transferSize": 406323,
           "resourceSize": 473324
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2876,
+          "transferSize": 2875,
           "resourceSize": 7723
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406445,
+          "transferSize": 406449,
           "resourceSize": 473892
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2691,
+          "transferSize": 2690,
           "resourceSize": 6943
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406024,
+          "transferSize": 406027,
           "resourceSize": 473039
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2968,
+          "transferSize": 2967,
           "resourceSize": 7769
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406306,
+          "transferSize": 406301,
           "resourceSize": 473866
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3148,
+          "transferSize": 3145,
           "resourceSize": 8740
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 631503,
+          "transferSize": 631499,
           "resourceSize": 699523
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3106,
+          "transferSize": 3104,
           "resourceSize": 8077
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1128,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412621,
+          "transferSize": 412622,
           "resourceSize": 486827
         }
       },

--- a/.github/page_size_audit_results/v1.48.0.json
+++ b/.github/page_size_audit_results/v1.48.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.48.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:59:31.281Z"
+    "generatedAt": "2025-12-25T01:03:06.157Z"
   },
-  "timestamp": "2025-12-24T18:59:31.282Z",
+  "timestamp": "2025-12-25T01:03:06.157Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 3027,
-          "resourceSize": 8239
+          "transferSize": 2859,
+          "resourceSize": 7782
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 48977,
-          "resourceSize": 136511
+          "transferSize": 12419,
+          "resourceSize": 28959
         },
         "stylesheet": {
-          "transferSize": 10970,
-          "resourceSize": 55658
+          "transferSize": 9800,
+          "resourceSize": 54654
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 444133,
-          "resourceSize": 580564
+          "transferSize": 406233,
+          "resourceSize": 471551
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2990,
-          "resourceSize": 8134
+          "transferSize": 2833,
+          "resourceSize": 7677
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 48977,
-          "resourceSize": 136511
+          "transferSize": 12419,
+          "resourceSize": 28959
         },
         "stylesheet": {
-          "transferSize": 10543,
-          "resourceSize": 55396
+          "transferSize": 9373,
+          "resourceSize": 54392
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 443665,
-          "resourceSize": 580197
+          "transferSize": 405777,
+          "resourceSize": 471184
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5778,
-          "resourceSize": 25805
+          "transferSize": 5652,
+          "resourceSize": 25164
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 52632,
-          "resourceSize": 142911
+          "transferSize": 16074,
+          "resourceSize": 35359
         },
         "stylesheet": {
-          "transferSize": 10529,
-          "resourceSize": 58728
+          "transferSize": 9359,
+          "resourceSize": 57724
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10215,
+          "transferSize": 10223,
           "resourceSize": 12954
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 235366,
-          "resourceSize": 396353
+          "transferSize": 197520,
+          "resourceSize": 287156
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2820,
-          "resourceSize": 7551
+          "transferSize": 2674,
+          "resourceSize": 7094
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 48938,
-          "resourceSize": 136472
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 10235,
-          "resourceSize": 55088
+          "transferSize": 9065,
+          "resourceSize": 54084
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 443148,
-          "resourceSize": 579267
+          "transferSize": 405275,
+          "resourceSize": 470254
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2989,
-          "resourceSize": 8160
+          "transferSize": 2836,
+          "resourceSize": 7703
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 48938,
-          "resourceSize": 136472
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 10193,
-          "resourceSize": 55047
+          "transferSize": 9023,
+          "resourceSize": 54043
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 443279,
-          "resourceSize": 579835
+          "transferSize": 405395,
+          "resourceSize": 470822
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2805,
-          "resourceSize": 7380
+          "transferSize": 2654,
+          "resourceSize": 6923
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 48938,
-          "resourceSize": 136472
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 9956,
-          "resourceSize": 54974
+          "transferSize": 8786,
+          "resourceSize": 53970
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 442857,
-          "resourceSize": 578983
+          "transferSize": 404978,
+          "resourceSize": 469969
         }
       },
       "themeResources": {
@@ -425,12 +425,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 401554,
-          "resourceSize": 462852
+          "transferSize": 401553,
+          "resourceSize": 462851
         }
       }
     },
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 3095,
-          "resourceSize": 8206
+          "transferSize": 2931,
+          "resourceSize": 7749
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 48938,
-          "resourceSize": 136472
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 9956,
-          "resourceSize": 54974
+          "transferSize": 8786,
+          "resourceSize": 53970
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 443154,
-          "resourceSize": 579809
+          "transferSize": 405254,
+          "resourceSize": 470796
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3255,
-          "resourceSize": 9177
+          "transferSize": 3111,
+          "resourceSize": 8720
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 48938,
-          "resourceSize": 136472
+          "transferSize": 12380,
+          "resourceSize": 28920
         },
         "stylesheet": {
-          "transferSize": 10801,
-          "resourceSize": 55654
+          "transferSize": 9631,
+          "resourceSize": 54650
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 668329,
-          "resourceSize": 805466
+          "transferSize": 630458,
+          "resourceSize": 696453
         }
       },
       "themeResources": {
@@ -580,20 +580,20 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3189,
-          "resourceSize": 8294
+          "transferSize": 3042,
+          "resourceSize": 7837
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 50949,
-          "resourceSize": 138310
+          "transferSize": 14391,
+          "resourceSize": 30758
         },
         "stylesheet": {
-          "transferSize": 9956,
-          "resourceSize": 54974
+          "transferSize": 8786,
+          "resourceSize": 53970
         },
         "image": {
           "transferSize": 224175,
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 445605,
-          "resourceSize": 581735
+          "transferSize": 407730,
+          "resourceSize": 472722
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.5.0.json
+++ b/.github/page_size_audit_results/v1.5.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.5.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:47.361Z"
+    "generatedAt": "2025-12-25T01:03:17.376Z"
   },
-  "timestamp": "2025-12-24T18:56:47.361Z",
+  "timestamp": "2025-12-25T01:03:17.376Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690278,
+          "transferSize": 690281,
           "resourceSize": 1367130
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2464,
+          "transferSize": 2463,
           "resourceSize": 5149
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4969,
+          "transferSize": 4972,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479002,
+          "transferSize": 479005,
           "resourceSize": 1172340
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689960,
+          "transferSize": 689962,
           "resourceSize": 1366198
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2454,
+          "transferSize": 2453,
           "resourceSize": 4959
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690138,
+          "transferSize": 690130,
           "resourceSize": 1366624
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690190,
+          "transferSize": 690186,
           "resourceSize": 1366734
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3196,
+          "transferSize": 3193,
           "resourceSize": 7535
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915048,
+          "transferSize": 915043,
           "resourceSize": 1593206
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697257,
+          "transferSize": 697254,
           "resourceSize": 1380526
         }
       },

--- a/.github/page_size_audit_results/v1.6.0.json
+++ b/.github/page_size_audit_results/v1.6.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.6.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:56:47.543Z"
+    "generatedAt": "2025-12-25T01:05:55.998Z"
   },
-  "timestamp": "2025-12-24T18:56:47.543Z",
+  "timestamp": "2025-12-25T01:05:55.998Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2600,
+          "transferSize": 2599,
           "resourceSize": 5476
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690290,
+          "transferSize": 690294,
           "resourceSize": 1367164
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2467,
+          "transferSize": 2466,
           "resourceSize": 5160
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690157,
+          "transferSize": 690158,
           "resourceSize": 1366848
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5228,
+          "transferSize": 5227,
           "resourceSize": 16806
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4976,
+          "transferSize": 4984,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479021,
+          "transferSize": 479028,
           "resourceSize": 1172374
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2457,
+          "transferSize": 2456,
           "resourceSize": 4970
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690150,
+          "transferSize": 690146,
           "resourceSize": 1366658
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689990,
+          "transferSize": 689993,
           "resourceSize": 1366214
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2513,
+          "transferSize": 2512,
           "resourceSize": 5080
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690202,
+          "transferSize": 690210,
           "resourceSize": 1366768
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915065,
+          "transferSize": 915067,
           "resourceSize": 1593240
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1134,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697270,
+          "transferSize": 697283,
           "resourceSize": 1380560
         }
       },

--- a/.github/page_size_audit_results/v1.6.1.json
+++ b/.github/page_size_audit_results/v1.6.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.6.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:54:13.302Z"
+    "generatedAt": "2025-12-25T01:06:01.704Z"
   },
-  "timestamp": "2025-12-24T18:54:13.302Z",
+  "timestamp": "2025-12-25T01:06:01.704Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690293,
+          "transferSize": 690286,
           "resourceSize": 1367177
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690161,
+          "transferSize": 690158,
           "resourceSize": 1366861
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4969,
+          "transferSize": 4975,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479019,
+          "transferSize": 479025,
           "resourceSize": 1172387
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689979,
+          "transferSize": 689987,
           "resourceSize": 1366245
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690147,
+          "transferSize": 690148,
           "resourceSize": 1366671
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689993,
+          "transferSize": 689994,
           "resourceSize": 1366227
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690204,
+          "transferSize": 690208,
           "resourceSize": 1366781
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3199,
+          "transferSize": 3198,
           "resourceSize": 7547
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915062,
+          "transferSize": 915069,
           "resourceSize": 1593253
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697272,
+          "transferSize": 697275,
           "resourceSize": 1380573
         }
       },

--- a/.github/page_size_audit_results/v1.7.0.json
+++ b/.github/page_size_audit_results/v1.7.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.7.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:47.197Z"
+    "generatedAt": "2025-12-25T01:00:11.421Z"
   },
-  "timestamp": "2025-12-24T18:53:47.197Z",
+  "timestamp": "2025-12-25T01:00:11.422Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2645,
+          "transferSize": 2646,
           "resourceSize": 5549
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690761,
+          "transferSize": 690759,
           "resourceSize": 1367249
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2512,
+          "transferSize": 2513,
           "resourceSize": 5233
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690629,
+          "transferSize": 690633,
           "resourceSize": 1366933
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5230,
+          "transferSize": 5229,
           "resourceSize": 16807
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4998,
+          "transferSize": 4985,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479048,
+          "transferSize": 479034,
           "resourceSize": 1172387
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2332,
+          "transferSize": 2334,
           "resourceSize": 4617
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690445,
+          "transferSize": 690454,
           "resourceSize": 1366317
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2500,
+          "transferSize": 2501,
           "resourceSize": 5043
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690616,
+          "transferSize": 690619,
           "resourceSize": 1366743
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2345,
+          "transferSize": 2348,
           "resourceSize": 4599
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690461,
+          "transferSize": 690466,
           "resourceSize": 1366299
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2558,
+          "transferSize": 2559,
           "resourceSize": 5153
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690675,
+          "transferSize": 690678,
           "resourceSize": 1366853
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3197,
+          "transferSize": 3200,
           "resourceSize": 7472
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691311,
+          "transferSize": 691320,
           "resourceSize": 1593178
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3201,
+          "transferSize": 3204,
           "resourceSize": 6549
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1129,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697737,
+          "transferSize": 697750,
           "resourceSize": 1380645
         }
       },

--- a/.github/page_size_audit_results/v1.8.0.json
+++ b/.github/page_size_audit_results/v1.8.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:54:03.209Z"
+    "generatedAt": "2025-12-25T01:03:15.759Z"
   },
-  "timestamp": "2025-12-24T18:54:03.209Z",
+  "timestamp": "2025-12-25T01:03:15.759Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2647,
+          "transferSize": 2645,
           "resourceSize": 5554
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690762,
+          "transferSize": 690759,
           "resourceSize": 1367254
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2514,
+          "transferSize": 2512,
           "resourceSize": 5238
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690628,
+          "transferSize": 690627,
           "resourceSize": 1366938
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5228,
+          "transferSize": 5226,
           "resourceSize": 16812
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4966,
+          "transferSize": 4963,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479014,
+          "transferSize": 479009,
           "resourceSize": 1172392
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690457,
+          "transferSize": 690450,
           "resourceSize": 1366322
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2503,
+          "transferSize": 2502,
           "resourceSize": 5048
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690619,
+          "transferSize": 690613,
           "resourceSize": 1366748
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690467,
+          "transferSize": 690463,
           "resourceSize": 1366304
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2561,
+          "transferSize": 2559,
           "resourceSize": 5158
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690673,
+          "transferSize": 690670,
           "resourceSize": 1366858
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3201,
+          "transferSize": 3200,
           "resourceSize": 7477
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691319,
+          "transferSize": 691316,
           "resourceSize": 1593183
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697748,
+          "transferSize": 697742,
           "resourceSize": 1380650
         }
       },

--- a/.github/page_size_audit_results/v1.8.1.json
+++ b/.github/page_size_audit_results/v1.8.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:53:56.555Z"
+    "generatedAt": "2025-12-25T01:00:22.447Z"
   },
-  "timestamp": "2025-12-24T18:53:56.555Z",
+  "timestamp": "2025-12-25T01:00:22.447Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2647,
+          "transferSize": 2646,
           "resourceSize": 5554
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2514,
+          "transferSize": 2513,
           "resourceSize": 5238
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690632,
+          "transferSize": 690629,
           "resourceSize": 1366938
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4972,
+          "transferSize": 4977,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479019,
+          "transferSize": 479024,
           "resourceSize": 1172392
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690450,
+          "transferSize": 690456,
           "resourceSize": 1366322
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2503,
+          "transferSize": 2502,
           "resourceSize": 5048
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690619,
+          "transferSize": 690621,
           "resourceSize": 1366748
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2561,
+          "transferSize": 2560,
           "resourceSize": 5158
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690682,
+          "transferSize": 690677,
           "resourceSize": 1366858
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3201,
+          "transferSize": 3199,
           "resourceSize": 7477
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691312,
+          "transferSize": 691316,
           "resourceSize": 1593183
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1128,
+          "transferSize": 1118,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697749,
+          "transferSize": 697739,
           "resourceSize": 1380650
         }
       },

--- a/.github/page_size_audit_results/v1.9.0.json
+++ b/.github/page_size_audit_results/v1.9.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.9.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-24T18:57:18.613Z"
+    "generatedAt": "2025-12-25T01:00:22.085Z"
   },
-  "timestamp": "2025-12-24T18:57:18.613Z",
+  "timestamp": "2025-12-25T01:00:22.085Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2731,
-          "resourceSize": 5885
+          "transferSize": 2653,
+          "resourceSize": 5593
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159046,
-          "resourceSize": 496369
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318935,
-          "resourceSize": 711543
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706440,
-          "resourceSize": 1438273
+          "transferSize": 690767,
+          "resourceSize": 1367293
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2598,
-          "resourceSize": 5569
+          "transferSize": 2520,
+          "resourceSize": 5277
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159046,
-          "resourceSize": 496369
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318935,
-          "resourceSize": 711543
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706307,
-          "resourceSize": 1437957
+          "transferSize": 690631,
+          "resourceSize": 1366977
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5308,
-          "resourceSize": 17143
+          "transferSize": 5239,
+          "resourceSize": 16851
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 165117,
-          "resourceSize": 508765
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 318935,
-          "resourceSize": 711543
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4998,
+          "transferSize": 4970,
           "resourceSize": 5685
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 494720,
-          "resourceSize": 1243411
+          "transferSize": 479029,
+          "resourceSize": 1172431
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2418,
-          "resourceSize": 4953
+          "transferSize": 2343,
+          "resourceSize": 4661
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159046,
-          "resourceSize": 496369
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318935,
-          "resourceSize": 711543
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706128,
-          "resourceSize": 1437341
+          "transferSize": 690454,
+          "resourceSize": 1366361
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2586,
-          "resourceSize": 5379
+          "transferSize": 2511,
+          "resourceSize": 5087
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159046,
-          "resourceSize": 496369
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318935,
-          "resourceSize": 711543
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706294,
-          "resourceSize": 1437767
+          "transferSize": 690624,
+          "resourceSize": 1366787
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2430,
-          "resourceSize": 4935
+          "transferSize": 2355,
+          "resourceSize": 4643
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159046,
-          "resourceSize": 496369
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318935,
-          "resourceSize": 711543
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706145,
-          "resourceSize": 1437323
+          "transferSize": 690471,
+          "resourceSize": 1366343
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2646,
-          "resourceSize": 5489
+          "transferSize": 2567,
+          "resourceSize": 5197
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159046,
-          "resourceSize": 496369
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318935,
-          "resourceSize": 711543
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706352,
-          "resourceSize": 1437877
+          "transferSize": 690688,
+          "resourceSize": 1366897
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3276,
-          "resourceSize": 7808
+          "transferSize": 3206,
+          "resourceSize": 7516
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159046,
-          "resourceSize": 496369
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
-          "transferSize": 318935,
-          "resourceSize": 711543
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 706988,
-          "resourceSize": 1664203
+          "transferSize": 691321,
+          "resourceSize": 1593222
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 687347,
-          "resourceSize": 1585512
+          "transferSize": 687346,
+          "resourceSize": 1585511
         }
       }
     },
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3288,
-          "resourceSize": 6885
+          "transferSize": 3212,
+          "resourceSize": 6593
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 165117,
-          "resourceSize": 508765
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
-          "transferSize": 318935,
-          "resourceSize": 711543
+          "transferSize": 317021,
+          "resourceSize": 709795
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1117,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 713422,
-          "resourceSize": 1451670
+          "transferSize": 697746,
+          "resourceSize": 1380689
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 691407,
-          "resourceSize": 1372064
+          "transferSize": 691406,
+          "resourceSize": 1372063
         }
       }
     }


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.0.1
- **End Version:** v1.48.0

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Audit workflow*