### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.12.2.json
+++ b/.github/page_size_audit_results/v1.12.2.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:06:13.318Z"
+    "generatedAt": "2025-12-25T10:46:23.622Z"
   },
-  "timestamp": "2025-12-25T01:06:13.318Z",
+  "timestamp": "2025-12-25T10:46:23.622Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2834,
-          "resourceSize": 6526
+          "transferSize": 2708,
+          "resourceSize": 6131
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318276,
-          "resourceSize": 711015
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 731216,
-          "resourceSize": 1482131
+          "transferSize": 693357,
+          "resourceSize": 1373180
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2794,
-          "resourceSize": 6523
+          "transferSize": 2669,
+          "resourceSize": 6128
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318276,
-          "resourceSize": 711015
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 731171,
-          "resourceSize": 1482128
+          "transferSize": 693320,
+          "resourceSize": 1373177
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5507,
-          "resourceSize": 18538
+          "transferSize": 5382,
+          "resourceSize": 18021
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 190170,
-          "resourceSize": 551112
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 318276,
-          "resourceSize": 711015
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4968,
+          "transferSize": 4962,
           "resourceSize": 5685
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 519283,
-          "resourceSize": 1286625
+          "transferSize": 481424,
+          "resourceSize": 1177552
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2617,
-          "resourceSize": 5909
+          "transferSize": 2488,
+          "resourceSize": 5514
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318276,
-          "resourceSize": 711015
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 730996,
-          "resourceSize": 1481514
+          "transferSize": 693132,
+          "resourceSize": 1372563
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2782,
-          "resourceSize": 6333
+          "transferSize": 2658,
+          "resourceSize": 5938
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318276,
-          "resourceSize": 711015
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 731156,
-          "resourceSize": 1481938
+          "transferSize": 693310,
+          "resourceSize": 1372987
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2627,
-          "resourceSize": 5891
+          "transferSize": 2498,
+          "resourceSize": 5496
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318276,
-          "resourceSize": 711015
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 731002,
-          "resourceSize": 1481496
+          "transferSize": 693143,
+          "resourceSize": 1372545
         }
       },
       "themeResources": {
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2842,
-          "resourceSize": 6443
+          "transferSize": 2716,
+          "resourceSize": 6048
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318276,
-          "resourceSize": 711015
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 731228,
-          "resourceSize": 1482049
+          "transferSize": 693365,
+          "resourceSize": 1373097
         }
       },
       "themeResources": {
@@ -496,12 +496,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 689881,
-          "resourceSize": 1366855
+          "transferSize": 689880,
+          "resourceSize": 1366854
         }
       }
     },
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3500,
-          "resourceSize": 8761
+          "transferSize": 3378,
+          "resourceSize": 8366
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 184373,
-          "resourceSize": 540114
+          "transferSize": 147815,
+          "resourceSize": 432562
         },
         "stylesheet": {
-          "transferSize": 318276,
-          "resourceSize": 711015
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 731880,
-          "resourceSize": 1708373
+          "transferSize": 694035,
+          "resourceSize": 1599421
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 689881,
-          "resourceSize": 1590861
+          "transferSize": 689880,
+          "resourceSize": 1590860
         }
       }
     },
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3479,
-          "resourceSize": 7811
+          "transferSize": 3362,
+          "resourceSize": 7416
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 190170,
-          "resourceSize": 551112
+          "transferSize": 153612,
+          "resourceSize": 443560
         },
         "stylesheet": {
-          "transferSize": 318276,
-          "resourceSize": 711015
+          "transferSize": 317106,
+          "resourceSize": 710011
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 738008,
-          "resourceSize": 1494415
+          "transferSize": 700161,
+          "resourceSize": 1385464
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.12.3.json
+++ b/.github/page_size_audit_results/v1.12.3.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:16.854Z"
+    "generatedAt": "2025-12-25T10:46:53.036Z"
   },
-  "timestamp": "2025-12-25T01:03:16.855Z",
+  "timestamp": "2025-12-25T10:46:53.037Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2719,
+          "transferSize": 2714,
           "resourceSize": 6137
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693370,
+          "transferSize": 693368,
           "resourceSize": 1373203
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2681,
+          "transferSize": 2676,
           "resourceSize": 6134
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693329,
+          "transferSize": 693322,
           "resourceSize": 1373200
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5389,
+          "transferSize": 5387,
           "resourceSize": 18027
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5026,
+          "transferSize": 5029,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481494,
+          "transferSize": 481495,
           "resourceSize": 1177575
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2507,
+          "transferSize": 2503,
           "resourceSize": 5520
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693158,
+          "transferSize": 693151,
           "resourceSize": 1372586
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2668,
+          "transferSize": 2666,
           "resourceSize": 5944
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2515,
+          "transferSize": 2512,
           "resourceSize": 5502
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693170,
+          "transferSize": 693162,
           "resourceSize": 1372568
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2728,
+          "transferSize": 2724,
           "resourceSize": 6054
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693378,
+          "transferSize": 693370,
           "resourceSize": 1373120
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3392,
+          "transferSize": 3389,
           "resourceSize": 8372
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694040,
+          "transferSize": 694036,
           "resourceSize": 1599444
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3375,
+          "transferSize": 3371,
           "resourceSize": 7422
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700174,
+          "transferSize": 700168,
           "resourceSize": 1385487
         }
       },

--- a/.github/page_size_audit_results/v1.13.0.json
+++ b/.github/page_size_audit_results/v1.13.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:14.243Z"
+    "generatedAt": "2025-12-25T10:46:12.395Z"
   },
-  "timestamp": "2025-12-25T01:03:14.243Z",
+  "timestamp": "2025-12-25T10:46:12.396Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693373,
+          "transferSize": 693364,
           "resourceSize": 1373203
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693330,
+          "transferSize": 693329,
           "resourceSize": 1373200
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4966,
+          "transferSize": 4976,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481435,
+          "transferSize": 481445,
           "resourceSize": 1177575
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693159,
+          "transferSize": 693158,
           "resourceSize": 1372586
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2669,
+          "transferSize": 2670,
           "resourceSize": 5944
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693313,
+          "transferSize": 693317,
           "resourceSize": 1373010
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693160,
+          "transferSize": 693165,
           "resourceSize": 1372568
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693376,
+          "transferSize": 693380,
           "resourceSize": 1373120
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694040,
+          "transferSize": 694045,
           "resourceSize": 1599444
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700171,
+          "transferSize": 700176,
           "resourceSize": 1385487
         }
       },

--- a/.github/page_size_audit_results/v1.13.1.json
+++ b/.github/page_size_audit_results/v1.13.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:19.407Z"
+    "generatedAt": "2025-12-25T10:46:15.587Z"
   },
-  "timestamp": "2025-12-25T01:00:19.407Z",
+  "timestamp": "2025-12-25T10:46:15.587Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2724,
+          "transferSize": 2726,
           "resourceSize": 6155
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693440,
+          "transferSize": 693435,
           "resourceSize": 1373874
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2687,
+          "transferSize": 2691,
           "resourceSize": 6152
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693402,
+          "transferSize": 693400,
           "resourceSize": 1373871
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4968,
+          "transferSize": 5056,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481507,
+          "transferSize": 481595,
           "resourceSize": 1178246
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2513,
+          "transferSize": 2516,
           "resourceSize": 5538
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693226,
+          "transferSize": 693228,
           "resourceSize": 1373257
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2677,
+          "transferSize": 2680,
           "resourceSize": 5962
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693385,
+          "transferSize": 693393,
           "resourceSize": 1373681
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2522,
+          "transferSize": 2525,
           "resourceSize": 5520
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693235,
+          "transferSize": 693239,
           "resourceSize": 1373239
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2734,
+          "transferSize": 2737,
           "resourceSize": 6072
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693448,
+          "transferSize": 693446,
           "resourceSize": 1373791
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3393,
+          "transferSize": 3396,
           "resourceSize": 8390
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 781,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694114,
+          "transferSize": 694106,
           "resourceSize": 1600115
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3380,
+          "transferSize": 3384,
           "resourceSize": 7440
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1132,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700250,
+          "transferSize": 700246,
           "resourceSize": 1386158
         }
       },

--- a/.github/page_size_audit_results/v1.14.0.json
+++ b/.github/page_size_audit_results/v1.14.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.14.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:05:57.091Z"
+    "generatedAt": "2025-12-25T10:46:35.521Z"
   },
-  "timestamp": "2025-12-25T01:05:57.091Z",
+  "timestamp": "2025-12-25T10:46:35.522Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693407,
+          "transferSize": 693404,
           "resourceSize": 1373802
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693370,
+          "transferSize": 693371,
           "resourceSize": 1373799
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5399,
+          "transferSize": 5400,
           "resourceSize": 18045
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5028,
+          "transferSize": 4983,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481567,
+          "transferSize": 481523,
           "resourceSize": 1178246
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693360,
+          "transferSize": 693357,
           "resourceSize": 1373609
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693235,
+          "transferSize": 693234,
           "resourceSize": 1373239
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693415,
+          "transferSize": 693412,
           "resourceSize": 1373719
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700249,
+          "transferSize": 700244,
           "resourceSize": 1386158
         }
       },

--- a/.github/page_size_audit_results/v1.15.0.json
+++ b/.github/page_size_audit_results/v1.15.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:13.939Z"
+    "generatedAt": "2025-12-25T10:46:18.633Z"
   },
-  "timestamp": "2025-12-25T01:00:13.939Z",
+  "timestamp": "2025-12-25T10:46:18.634Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2705,
+          "transferSize": 2709,
           "resourceSize": 6101
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693547,
+          "transferSize": 693555,
           "resourceSize": 1374456
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2670,
+          "transferSize": 2674,
           "resourceSize": 6098
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693510,
+          "transferSize": 693514,
           "resourceSize": 1374453
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5583,
+          "transferSize": 5584,
           "resourceSize": 18349
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4975,
+          "transferSize": 4969,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481830,
+          "transferSize": 481825,
           "resourceSize": 1179186
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2527,
+          "transferSize": 2530,
           "resourceSize": 5556
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693370,
+          "transferSize": 693373,
           "resourceSize": 1373911
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2659,
+          "transferSize": 2663,
           "resourceSize": 5908
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693497,
+          "transferSize": 693502,
           "resourceSize": 1374263
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2538,
+          "transferSize": 2541,
           "resourceSize": 5538
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693380,
+          "transferSize": 693383,
           "resourceSize": 1373893
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2715,
+          "transferSize": 2719,
           "resourceSize": 6018
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693561,
+          "transferSize": 693566,
           "resourceSize": 1374373
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3373,
+          "transferSize": 3375,
           "resourceSize": 8336
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694216,
+          "transferSize": 694218,
           "resourceSize": 1600697
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3394,
+          "transferSize": 3395,
           "resourceSize": 7458
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700386,
+          "transferSize": 700387,
           "resourceSize": 1386812
         }
       },

--- a/.github/page_size_audit_results/v1.15.1.json
+++ b/.github/page_size_audit_results/v1.15.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:18.996Z"
+    "generatedAt": "2025-12-25T10:46:11.331Z"
   },
-  "timestamp": "2025-12-25T01:00:18.996Z",
+  "timestamp": "2025-12-25T10:46:11.332Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2058,
+          "transferSize": 2061,
           "resourceSize": 4959
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692426,
+          "transferSize": 692437,
           "resourceSize": 1372340
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2025,
+          "transferSize": 2028,
           "resourceSize": 4956
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692398,
+          "transferSize": 692395,
           "resourceSize": 1372337
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5031,
+          "transferSize": 5032,
           "resourceSize": 17245
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4972,
+          "transferSize": 4978,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480805,
+          "transferSize": 480812,
           "resourceSize": 1177108
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1895,
+          "transferSize": 1897,
           "resourceSize": 4414
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692266,
+          "transferSize": 692271,
           "resourceSize": 1371795
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2026,
+          "transferSize": 2031,
           "resourceSize": 4766
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692394,
+          "transferSize": 692406,
           "resourceSize": 1372147
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1909,
+          "transferSize": 1912,
           "resourceSize": 4396
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692289,
+          "transferSize": 692284,
           "resourceSize": 1371777
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2101,
+          "transferSize": 2104,
           "resourceSize": 4876
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692474,
+          "transferSize": 692475,
           "resourceSize": 1372257
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2750,
+          "transferSize": 2754,
           "resourceSize": 7194
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 779,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693131,
+          "transferSize": 693124,
           "resourceSize": 1598581
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2789,
+          "transferSize": 2795,
           "resourceSize": 6298
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699313,
+          "transferSize": 699316,
           "resourceSize": 1384678
         }
       },

--- a/.github/page_size_audit_results/v1.16.0.json
+++ b/.github/page_size_audit_results/v1.16.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:18.419Z"
+    "generatedAt": "2025-12-25T10:46:21.747Z"
   },
-  "timestamp": "2025-12-25T01:00:18.419Z",
+  "timestamp": "2025-12-25T10:46:21.747Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692524,
+          "transferSize": 692528,
           "resourceSize": 1372886
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2025,
+          "transferSize": 2026,
           "resourceSize": 4966
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5031,
+          "transferSize": 5032,
           "resourceSize": 17255
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5017,
+          "transferSize": 5054,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480948,
+          "transferSize": 480986,
           "resourceSize": 1177654
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692366,
+          "transferSize": 692367,
           "resourceSize": 1372341
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2027,
+          "transferSize": 2029,
           "resourceSize": 4776
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 780,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692498,
+          "transferSize": 692509,
           "resourceSize": 1372693
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692378,
+          "transferSize": 692380,
           "resourceSize": 1372323
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2102,
+          "transferSize": 2103,
           "resourceSize": 4886
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693226,
+          "transferSize": 693223,
           "resourceSize": 1599127
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699412,
+          "transferSize": 699411,
           "resourceSize": 1385224
         }
       },

--- a/.github/page_size_audit_results/v1.16.1.json
+++ b/.github/page_size_audit_results/v1.16.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:13.339Z"
+    "generatedAt": "2025-12-25T10:46:20.997Z"
   },
-  "timestamp": "2025-12-25T01:03:13.340Z",
+  "timestamp": "2025-12-25T10:46:20.997Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2058,
+          "transferSize": 2063,
           "resourceSize": 4969
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 780,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692530,
+          "transferSize": 692543,
           "resourceSize": 1372886
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2024,
+          "transferSize": 2028,
           "resourceSize": 4966
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692489,
+          "transferSize": 692498,
           "resourceSize": 1372883
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5029,
+          "transferSize": 5034,
           "resourceSize": 17255
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5017,
+          "transferSize": 5018,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480946,
+          "transferSize": 480952,
           "resourceSize": 1177654
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1897,
+          "transferSize": 1900,
           "resourceSize": 4424
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692364,
+          "transferSize": 692374,
           "resourceSize": 1372341
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2027,
+          "transferSize": 2031,
           "resourceSize": 4776
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692499,
+          "transferSize": 692497,
           "resourceSize": 1372693
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1911,
+          "transferSize": 1914,
           "resourceSize": 4406
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692380,
+          "transferSize": 692385,
           "resourceSize": 1372323
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2101,
+          "transferSize": 2106,
           "resourceSize": 4886
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692569,
+          "transferSize": 692576,
           "resourceSize": 1372803
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2752,
+          "transferSize": 2755,
           "resourceSize": 7204
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693222,
+          "transferSize": 693223,
           "resourceSize": 1599127
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2791,
+          "transferSize": 2797,
           "resourceSize": 6308
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699416,
+          "transferSize": 699417,
           "resourceSize": 1385224
         }
       },

--- a/.github/page_size_audit_results/v1.17.0.json
+++ b/.github/page_size_audit_results/v1.17.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.17.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:21.248Z"
+    "generatedAt": "2025-12-25T10:46:13.852Z"
   },
-  "timestamp": "2025-12-25T01:03:21.248Z",
+  "timestamp": "2025-12-25T10:46:13.852Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2151,
+          "transferSize": 2154,
           "resourceSize": 5445
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692163,
+          "transferSize": 692176,
           "resourceSize": 1373215
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2120,
           "resourceSize": 5442
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692134,
+          "transferSize": 692133,
           "resourceSize": 1373212
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5170,
+          "transferSize": 5174,
           "resourceSize": 17803
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4977,
+          "transferSize": 5067,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481012,
+          "transferSize": 481106,
           "resourceSize": 1178055
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2121,
+          "transferSize": 2124,
           "resourceSize": 5252
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692135,
+          "transferSize": 692136,
           "resourceSize": 1373022
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692015,
+          "transferSize": 692019,
           "resourceSize": 1372652
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2196,
+          "transferSize": 2198,
           "resourceSize": 5362
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692207,
+          "transferSize": 692211,
           "resourceSize": 1373132
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917033,
+          "transferSize": 917035,
           "resourceSize": 1599456
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699052,
+          "transferSize": 699048,
           "resourceSize": 1385553
         }
       },

--- a/.github/page_size_audit_results/v1.18.0.json
+++ b/.github/page_size_audit_results/v1.18.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.18.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:15.668Z"
+    "generatedAt": "2025-12-25T10:46:17.769Z"
   },
-  "timestamp": "2025-12-25T01:00:15.668Z",
+  "timestamp": "2025-12-25T10:46:17.769Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2113,
+          "transferSize": 2116,
           "resourceSize": 5153
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692329,
+          "transferSize": 692326,
           "resourceSize": 1376572
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2079,
+          "transferSize": 2082,
           "resourceSize": 5150
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692289,
+          "transferSize": 692294,
           "resourceSize": 1376569
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5116,
+          "transferSize": 5119,
           "resourceSize": 17511
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4969,
+          "transferSize": 4968,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481147,
+          "transferSize": 481149,
           "resourceSize": 1181412
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1953,
+          "transferSize": 1956,
           "resourceSize": 4608
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692159,
+          "transferSize": 692165,
           "resourceSize": 1376027
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2081,
+          "transferSize": 2086,
           "resourceSize": 4960
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692290,
+          "transferSize": 692296,
           "resourceSize": 1376379
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1965,
+          "transferSize": 1967,
           "resourceSize": 4590
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 779,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692172,
+          "transferSize": 692186,
           "resourceSize": 1376009
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2156,
+          "transferSize": 2160,
           "resourceSize": 5070
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692363,
+          "transferSize": 692373,
           "resourceSize": 1376489
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2800,
+          "transferSize": 2803,
           "resourceSize": 7388
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917188,
+          "transferSize": 917186,
           "resourceSize": 1602813
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2837,
+          "transferSize": 2841,
           "resourceSize": 6492
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.19.0.json
+++ b/.github/page_size_audit_results/v1.19.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.19.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:10.706Z"
+    "generatedAt": "2025-12-25T10:46:20.169Z"
   },
-  "timestamp": "2025-12-25T01:00:10.706Z",
+  "timestamp": "2025-12-25T10:46:20.169Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692322,
+          "transferSize": 692327,
           "resourceSize": 1376572
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692290,
+          "transferSize": 692289,
           "resourceSize": 1376569
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7899,
+          "transferSize": 7860,
           "resourceSize": 8841
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484342,
+          "transferSize": 484303,
           "resourceSize": 1187673
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692164,
+          "transferSize": 692162,
           "resourceSize": 1376027
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2087,
+          "transferSize": 2086,
           "resourceSize": 4960
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692302,
+          "transferSize": 692292,
           "resourceSize": 1376379
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692180,
+          "transferSize": 692174,
           "resourceSize": 1376009
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692367,
+          "transferSize": 692369,
           "resourceSize": 1376489
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917189,
+          "transferSize": 917184,
           "resourceSize": 1602813
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699203,
+          "transferSize": 699198,
           "resourceSize": 1388910
         }
       },

--- a/.github/page_size_audit_results/v1.20.0.json
+++ b/.github/page_size_audit_results/v1.20.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.20.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:06:11.529Z"
+    "generatedAt": "2025-12-25T10:46:22.231Z"
   },
-  "timestamp": "2025-12-25T01:06:11.529Z",
+  "timestamp": "2025-12-25T10:46:22.232Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2114,
+          "transferSize": 2113,
           "resourceSize": 5153
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692356,
+          "transferSize": 692357,
           "resourceSize": 1377138
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2081,
+          "transferSize": 2080,
           "resourceSize": 5150
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692319,
+          "transferSize": 692320,
           "resourceSize": 1377135
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 7777,
+          "transferSize": 7867,
           "resourceSize": 8841
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484249,
+          "transferSize": 484339,
           "resourceSize": 1188239
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692195,
+          "transferSize": 692191,
           "resourceSize": 1376593
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692328,
+          "transferSize": 692325,
           "resourceSize": 1376945
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692206,
+          "transferSize": 692208,
           "resourceSize": 1376575
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2158,
+          "transferSize": 2157,
           "resourceSize": 5070
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692395,
+          "transferSize": 692399,
           "resourceSize": 1377055
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 917220,
+          "transferSize": 917218,
           "resourceSize": 1603379
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699228,
+          "transferSize": 699229,
           "resourceSize": 1389476
         }
       },

--- a/.github/page_size_audit_results/v1.21.0.json
+++ b/.github/page_size_audit_results/v1.21.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.21.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:25.868Z"
+    "generatedAt": "2025-12-25T10:46:04.322Z"
   },
-  "timestamp": "2025-12-25T01:00:25.868Z",
+  "timestamp": "2025-12-25T10:46:04.322Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692569,
+          "transferSize": 692566,
           "resourceSize": 1378420
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9095,
+          "transferSize": 9520,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486080,
+          "transferSize": 486505,
           "resourceSize": 1195590
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692397,
+          "transferSize": 692407,
           "resourceSize": 1377875
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692416,
+          "transferSize": 692418,
           "resourceSize": 1377857
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692611,
+          "transferSize": 692608,
           "resourceSize": 1378337
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1322,
+          "transferSize": 1324,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918171,
+          "transferSize": 918173,
           "resourceSize": 1606230
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1118,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699439,
+          "transferSize": 699442,
           "resourceSize": 1390758
         }
       },

--- a/.github/page_size_audit_results/v1.22.0.json
+++ b/.github/page_size_audit_results/v1.22.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.22.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:21.370Z"
+    "generatedAt": "2025-12-25T10:49:00.522Z"
   },
-  "timestamp": "2025-12-25T01:03:21.370Z",
+  "timestamp": "2025-12-25T10:49:00.522Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2137,
+          "transferSize": 2140,
           "resourceSize": 5448
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692669,
+          "transferSize": 692664,
           "resourceSize": 1379006
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2100,
+          "transferSize": 2103,
           "resourceSize": 5438
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692634,
+          "transferSize": 692630,
           "resourceSize": 1378996
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5703,
+          "transferSize": 5704,
           "resourceSize": 23900
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9088,
+          "transferSize": 9591,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486173,
+          "transferSize": 486677,
           "resourceSize": 1196184
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692511,
+          "transferSize": 692504,
           "resourceSize": 1378454
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2101,
+          "transferSize": 2105,
           "resourceSize": 5248
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692632,
+          "transferSize": 692634,
           "resourceSize": 1378806
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2177,
+          "transferSize": 2180,
           "resourceSize": 5358
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692709,
+          "transferSize": 692711,
           "resourceSize": 1378916
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1320,
+          "transferSize": 1316,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918279,
+          "transferSize": 918275,
           "resourceSize": 1606861
         }
       },

--- a/.github/page_size_audit_results/v1.23.0.json
+++ b/.github/page_size_audit_results/v1.23.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.23.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:11.500Z"
+    "generatedAt": "2025-12-25T10:46:21.776Z"
   },
-  "timestamp": "2025-12-25T01:03:11.500Z",
+  "timestamp": "2025-12-25T10:46:21.776Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2140,
+          "transferSize": 2138,
           "resourceSize": 5461
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692704,
+          "transferSize": 692701,
           "resourceSize": 1379103
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2103,
+          "transferSize": 2102,
           "resourceSize": 5438
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692666,
+          "transferSize": 692663,
           "resourceSize": 1379080
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5708,
+          "transferSize": 5705,
           "resourceSize": 23900
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9487,
+          "transferSize": 9110,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486609,
+          "transferSize": 486229,
           "resourceSize": 1196268
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1976,
+          "transferSize": 1974,
           "resourceSize": 4896
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692534,
+          "transferSize": 692538,
           "resourceSize": 1378538
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2106,
+          "transferSize": 2104,
           "resourceSize": 5248
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692670,
+          "transferSize": 692665,
           "resourceSize": 1378890
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1991,
+          "transferSize": 1988,
           "resourceSize": 4878
         },
         "font": {
@@ -387,16 +387,16 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 359,
-          "resourceSize": 272
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 692552,
-          "resourceSize": 1378517
+          "transferSize": 692553,
+          "resourceSize": 1378520
         }
       },
       "themeResources": {
@@ -425,12 +425,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 359,
-          "resourceSize": 272
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 689789,
-          "resourceSize": 1373444
+          "transferSize": 689792,
+          "resourceSize": 1373447
         }
       }
     },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2181,
+          "transferSize": 2180,
           "resourceSize": 5358
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692745,
+          "transferSize": 692744,
           "resourceSize": 1379000
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3027,
+          "transferSize": 3024,
           "resourceSize": 8959
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1322,
+          "transferSize": 1317,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918316,
+          "transferSize": 918308,
           "resourceSize": 1607016
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2869,
+          "transferSize": 2866,
           "resourceSize": 6780
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699585,
+          "transferSize": 699577,
           "resourceSize": 1391421
         }
       },

--- a/.github/page_size_audit_results/v1.24.0.json
+++ b/.github/page_size_audit_results/v1.24.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.24.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:12.170Z"
+    "generatedAt": "2025-12-25T10:46:19.533Z"
   },
-  "timestamp": "2025-12-25T01:00:12.170Z",
+  "timestamp": "2025-12-25T10:46:19.534Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2140,
+          "transferSize": 2141,
           "resourceSize": 5461
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692705,
+          "transferSize": 692702,
           "resourceSize": 1379103
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2104,
+          "transferSize": 2105,
           "resourceSize": 5438
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692669,
+          "transferSize": 692666,
           "resourceSize": 1379080
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9094,
+          "transferSize": 9089,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486215,
+          "transferSize": 486210,
           "resourceSize": 1196268
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692539,
+          "transferSize": 692542,
           "resourceSize": 1378538
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692674,
+          "transferSize": 692670,
           "resourceSize": 1378931
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692560,
+          "transferSize": 692553,
           "resourceSize": 1378520
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2184,
+          "transferSize": 2185,
           "resourceSize": 5399
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692750,
+          "transferSize": 692745,
           "resourceSize": 1379041
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1333,
+          "transferSize": 1317,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918327,
+          "transferSize": 918311,
           "resourceSize": 1607016
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699582,
+          "transferSize": 699579,
           "resourceSize": 1391421
         }
       },

--- a/.github/page_size_audit_results/v1.25.0.json
+++ b/.github/page_size_audit_results/v1.25.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.25.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:26.528Z"
+    "generatedAt": "2025-12-25T10:46:27.513Z"
   },
-  "timestamp": "2025-12-25T01:00:26.528Z",
+  "timestamp": "2025-12-25T10:46:27.513Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2135,
+          "transferSize": 2141,
           "resourceSize": 5461
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692842,
+          "transferSize": 692848,
           "resourceSize": 1379466
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2103,
+          "transferSize": 2109,
           "resourceSize": 5457
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692810,
+          "transferSize": 692819,
           "resourceSize": 1379462
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5702,
+          "transferSize": 5706,
           "resourceSize": 23900
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9497,
+          "transferSize": 9078,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486760,
+          "transferSize": 486345,
           "resourceSize": 1196631
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1974,
+          "transferSize": 1977,
           "resourceSize": 4896
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692677,
+          "transferSize": 692685,
           "resourceSize": 1378901
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2105,
+          "transferSize": 2110,
           "resourceSize": 5289
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692815,
+          "transferSize": 692819,
           "resourceSize": 1379294
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1987,
+          "transferSize": 1990,
           "resourceSize": 4878
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692694,
+          "transferSize": 692696,
           "resourceSize": 1378883
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2179,
+          "transferSize": 2184,
           "resourceSize": 5399
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692889,
+          "transferSize": 692892,
           "resourceSize": 1379404
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3023,
+          "transferSize": 3026,
           "resourceSize": 8959
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1315,
+          "transferSize": 1325,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918452,
+          "transferSize": 918465,
           "resourceSize": 1607379
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2865,
+          "transferSize": 2869,
           "resourceSize": 6780
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.26.0.json
+++ b/.github/page_size_audit_results/v1.26.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.26.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:16.809Z"
+    "generatedAt": "2025-12-25T10:46:17.722Z"
   },
-  "timestamp": "2025-12-25T01:03:16.809Z",
+  "timestamp": "2025-12-25T10:46:17.722Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2136,
+          "transferSize": 2138,
           "resourceSize": 5461
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692842,
+          "transferSize": 692846,
           "resourceSize": 1379466
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2105,
+          "transferSize": 2106,
           "resourceSize": 5457
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692812,
+          "transferSize": 692813,
           "resourceSize": 1379462
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5704,
+          "transferSize": 5705,
           "resourceSize": 23900
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9073,
+          "transferSize": 9087,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 486338,
+          "transferSize": 486353,
           "resourceSize": 1196631
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692681,
+          "transferSize": 692682,
           "resourceSize": 1378901
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2107,
+          "transferSize": 2108,
           "resourceSize": 5289
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2181,
+          "transferSize": 2182,
           "resourceSize": 5399
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692891,
+          "transferSize": 692886,
           "resourceSize": 1379404
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1318,
+          "transferSize": 1320,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918467,
+          "transferSize": 918469,
           "resourceSize": 1607392
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699726,
+          "transferSize": 699728,
           "resourceSize": 1391784
         }
       },

--- a/.github/page_size_audit_results/v1.27.0.json
+++ b/.github/page_size_audit_results/v1.27.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.27.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:02:53.328Z"
+    "generatedAt": "2025-12-25T10:46:17.207Z"
   },
-  "timestamp": "2025-12-25T01:02:53.328Z",
+  "timestamp": "2025-12-25T10:46:17.208Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2244,
-          "resourceSize": 5902
+          "transferSize": 2155,
+          "resourceSize": 5621
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295736,
-          "resourceSize": 940427
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 318748,
-          "resourceSize": 717268
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842037,
-          "resourceSize": 1888073
+          "transferSize": 693388,
+          "resourceSize": 1379201
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2208,
-          "resourceSize": 5898
+          "transferSize": 2119,
+          "resourceSize": 5617
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295736,
-          "resourceSize": 940427
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 318748,
-          "resourceSize": 717268
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841997,
-          "resourceSize": 1888069
+          "transferSize": 693350,
+          "resourceSize": 1379197
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5931,
-          "resourceSize": 24790
+          "transferSize": 5717,
+          "resourceSize": 24060
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 697449,
-          "resourceSize": 2097454
+          "transferSize": 154428,
+          "resourceSize": 444120
         },
         "stylesheet": {
-          "transferSize": 318748,
-          "resourceSize": 717268
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 11959,
-          "resourceSize": 13227
+          "transferSize": 9093,
+          "resourceSize": 11929
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 1034449,
-          "resourceSize": 2853014
+          "transferSize": 486896,
+          "resourceSize": 1196366
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2077,
-          "resourceSize": 5337
+          "transferSize": 1988,
+          "resourceSize": 5056
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295736,
-          "resourceSize": 940427
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 318748,
-          "resourceSize": 717268
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 841867,
-          "resourceSize": 1887508
+          "transferSize": 693219,
+          "resourceSize": 1378636
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2210,
-          "resourceSize": 5730
+          "transferSize": 2121,
+          "resourceSize": 5449
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295736,
-          "resourceSize": 940427
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 318748,
-          "resourceSize": 717268
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 842006,
-          "resourceSize": 1887901
+          "transferSize": 693355,
+          "resourceSize": 1379029
         }
       },
       "themeResources": {
@@ -367,36 +367,36 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2089,
-          "resourceSize": 5319
+          "transferSize": 2002,
+          "resourceSize": 5038
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295736,
-          "resourceSize": 940427
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 318748,
-          "resourceSize": 717268
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 841881,
-          "resourceSize": 1887491
+          "transferSize": 693237,
+          "resourceSize": 1378618
         }
       },
       "themeResources": {
@@ -425,12 +425,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 690465,
-          "resourceSize": 1373386
+          "transferSize": 690464,
+          "resourceSize": 1373385
         }
       }
     },
@@ -438,36 +438,36 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2285,
-          "resourceSize": 5840
+          "transferSize": 2196,
+          "resourceSize": 5559
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295736,
-          "resourceSize": 940427
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 318748,
-          "resourceSize": 717268
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 842077,
-          "resourceSize": 1888012
+          "transferSize": 693429,
+          "resourceSize": 1379139
         }
       },
       "themeResources": {
@@ -496,12 +496,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 690465,
-          "resourceSize": 1373386
+          "transferSize": 690464,
+          "resourceSize": 1373385
         }
       }
     },
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3129,
-          "resourceSize": 9413
+          "transferSize": 3042,
+          "resourceSize": 9132
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 295736,
-          "resourceSize": 940427
+          "transferSize": 148631,
+          "resourceSize": 433122
         },
         "stylesheet": {
-          "transferSize": 318748,
-          "resourceSize": 717268
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1320,
+          "transferSize": 1315,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 1067646,
-          "resourceSize": 2116000
+          "transferSize": 918996,
+          "resourceSize": 1607127
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 914640,
-          "resourceSize": 1597392
+          "transferSize": 914639,
+          "resourceSize": 1597391
         }
       }
     },
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3084,
-          "resourceSize": 7724
+          "transferSize": 2876,
+          "resourceSize": 6940
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 697449,
-          "resourceSize": 2097454
+          "transferSize": 154428,
+          "resourceSize": 444120
         },
         "stylesheet": {
-          "transferSize": 318748,
-          "resourceSize": 717268
+          "transferSize": 317296,
+          "resourceSize": 715982
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 3996,
-          "resourceSize": 1493
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 363,
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 1247815,
-          "resourceSize": 3048221
+          "transferSize": 700260,
+          "resourceSize": 1391519
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.28.0.json
+++ b/.github/page_size_audit_results/v1.28.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.28.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:23.401Z"
+    "generatedAt": "2025-12-25T10:46:20.477Z"
   },
-  "timestamp": "2025-12-25T01:00:23.402Z",
+  "timestamp": "2025-12-25T10:46:20.478Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2231,
-          "resourceSize": 5920
+          "transferSize": 2145,
+          "resourceSize": 5628
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159166,
-          "resourceSize": 471497
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319207,
-          "resourceSize": 717733
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 705915,
-          "resourceSize": 1419626
+          "transferSize": 690233,
+          "resourceSize": 1348646
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2196,
-          "resourceSize": 5909
+          "transferSize": 2110,
+          "resourceSize": 5617
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159166,
-          "resourceSize": 471497
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319207,
-          "resourceSize": 717733
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 705879,
-          "resourceSize": 1419615
+          "transferSize": 690193,
+          "resourceSize": 1348635
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5792,
-          "resourceSize": 24354
+          "transferSize": 5708,
+          "resourceSize": 24062
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 164963,
-          "resourceSize": 482495
+          "transferSize": 151283,
+          "resourceSize": 413555
         },
         "stylesheet": {
-          "transferSize": 319207,
-          "resourceSize": 717733
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9096,
+          "transferSize": 9090,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 499420,
-          "resourceSize": 1236786
+          "transferSize": 483736,
+          "resourceSize": 1165806
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2064,
-          "resourceSize": 5348
+          "transferSize": 1980,
+          "resourceSize": 5056
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159166,
-          "resourceSize": 471497
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319207,
-          "resourceSize": 717733
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 705742,
-          "resourceSize": 1419054
+          "transferSize": 690068,
+          "resourceSize": 1348074
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2196,
-          "resourceSize": 5741
+          "transferSize": 2112,
+          "resourceSize": 5449
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159166,
-          "resourceSize": 471497
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319207,
-          "resourceSize": 717733
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 705878,
-          "resourceSize": 1419447
+          "transferSize": 690198,
+          "resourceSize": 1348467
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2078,
-          "resourceSize": 5330
+          "transferSize": 1994,
+          "resourceSize": 5038
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159166,
-          "resourceSize": 471497
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319207,
-          "resourceSize": 717733
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 705759,
-          "resourceSize": 1419036
+          "transferSize": 690088,
+          "resourceSize": 1348056
         }
       },
       "themeResources": {
@@ -438,20 +438,20 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2273,
-          "resourceSize": 5851
+          "transferSize": 2187,
+          "resourceSize": 5559
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159166,
-          "resourceSize": 471497
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319207,
-          "resourceSize": 717733
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 705954,
-          "resourceSize": 1419557
+          "transferSize": 690274,
+          "resourceSize": 1348577
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3118,
-          "resourceSize": 9424
+          "transferSize": 3033,
+          "resourceSize": 9132
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159166,
-          "resourceSize": 471497
+          "transferSize": 145486,
+          "resourceSize": 402557
         },
         "stylesheet": {
-          "transferSize": 319207,
-          "resourceSize": 717733
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1324,
+          "transferSize": 1316,
           "resourceSize": 604
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 931528,
-          "resourceSize": 1647546
+          "transferSize": 915840,
+          "resourceSize": 1576565
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 911492,
-          "resourceSize": 1566830
+          "transferSize": 911491,
+          "resourceSize": 1566829
         }
       }
     },
@@ -580,27 +580,27 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2949,
-          "resourceSize": 7234
+          "transferSize": 2868,
+          "resourceSize": 6942
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 164963,
-          "resourceSize": 482495
+          "transferSize": 151283,
+          "resourceSize": 413555
         },
         "stylesheet": {
-          "transferSize": 319207,
-          "resourceSize": 717733
+          "transferSize": 317293,
+          "resourceSize": 715985
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 712784,
-          "resourceSize": 1431939
+          "transferSize": 697106,
+          "resourceSize": 1360959
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.29.0.json
+++ b/.github/page_size_audit_results/v1.29.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.29.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:19.293Z"
+    "generatedAt": "2025-12-25T10:49:06.535Z"
   },
-  "timestamp": "2025-12-25T01:00:19.293Z",
+  "timestamp": "2025-12-25T10:49:06.536Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2145,
+          "transferSize": 2146,
           "resourceSize": 5633
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690232,
+          "transferSize": 690228,
           "resourceSize": 1348651
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2110,
+          "transferSize": 2111,
           "resourceSize": 5622
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690199,
+          "transferSize": 690195,
           "resourceSize": 1348640
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9493,
+          "transferSize": 9088,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484139,
+          "transferSize": 483734,
           "resourceSize": 1165811
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690065,
+          "transferSize": 690066,
           "resourceSize": 1348079
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2112,
+          "transferSize": 2113,
           "resourceSize": 5454
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690197,
+          "transferSize": 690202,
           "resourceSize": 1348472
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690078,
+          "transferSize": 690077,
           "resourceSize": 1348061
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2187,
+          "transferSize": 2188,
           "resourceSize": 5564
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690271,
+          "transferSize": 690278,
           "resourceSize": 1348582
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1316,
+          "transferSize": 1311,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915838,
+          "transferSize": 915833,
           "resourceSize": 1576570
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697107,
+          "transferSize": 697103,
           "resourceSize": 1360964
         }
       },

--- a/.github/page_size_audit_results/v1.29.1.json
+++ b/.github/page_size_audit_results/v1.29.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.29.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:13.331Z"
+    "generatedAt": "2025-12-25T10:46:14.408Z"
   },
-  "timestamp": "2025-12-25T01:00:13.331Z",
+  "timestamp": "2025-12-25T10:46:14.408Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2145,
+          "transferSize": 2146,
           "resourceSize": 5633
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690230,
+          "transferSize": 690239,
           "resourceSize": 1348669
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2109,
+          "transferSize": 2110,
           "resourceSize": 5622
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690197,
+          "transferSize": 690204,
           "resourceSize": 1348658
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5708,
+          "transferSize": 5707,
           "resourceSize": 24067
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9099,
+          "transferSize": 9517,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483750,
+          "transferSize": 484167,
           "resourceSize": 1165829
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690071,
+          "transferSize": 690077,
           "resourceSize": 1348097
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2112,
+          "transferSize": 2113,
           "resourceSize": 5454
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690203,
+          "transferSize": 690205,
           "resourceSize": 1348490
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690084,
+          "transferSize": 690085,
           "resourceSize": 1348079
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2187,
+          "transferSize": 2188,
           "resourceSize": 5564
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690272,
+          "transferSize": 690277,
           "resourceSize": 1348600
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1317,
+          "transferSize": 1321,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915844,
+          "transferSize": 915848,
           "resourceSize": 1576588
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697108,
+          "transferSize": 697105,
           "resourceSize": 1360982
         }
       },

--- a/.github/page_size_audit_results/v1.30.0.json
+++ b/.github/page_size_audit_results/v1.30.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.30.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:07.341Z"
+    "generatedAt": "2025-12-25T10:46:20.159Z"
   },
-  "timestamp": "2025-12-25T01:03:07.342Z",
+  "timestamp": "2025-12-25T10:46:20.159Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2153,
+          "transferSize": 2151,
           "resourceSize": 5712
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690258,
+          "transferSize": 690255,
           "resourceSize": 1348699
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2115,
+          "transferSize": 2113,
           "resourceSize": 5701
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690217,
+          "transferSize": 690215,
           "resourceSize": 1348688
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5720,
+          "transferSize": 5717,
           "resourceSize": 24162
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9075,
+          "transferSize": 9090,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483747,
+          "transferSize": 483759,
           "resourceSize": 1165875
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1986,
+          "transferSize": 1984,
           "resourceSize": 5140
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690087,
+          "transferSize": 690082,
           "resourceSize": 1348127
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2118,
+          "transferSize": 2116,
           "resourceSize": 5533
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690218,
+          "transferSize": 690219,
           "resourceSize": 1348520
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1998,
+          "transferSize": 1996,
           "resourceSize": 5122
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690100,
+          "transferSize": 690095,
           "resourceSize": 1348109
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2192,
+          "transferSize": 2191,
           "resourceSize": 5643
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690295,
+          "transferSize": 690292,
           "resourceSize": 1348630
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3041,
+          "transferSize": 3038,
           "resourceSize": 9216
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1315,
+          "transferSize": 1318,
           "resourceSize": 604
         },
         "other": {
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2882,
+          "transferSize": 2878,
           "resourceSize": 7048
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1118,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697136,
+          "transferSize": 697124,
           "resourceSize": 1361034
         }
       },

--- a/.github/page_size_audit_results/v1.31.0.json
+++ b/.github/page_size_audit_results/v1.31.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.31.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:12.761Z"
+    "generatedAt": "2025-12-25T10:49:07.086Z"
   },
-  "timestamp": "2025-12-25T01:03:12.761Z",
+  "timestamp": "2025-12-25T10:49:07.087Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2148,
+          "transferSize": 2149,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690244,
+          "transferSize": 690252,
           "resourceSize": 1348703
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690218,
+          "transferSize": 690216,
           "resourceSize": 1348692
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5712,
+          "transferSize": 5713,
           "resourceSize": 24170
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9510,
+          "transferSize": 9094,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484174,
+          "transferSize": 483759,
           "resourceSize": 1165883
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690082,
+          "transferSize": 690081,
           "resourceSize": 1348131
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690214,
+          "transferSize": 690210,
           "resourceSize": 1348524
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690094,
+          "transferSize": 690097,
           "resourceSize": 1348113
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690292,
+          "transferSize": 690285,
           "resourceSize": 1348634
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1322,
+          "transferSize": 1324,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915861,
+          "transferSize": 915863,
           "resourceSize": 1576622
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697122,
+          "transferSize": 697128,
           "resourceSize": 1361038
         }
       },

--- a/.github/page_size_audit_results/v1.32.0.json
+++ b/.github/page_size_audit_results/v1.32.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.32.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:19.151Z"
+    "generatedAt": "2025-12-25T10:46:33.082Z"
   },
-  "timestamp": "2025-12-25T01:00:19.151Z",
+  "timestamp": "2025-12-25T10:46:33.083Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2151,
+          "transferSize": 2149,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690274,
+          "transferSize": 690273,
           "resourceSize": 1348816
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2116,
+          "transferSize": 2114,
           "resourceSize": 5705
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690236,
+          "transferSize": 690239,
           "resourceSize": 1348805
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5734,
+          "transferSize": 5732,
           "resourceSize": 24244
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9536,
+          "transferSize": 9106,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484245,
+          "transferSize": 483813,
           "resourceSize": 1166070
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1982,
+          "transferSize": 1978,
           "resourceSize": 5144
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690103,
+          "transferSize": 690105,
           "resourceSize": 1348244
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2116,
+          "transferSize": 2114,
           "resourceSize": 5537
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1994,
+          "transferSize": 1991,
           "resourceSize": 5126
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690117,
+          "transferSize": 690115,
           "resourceSize": 1348226
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2189,
+          "transferSize": 2188,
           "resourceSize": 5647
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690312,
+          "transferSize": 690311,
           "resourceSize": 1348747
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3037,
+          "transferSize": 3034,
           "resourceSize": 9220
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1323,
+          "transferSize": 1328,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915888,
+          "transferSize": 915890,
           "resourceSize": 1576735
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2877,
+          "transferSize": 2874,
           "resourceSize": 7052
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1116,
+          "transferSize": 1121,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697144,
+          "transferSize": 697146,
           "resourceSize": 1361151
         }
       },

--- a/.github/page_size_audit_results/v1.32.1.json
+++ b/.github/page_size_audit_results/v1.32.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.32.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:09.159Z"
+    "generatedAt": "2025-12-25T10:46:12.895Z"
   },
-  "timestamp": "2025-12-25T01:03:09.160Z",
+  "timestamp": "2025-12-25T10:46:12.896Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2151,
+          "transferSize": 2152,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690309,
+          "transferSize": 690313,
           "resourceSize": 1348953
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690272,
+          "transferSize": 690277,
           "resourceSize": 1348942
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9071,
+          "transferSize": 9096,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483812,
+          "transferSize": 483837,
           "resourceSize": 1166253
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690139,
+          "transferSize": 690141,
           "resourceSize": 1348381
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2115,
+          "transferSize": 2116,
           "resourceSize": 5537
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690273,
+          "transferSize": 690280,
           "resourceSize": 1348774
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690152,
+          "transferSize": 690161,
           "resourceSize": 1348363
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2188,
+          "transferSize": 2189,
           "resourceSize": 5647
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690351,
+          "transferSize": 690349,
           "resourceSize": 1348884
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1317,
+          "transferSize": 1309,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915918,
+          "transferSize": 915910,
           "resourceSize": 1576872
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697190,
+          "transferSize": 697187,
           "resourceSize": 1361288
         }
       },

--- a/.github/page_size_audit_results/v1.33.0.json
+++ b/.github/page_size_audit_results/v1.33.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.33.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:20.810Z"
+    "generatedAt": "2025-12-25T10:49:09.699Z"
   },
-  "timestamp": "2025-12-25T01:00:20.811Z",
+  "timestamp": "2025-12-25T10:49:09.700Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2153,
+          "transferSize": 2149,
           "resourceSize": 5716
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690312,
+          "transferSize": 690308,
           "resourceSize": 1348953
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2113,
           "resourceSize": 5705
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690281,
+          "transferSize": 690270,
           "resourceSize": 1348942
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5730,
+          "transferSize": 5727,
           "resourceSize": 24295
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9482,
+          "transferSize": 9081,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 484224,
+          "transferSize": 483820,
           "resourceSize": 1166258
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1983,
+          "transferSize": 1980,
           "resourceSize": 5144
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690143,
+          "transferSize": 690140,
           "resourceSize": 1348381
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2117,
+          "transferSize": 2114,
           "resourceSize": 5537
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690277,
+          "transferSize": 690273,
           "resourceSize": 1348774
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1995,
+          "transferSize": 1992,
           "resourceSize": 5126
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690153,
+          "transferSize": 690148,
           "resourceSize": 1348363
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2190,
+          "transferSize": 2188,
           "resourceSize": 5647
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690358,
+          "transferSize": 690344,
           "resourceSize": 1348884
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3038,
+          "transferSize": 3035,
           "resourceSize": 9220
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915923,
+          "transferSize": 915920,
           "resourceSize": 1576872
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2878,
+          "transferSize": 2875,
           "resourceSize": 7052
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1127,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697193,
+          "transferSize": 697186,
           "resourceSize": 1361288
         }
       },

--- a/.github/page_size_audit_results/v1.34.0.json
+++ b/.github/page_size_audit_results/v1.34.0.json
@@ -4,24 +4,24 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.34.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:10.929Z"
+    "generatedAt": "2025-12-25T10:46:20.882Z"
   },
-  "timestamp": "2025-12-25T01:00:10.929Z",
+  "timestamp": "2025-12-25T10:46:20.882Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2214,
-          "resourceSize": 5866
+          "transferSize": 2149,
+          "resourceSize": 5716
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158125,
-          "resourceSize": 447133
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 702993,
-          "resourceSize": 1393673
+          "transferSize": 690309,
+          "resourceSize": 1348953
         }
       },
       "themeResources": {
@@ -83,16 +83,16 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2179,
-          "resourceSize": 5855
+          "transferSize": 2114,
+          "resourceSize": 5705
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158125,
-          "resourceSize": 447133
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 702950,
-          "resourceSize": 1393662
+          "transferSize": 690280,
+          "resourceSize": 1348942
         }
       },
       "themeResources": {
@@ -154,16 +154,16 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5574,
-          "resourceSize": 24171
+          "transferSize": 5439,
+          "resourceSize": 23874
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 163922,
-          "resourceSize": 458131
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9082,
+          "transferSize": 9075,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 496282,
-          "resourceSize": 1210704
+          "transferSize": 483526,
+          "resourceSize": 1165837
         }
       },
       "themeResources": {
@@ -225,16 +225,16 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2044,
-          "resourceSize": 5294
+          "transferSize": 1980,
+          "resourceSize": 5144
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158125,
-          "resourceSize": 447133
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 702823,
-          "resourceSize": 1393101
+          "transferSize": 690143,
+          "resourceSize": 1348381
         }
       },
       "themeResources": {
@@ -296,16 +296,16 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2180,
-          "resourceSize": 5687
+          "transferSize": 2114,
+          "resourceSize": 5537
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158125,
-          "resourceSize": 447133
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 702949,
-          "resourceSize": 1393494
+          "transferSize": 690270,
+          "resourceSize": 1348774
         }
       },
       "themeResources": {
@@ -367,16 +367,16 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2058,
-          "resourceSize": 5276
+          "transferSize": 1992,
+          "resourceSize": 5126
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158125,
-          "resourceSize": 447133
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 702835,
-          "resourceSize": 1393083
+          "transferSize": 690152,
+          "resourceSize": 1348363
         }
       },
       "themeResources": {
@@ -438,16 +438,16 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2255,
-          "resourceSize": 5797
+          "transferSize": 2189,
+          "resourceSize": 5647
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158125,
-          "resourceSize": 447133
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703029,
-          "resourceSize": 1393604
+          "transferSize": 690350,
+          "resourceSize": 1348884
         }
       },
       "themeResources": {
@@ -509,16 +509,16 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3096,
-          "resourceSize": 9370
+          "transferSize": 3035,
+          "resourceSize": 9220
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 158125,
-          "resourceSize": 447133
+          "transferSize": 145511,
+          "resourceSize": 402563
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1319,
+          "transferSize": 1314,
           "resourceSize": 604
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 928594,
-          "resourceSize": 1621592
+          "transferSize": 915914,
+          "resourceSize": 1576872
         }
       },
       "themeResources": {
@@ -580,16 +580,16 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2988,
-          "resourceSize": 7347
+          "transferSize": 2867,
+          "resourceSize": 7050
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 163922,
-          "resourceSize": 458131
+          "transferSize": 151308,
+          "resourceSize": 413561
         },
         "stylesheet": {
           "transferSize": 317342,
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1119,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,8 +608,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 709909,
-          "resourceSize": 1406153
+          "transferSize": 697175,
+          "resourceSize": 1361286
         }
       },
       "themeResources": {

--- a/.github/page_size_audit_results/v1.34.1.json
+++ b/.github/page_size_audit_results/v1.34.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.34.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:20.537Z"
+    "generatedAt": "2025-12-25T10:49:02.881Z"
   },
-  "timestamp": "2025-12-25T01:00:20.538Z",
+  "timestamp": "2025-12-25T10:49:02.882Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2166,
+          "transferSize": 2165,
           "resourceSize": 5770
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690445,
+          "transferSize": 690450,
           "resourceSize": 1350739
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2127,
+          "transferSize": 2126,
           "resourceSize": 5759
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5459,
+          "transferSize": 5460,
           "resourceSize": 23928
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9088,
+          "transferSize": 9085,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 483682,
+          "transferSize": 483680,
           "resourceSize": 1167623
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 780,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690280,
+          "transferSize": 690289,
           "resourceSize": 1350167
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2131,
+          "transferSize": 2129,
           "resourceSize": 5591
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690414,
+          "transferSize": 690413,
           "resourceSize": 1350560
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690291,
+          "transferSize": 690287,
           "resourceSize": 1350149
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2205,
+          "transferSize": 2203,
           "resourceSize": 5701
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690488,
+          "transferSize": 690486,
           "resourceSize": 1350670
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3069,
+          "transferSize": 3070,
           "resourceSize": 9266
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1317,
+          "transferSize": 1320,
           "resourceSize": 604
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 916074,
+          "transferSize": 916078,
           "resourceSize": 1578650
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 697316,
+          "transferSize": 697317,
           "resourceSize": 1363072
         }
       },

--- a/.github/page_size_audit_results/v1.35.0.json
+++ b/.github/page_size_audit_results/v1.35.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.35.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:06:20.161Z"
+    "generatedAt": "2025-12-25T10:46:12.952Z"
   },
-  "timestamp": "2025-12-25T01:06:20.162Z",
+  "timestamp": "2025-12-25T10:46:12.952Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2165,
+          "transferSize": 2167,
           "resourceSize": 5783
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689419,
+          "transferSize": 689417,
           "resourceSize": 1345673
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2126,
+          "transferSize": 2128,
           "resourceSize": 5768
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689380,
+          "transferSize": 689381,
           "resourceSize": 1345658
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5241,
+          "transferSize": 5244,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9089,
+          "transferSize": 9527,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478651,
+          "transferSize": 479092,
           "resourceSize": 1153244
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1995,
+          "transferSize": 1998,
           "resourceSize": 5207
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689253,
+          "transferSize": 689256,
           "resourceSize": 1345097
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2130,
+          "transferSize": 2131,
           "resourceSize": 5600
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689390,
+          "transferSize": 689381,
           "resourceSize": 1345490
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2009,
+          "transferSize": 2011,
           "resourceSize": 5189
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689261,
+          "transferSize": 689269,
           "resourceSize": 1345079
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2204,
+          "transferSize": 2205,
           "resourceSize": 5710
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689462,
+          "transferSize": 689457,
           "resourceSize": 1345600
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3080,
+          "transferSize": 3084,
           "resourceSize": 9307
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1283,
+          "transferSize": 1281,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915023,
+          "transferSize": 915025,
           "resourceSize": 1573565
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2361,
+          "transferSize": 2365,
           "resourceSize": 5976
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691978,
+          "transferSize": 691981,
           "resourceSize": 1347704
         }
       },

--- a/.github/page_size_audit_results/v1.36.0.json
+++ b/.github/page_size_audit_results/v1.36.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.36.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:15.533Z"
+    "generatedAt": "2025-12-25T10:46:22.312Z"
   },
-  "timestamp": "2025-12-25T01:00:15.533Z",
+  "timestamp": "2025-12-25T10:46:22.312Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2170,
+          "transferSize": 2169,
           "resourceSize": 5788
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689270,
+          "transferSize": 689265,
           "resourceSize": 1345259
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689232,
+          "transferSize": 689225,
           "resourceSize": 1345239
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9513,
+          "transferSize": 9077,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478922,
+          "transferSize": 478486,
           "resourceSize": 1152825
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689098,
+          "transferSize": 689096,
           "resourceSize": 1344678
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2132,
+          "transferSize": 2133,
           "resourceSize": 5600
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 763,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689224,
+          "transferSize": 689231,
           "resourceSize": 1345071
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689105,
+          "transferSize": 689107,
           "resourceSize": 1344660
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689302,
+          "transferSize": 689309,
           "resourceSize": 1345181
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1290,
+          "transferSize": 1297,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 914878,
+          "transferSize": 914885,
           "resourceSize": 1573146
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691827,
+          "transferSize": 691829,
           "resourceSize": 1347285
         }
       },

--- a/.github/page_size_audit_results/v1.37.0.json
+++ b/.github/page_size_audit_results/v1.37.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.37.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:07.477Z"
+    "generatedAt": "2025-12-25T10:46:18.393Z"
   },
-  "timestamp": "2025-12-25T01:03:07.478Z",
+  "timestamp": "2025-12-25T10:46:18.393Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2169,
-          "resourceSize": 5788
+          "transferSize": 2255,
+          "resourceSize": 6080
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145356,
-          "resourceSize": 402288
+          "transferSize": 159036,
+          "resourceSize": 471228
         },
         "stylesheet": {
-          "transferSize": 317134,
-          "resourceSize": 730498
+          "transferSize": 319048,
+          "resourceSize": 732246
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689962,
-          "resourceSize": 1363050
+          "transferSize": 705649,
+          "resourceSize": 1434030
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2130,
-          "resourceSize": 5768
+          "transferSize": 2212,
+          "resourceSize": 6060
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145356,
-          "resourceSize": 402288
+          "transferSize": 159036,
+          "resourceSize": 471228
         },
         "stylesheet": {
-          "transferSize": 317134,
-          "resourceSize": 730498
+          "transferSize": 319048,
+          "resourceSize": 732246
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689926,
-          "resourceSize": 1363030
+          "transferSize": 705601,
+          "resourceSize": 1434010
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5244,
-          "resourceSize": 23788
+          "transferSize": 5328,
+          "resourceSize": 24080
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147367,
-          "resourceSize": 404126
+          "transferSize": 161047,
+          "resourceSize": 473066
         },
         "stylesheet": {
-          "transferSize": 317134,
-          "resourceSize": 730498
+          "transferSize": 319048,
+          "resourceSize": 732246
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9498,
+          "transferSize": 9094,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479605,
-          "resourceSize": 1170616
+          "transferSize": 494879,
+          "resourceSize": 1241596
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1997,
-          "resourceSize": 5207
+          "transferSize": 2081,
+          "resourceSize": 5499
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145356,
-          "resourceSize": 402288
+          "transferSize": 159036,
+          "resourceSize": 471228
         },
         "stylesheet": {
-          "transferSize": 317134,
-          "resourceSize": 730498
+          "transferSize": 319048,
+          "resourceSize": 732246
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689793,
-          "resourceSize": 1362469
+          "transferSize": 705470,
+          "resourceSize": 1433449
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2133,
-          "resourceSize": 5600
+          "transferSize": 2216,
+          "resourceSize": 5892
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145356,
-          "resourceSize": 402288
+          "transferSize": 159036,
+          "resourceSize": 471228
         },
         "stylesheet": {
-          "transferSize": 317134,
-          "resourceSize": 730498
+          "transferSize": 319048,
+          "resourceSize": 732246
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689932,
-          "resourceSize": 1362862
+          "transferSize": 705604,
+          "resourceSize": 1433842
         }
       },
       "themeResources": {
@@ -367,27 +367,27 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2011,
-          "resourceSize": 5189
+          "transferSize": 2095,
+          "resourceSize": 5481
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145356,
-          "resourceSize": 402288
+          "transferSize": 159036,
+          "resourceSize": 471228
         },
         "stylesheet": {
-          "transferSize": 317134,
-          "resourceSize": 730498
+          "transferSize": 319048,
+          "resourceSize": 732246
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689806,
-          "resourceSize": 1362451
+          "transferSize": 705485,
+          "resourceSize": 1433431
         }
       },
       "themeResources": {
@@ -438,20 +438,20 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2207,
-          "resourceSize": 5710
+          "transferSize": 2291,
+          "resourceSize": 6002
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145356,
-          "resourceSize": 402288
+          "transferSize": 159036,
+          "resourceSize": 471228
         },
         "stylesheet": {
-          "transferSize": 317134,
-          "resourceSize": 730498
+          "transferSize": 319048,
+          "resourceSize": 732246
         },
         "image": {
           "transferSize": 224175,
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690003,
-          "resourceSize": 1362972
+          "transferSize": 705681,
+          "resourceSize": 1433952
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3155,
-          "resourceSize": 9638
+          "transferSize": 3248,
+          "resourceSize": 9930
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145356,
-          "resourceSize": 402288
+          "transferSize": 159036,
+          "resourceSize": 471228
         },
         "stylesheet": {
-          "transferSize": 317134,
-          "resourceSize": 730498
+          "transferSize": 319048,
+          "resourceSize": 732246
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1282,
+          "transferSize": 1278,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 915639,
-          "resourceSize": 1591268
+          "transferSize": 931323,
+          "resourceSize": 1662249
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 911202,
-          "resourceSize": 1581073
+          "transferSize": 911203,
+          "resourceSize": 1581074
         }
       }
     },
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2365,
-          "resourceSize": 5976
+          "transferSize": 2439,
+          "resourceSize": 6268
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 147367,
-          "resourceSize": 404126
+          "transferSize": 161047,
+          "resourceSize": 473066
         },
         "stylesheet": {
-          "transferSize": 317134,
-          "resourceSize": 730498
+          "transferSize": 319048,
+          "resourceSize": 732246
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 692524,
-          "resourceSize": 1365076
+          "transferSize": 708198,
+          "resourceSize": 1436057
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 362,
-          "resourceSize": 275
+          "transferSize": 363,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 687027,
-          "resourceSize": 1357067
+          "transferSize": 687028,
+          "resourceSize": 1357068
         }
       }
     }

--- a/.github/page_size_audit_results/v1.38.0.json
+++ b/.github/page_size_audit_results/v1.38.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.38.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:23.003Z"
+    "generatedAt": "2025-12-25T10:46:24.625Z"
   },
-  "timestamp": "2025-12-25T01:03:23.003Z",
+  "timestamp": "2025-12-25T10:46:24.626Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2168,
+          "transferSize": 2169,
           "resourceSize": 5788
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690135,
+          "transferSize": 690137,
           "resourceSize": 1363343
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2128,
+          "transferSize": 2129,
           "resourceSize": 5768
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690093,
+          "transferSize": 690101,
           "resourceSize": 1363323
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5242,
+          "transferSize": 5244,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9065,
+          "transferSize": 9085,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479343,
+          "transferSize": 479365,
           "resourceSize": 1170909
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689976,
+          "transferSize": 689979,
           "resourceSize": 1362817
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2136,
+          "transferSize": 2138,
           "resourceSize": 5638
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690111,
+          "transferSize": 690113,
           "resourceSize": 1363193
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689978,
+          "transferSize": 689985,
           "resourceSize": 1362744
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2212,
+          "transferSize": 2213,
           "resourceSize": 5748
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1278,
+          "transferSize": 1282,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915823,
+          "transferSize": 915827,
           "resourceSize": 1591629
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692699,
+          "transferSize": 692700,
           "resourceSize": 1365369
         }
       },

--- a/.github/page_size_audit_results/v1.39.0.json
+++ b/.github/page_size_audit_results/v1.39.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.39.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:01.263Z"
+    "generatedAt": "2025-12-25T10:46:23.064Z"
   },
-  "timestamp": "2025-12-25T01:00:01.264Z",
+  "timestamp": "2025-12-25T10:46:23.065Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2190,
+          "transferSize": 2192,
           "resourceSize": 5873
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690155,
+          "transferSize": 690163,
           "resourceSize": 1363368
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2149,
+          "transferSize": 2152,
           "resourceSize": 5853
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690116,
+          "transferSize": 690123,
           "resourceSize": 1363348
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5269,
+          "transferSize": 5275,
           "resourceSize": 23873
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9479,
+          "transferSize": 9570,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479784,
+          "transferSize": 479881,
           "resourceSize": 1170934
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2030,
+          "transferSize": 2033,
           "resourceSize": 5347
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 689996,
+          "transferSize": 690007,
           "resourceSize": 1362842
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2159,
+          "transferSize": 2162,
           "resourceSize": 5723
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690126,
+          "transferSize": 690132,
           "resourceSize": 1363218
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2033,
+          "transferSize": 2035,
           "resourceSize": 5274
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690002,
+          "transferSize": 690007,
           "resourceSize": 1362769
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2232,
+          "transferSize": 2236,
           "resourceSize": 5833
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690201,
+          "transferSize": 690200,
           "resourceSize": 1363328
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3193,
+          "transferSize": 3197,
           "resourceSize": 9791
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1282,
+          "transferSize": 1281,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 915850,
+          "transferSize": 915853,
           "resourceSize": 1591654
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2384,
+          "transferSize": 2387,
           "resourceSize": 6061
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692719,
+          "transferSize": 692720,
           "resourceSize": 1365394
         }
       },

--- a/.github/page_size_audit_results/v1.40.0.json
+++ b/.github/page_size_audit_results/v1.40.0.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.40.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:02.941Z"
+    "generatedAt": "2025-12-25T10:46:27.632Z"
   },
-  "timestamp": "2025-12-25T01:03:02.941Z",
+  "timestamp": "2025-12-25T10:46:27.632Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2291,
-          "resourceSize": 6214
+          "transferSize": 2206,
+          "resourceSize": 5922
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159897,
-          "resourceSize": 473996
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319042,
-          "resourceSize": 732176
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706536,
-          "resourceSize": 1436862
+          "transferSize": 690862,
+          "resourceSize": 1365882
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2248,
-          "resourceSize": 6194
+          "transferSize": 2165,
+          "resourceSize": 5902
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159897,
-          "resourceSize": 473996
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319042,
-          "resourceSize": 732176
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706490,
-          "resourceSize": 1436842
+          "transferSize": 690816,
+          "resourceSize": 1365862
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5329,
-          "resourceSize": 24186
+          "transferSize": 5254,
+          "resourceSize": 23894
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161908,
-          "resourceSize": 475834
+          "transferSize": 148228,
+          "resourceSize": 406894
         },
         "stylesheet": {
-          "transferSize": 319042,
-          "resourceSize": 732176
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9486,
+          "transferSize": 9074,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 496127,
-          "resourceSize": 1244400
+          "transferSize": 480046,
+          "resourceSize": 1173420
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2129,
-          "resourceSize": 5688
+          "transferSize": 2047,
+          "resourceSize": 5396
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159897,
-          "resourceSize": 473996
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319042,
-          "resourceSize": 732176
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706381,
-          "resourceSize": 1436336
+          "transferSize": 690699,
+          "resourceSize": 1365356
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2259,
-          "resourceSize": 6064
+          "transferSize": 2176,
+          "resourceSize": 5772
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159897,
-          "resourceSize": 473996
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319042,
-          "resourceSize": 732176
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706506,
-          "resourceSize": 1436712
+          "transferSize": 690832,
+          "resourceSize": 1365732
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2130,
-          "resourceSize": 5615
+          "transferSize": 2047,
+          "resourceSize": 5323
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159897,
-          "resourceSize": 473996
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319042,
-          "resourceSize": 732176
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706376,
-          "resourceSize": 1436263
+          "transferSize": 690699,
+          "resourceSize": 1365283
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2335,
-          "resourceSize": 6174
+          "transferSize": 2250,
+          "resourceSize": 5882
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159897,
-          "resourceSize": 473996
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319042,
-          "resourceSize": 732176
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 706580,
-          "resourceSize": 1436822
+          "transferSize": 690907,
+          "resourceSize": 1365842
         }
       },
       "themeResources": {
@@ -509,36 +509,36 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3288,
-          "resourceSize": 10132
+          "transferSize": 3209,
+          "resourceSize": 9840
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 159897,
-          "resourceSize": 473996
+          "transferSize": 146217,
+          "resourceSize": 405056
         },
         "stylesheet": {
-          "transferSize": 319042,
-          "resourceSize": 732176
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1281,
+          "transferSize": 1279,
           "resourceSize": 557
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 932221,
-          "resourceSize": 1665149
+          "transferSize": 916545,
+          "resourceSize": 1594168
         }
       },
       "themeResources": {
@@ -567,12 +567,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 912058,
-          "resourceSize": 1583772
+          "transferSize": 912057,
+          "resourceSize": 1583771
         }
       }
     },
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2483,
-          "resourceSize": 6412
+          "transferSize": 2399,
+          "resourceSize": 6120
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 161908,
-          "resourceSize": 475834
+          "transferSize": 148228,
+          "resourceSize": 406894
         },
         "stylesheet": {
-          "transferSize": 319042,
-          "resourceSize": 732176
+          "transferSize": 317128,
+          "resourceSize": 730428
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1126,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 709093,
-          "resourceSize": 1438899
+          "transferSize": 693418,
+          "resourceSize": 1367918
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 687883,
-          "resourceSize": 1359766
+          "transferSize": 687882,
+          "resourceSize": 1359765
         }
       }
     }

--- a/.github/page_size_audit_results/v1.40.1.json
+++ b/.github/page_size_audit_results/v1.40.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.40.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:09.737Z"
+    "generatedAt": "2025-12-25T10:46:25.555Z"
   },
-  "timestamp": "2025-12-25T01:03:09.738Z",
+  "timestamp": "2025-12-25T10:46:25.555Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656882,
+          "transferSize": 656887,
           "resourceSize": 1280081
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2147,
+          "transferSize": 2150,
           "resourceSize": 5790
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656842,
+          "transferSize": 656847,
           "resourceSize": 1280061
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5239,
+          "transferSize": 5240,
           "resourceSize": 23782
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9494,
+          "transferSize": 9124,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 446494,
+          "transferSize": 446125,
           "resourceSize": 1087619
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656728,
+          "transferSize": 656727,
           "resourceSize": 1279555
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2160,
+          "transferSize": 2161,
           "resourceSize": 5660
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656852,
+          "transferSize": 656860,
           "resourceSize": 1279931
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656725,
+          "transferSize": 656729,
           "resourceSize": 1279482
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2234,
+          "transferSize": 2235,
           "resourceSize": 5770
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656927,
+          "transferSize": 656931,
           "resourceSize": 1280041
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1280,
+          "transferSize": 1283,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 882569,
+          "transferSize": 882572,
           "resourceSize": 1508367
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 659445,
+          "transferSize": 659442,
           "resourceSize": 1282117
         }
       },

--- a/.github/page_size_audit_results/v1.41.0.json
+++ b/.github/page_size_audit_results/v1.41.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:05:54.019Z"
+    "generatedAt": "2025-12-25T10:46:47.281Z"
   },
-  "timestamp": "2025-12-25T01:05:54.019Z",
+  "timestamp": "2025-12-25T10:46:47.282Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2191,
+          "transferSize": 2193,
           "resourceSize": 5816
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656884,
+          "transferSize": 656889,
           "resourceSize": 1280087
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2151,
+          "transferSize": 2152,
           "resourceSize": 5796
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656846,
+          "transferSize": 656842,
           "resourceSize": 1280067
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5243,
+          "transferSize": 5244,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9504,
+          "transferSize": 9083,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 446508,
+          "transferSize": 446088,
           "resourceSize": 1087625
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656732,
+          "transferSize": 656731,
           "resourceSize": 1279561
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2162,
+          "transferSize": 2163,
           "resourceSize": 5666
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656860,
+          "transferSize": 656858,
           "resourceSize": 1279937
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656735,
+          "transferSize": 656728,
           "resourceSize": 1279488
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2236,
+          "transferSize": 2237,
           "resourceSize": 5776
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656929,
+          "transferSize": 656933,
           "resourceSize": 1280047
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1279,
+          "transferSize": 1278,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 882569,
+          "transferSize": 882568,
           "resourceSize": 1508373
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 659450,
+          "transferSize": 659449,
           "resourceSize": 1282123
         }
       },

--- a/.github/page_size_audit_results/v1.41.1.json
+++ b/.github/page_size_audit_results/v1.41.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:07.745Z"
+    "generatedAt": "2025-12-25T10:46:16.582Z"
   },
-  "timestamp": "2025-12-25T01:03:07.746Z",
+  "timestamp": "2025-12-25T10:46:16.582Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2190,
+          "transferSize": 2194,
           "resourceSize": 5816
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656883,
+          "transferSize": 656891,
           "resourceSize": 1280087
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2149,
+          "transferSize": 2152,
           "resourceSize": 5796
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656842,
+          "transferSize": 656847,
           "resourceSize": 1280067
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5240,
+          "transferSize": 5243,
           "resourceSize": 23788
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9080,
+          "transferSize": 9575,
           "resourceSize": 11929
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 446081,
+          "transferSize": 446579,
           "resourceSize": 1087625
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2032,
+          "transferSize": 2034,
           "resourceSize": 5290
         },
         "font": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656723,
+          "transferSize": 656725,
           "resourceSize": 1279561
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2159,
+          "transferSize": 2163,
           "resourceSize": 5666
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656853,
+          "transferSize": 656861,
           "resourceSize": 1279937
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2032,
+          "transferSize": 2034,
           "resourceSize": 5217
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656729,
+          "transferSize": 656731,
           "resourceSize": 1279488
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2234,
+          "transferSize": 2237,
           "resourceSize": 5776
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 656929,
+          "transferSize": 656936,
           "resourceSize": 1280047
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3188,
+          "transferSize": 3190,
           "resourceSize": 9734
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1285,
+          "transferSize": 1275,
           "resourceSize": 557
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 882573,
+          "transferSize": 882565,
           "resourceSize": 1508373
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2385,
+          "transferSize": 2389,
           "resourceSize": 6014
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 659444,
+          "transferSize": 659448,
           "resourceSize": 1282123
         }
       },

--- a/.github/page_size_audit_results/v1.41.2.json
+++ b/.github/page_size_audit_results/v1.41.2.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.41.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:07.679Z"
+    "generatedAt": "2025-12-25T10:48:59.800Z"
   },
-  "timestamp": "2025-12-25T01:03:07.680Z",
+  "timestamp": "2025-12-25T10:48:59.801Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2328,
-          "resourceSize": 6211
+          "transferSize": 2195,
+          "resourceSize": 5816
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146998,
-          "resourceSize": 424688
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 318113,
-          "resourceSize": 729206
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692749,
-          "resourceSize": 1384581
+          "transferSize": 654886,
+          "resourceSize": 1275630
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2288,
-          "resourceSize": 6191
+          "transferSize": 2154,
+          "resourceSize": 5796
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146998,
-          "resourceSize": 424688
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 318113,
-          "resourceSize": 729206
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692703,
-          "resourceSize": 1384561
+          "transferSize": 654848,
+          "resourceSize": 1275610
         }
       },
       "themeResources": {
@@ -154,27 +154,27 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5366,
-          "resourceSize": 24310
+          "transferSize": 5246,
+          "resourceSize": 23793
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 149009,
-          "resourceSize": 426526
+          "transferSize": 112451,
+          "resourceSize": 318974
         },
         "stylesheet": {
-          "transferSize": 318113,
-          "resourceSize": 729206
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 9088,
+          "transferSize": 9558,
           "resourceSize": 11929
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481938,
-          "resourceSize": 1192246
+          "transferSize": 444560,
+          "resourceSize": 1083173
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2168,
-          "resourceSize": 5685
+          "transferSize": 2034,
+          "resourceSize": 5290
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146998,
-          "resourceSize": 424688
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 318113,
-          "resourceSize": 729206
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692588,
-          "resourceSize": 1384055
+          "transferSize": 654722,
+          "resourceSize": 1275104
         }
       },
       "themeResources": {
@@ -296,27 +296,27 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2296,
-          "resourceSize": 6061
+          "transferSize": 2164,
+          "resourceSize": 5666
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146998,
-          "resourceSize": 424688
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 318113,
-          "resourceSize": 729206
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692716,
-          "resourceSize": 1384431
+          "transferSize": 654853,
+          "resourceSize": 1275480
         }
       },
       "themeResources": {
@@ -367,20 +367,20 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2170,
-          "resourceSize": 5612
+          "transferSize": 2035,
+          "resourceSize": 5217
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146998,
-          "resourceSize": 424688
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 318113,
-          "resourceSize": 729206
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692587,
-          "resourceSize": 1383982
+          "transferSize": 654724,
+          "resourceSize": 1275031
         }
       },
       "themeResources": {
@@ -438,27 +438,27 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2370,
-          "resourceSize": 6171
+          "transferSize": 2239,
+          "resourceSize": 5776
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146998,
-          "resourceSize": 424688
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 318113,
-          "resourceSize": 729206
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692787,
-          "resourceSize": 1384541
+          "transferSize": 654926,
+          "resourceSize": 1275590
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3326,
-          "resourceSize": 10129
+          "transferSize": 3191,
+          "resourceSize": 9734
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 146998,
-          "resourceSize": 424688
+          "transferSize": 110440,
+          "resourceSize": 317136
         },
         "stylesheet": {
-          "transferSize": 318113,
-          "resourceSize": 729206
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1275,
+          "transferSize": 1278,
           "resourceSize": 557
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 918424,
-          "resourceSize": 1612867
+          "transferSize": 880564,
+          "resourceSize": 1503916
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2521,
-          "resourceSize": 6414
+          "transferSize": 2389,
+          "resourceSize": 6019
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 149009,
-          "resourceSize": 426526
+          "transferSize": 112451,
+          "resourceSize": 318974
         },
         "stylesheet": {
-          "transferSize": 318113,
-          "resourceSize": 729206
+          "transferSize": 316943,
+          "resourceSize": 728202
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1118,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 695307,
-          "resourceSize": 1386623
+          "transferSize": 657438,
+          "resourceSize": 1277671
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 651921,
-          "resourceSize": 1269620
+          "transferSize": 651920,
+          "resourceSize": 1269619
         }
       }
     }

--- a/.github/page_size_audit_results/v1.42.0.json
+++ b/.github/page_size_audit_results/v1.42.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:07.823Z"
+    "generatedAt": "2025-12-25T10:49:02.964Z"
   },
-  "timestamp": "2025-12-25T01:03:07.824Z",
+  "timestamp": "2025-12-25T10:49:02.965Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2330,
+          "transferSize": 2333,
           "resourceSize": 6309
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408116,
+          "transferSize": 408124,
           "resourceSize": 477464
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2267,
+          "transferSize": 2271,
           "resourceSize": 6191
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407504,
+          "transferSize": 407510,
           "resourceSize": 476968
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5371,
+          "transferSize": 5376,
           "resourceSize": 24295
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10163,
+          "transferSize": 10205,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 277552,
+          "transferSize": 277599,
           "resourceSize": 524677
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2128,
+          "transferSize": 2131,
           "resourceSize": 5578
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405597,
+          "transferSize": 405606,
           "resourceSize": 473039
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2258,
+          "transferSize": 2261,
           "resourceSize": 5954
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405730,
+          "transferSize": 405731,
           "resourceSize": 473415
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2131,
+          "transferSize": 2134,
           "resourceSize": 5505
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405599,
+          "transferSize": 405604,
           "resourceSize": 472966
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2333,
+          "transferSize": 2337,
           "resourceSize": 6064
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405803,
+          "transferSize": 405809,
           "resourceSize": 473525
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1912,
+          "transferSize": 1911,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 632799,
+          "transferSize": 632798,
           "resourceSize": 703242
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2525,
+          "transferSize": 2529,
           "resourceSize": 6519
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1126,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 489845,
+          "transferSize": 489847,
           "resourceSize": 718149
         }
       },

--- a/.github/page_size_audit_results/v1.42.1.json
+++ b/.github/page_size_audit_results/v1.42.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:19.718Z"
+    "generatedAt": "2025-12-25T10:49:03.461Z"
   },
-  "timestamp": "2025-12-25T01:00:19.718Z",
+  "timestamp": "2025-12-25T10:49:03.462Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2831,
+          "transferSize": 2833,
           "resourceSize": 7581
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408249,
+          "transferSize": 408247,
           "resourceSize": 476789
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2795,
+          "transferSize": 2796,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407892,
+          "transferSize": 407890,
           "resourceSize": 476458
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5907,
+          "transferSize": 5912,
           "resourceSize": 25659
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10210,
+          "transferSize": 10183,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 277771,
+          "transferSize": 277749,
           "resourceSize": 523718
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405984,
+          "transferSize": 405988,
           "resourceSize": 472520
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2793,
+          "transferSize": 2794,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406126,
+          "transferSize": 406122,
           "resourceSize": 472894
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2658,
+          "transferSize": 2659,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 405990,
+          "transferSize": 405985,
           "resourceSize": 472459
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2873,
+          "transferSize": 2875,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406205,
+          "transferSize": 406206,
           "resourceSize": 473015
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3852,
+          "transferSize": 3851,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1916,
+          "transferSize": 1951,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633148,
+          "transferSize": 633182,
           "resourceSize": 702666
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3046,
+          "transferSize": 3048,
           "resourceSize": 7883
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {

--- a/.github/page_size_audit_results/v1.42.2.json
+++ b/.github/page_size_audit_results/v1.42.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:19.275Z"
+    "generatedAt": "2025-12-25T10:46:21.948Z"
   },
-  "timestamp": "2025-12-25T01:00:19.275Z",
+  "timestamp": "2025-12-25T10:46:21.948Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2835,
+          "transferSize": 2831,
           "resourceSize": 7581
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408271,
+          "transferSize": 408267,
           "resourceSize": 476838
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2793,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407915,
+          "transferSize": 407913,
           "resourceSize": 476507
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5593,
+          "transferSize": 5591,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10183,
+          "transferSize": 10167,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200011,
+          "transferSize": 199993,
           "resourceSize": 288729
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2658,
+          "transferSize": 2656,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406005,
+          "transferSize": 406011,
           "resourceSize": 472569
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2794,
+          "transferSize": 2792,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406142,
+          "transferSize": 406147,
           "resourceSize": 472943
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2658,
+          "transferSize": 2656,
           "resourceSize": 6886
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406006,
+          "transferSize": 406004,
           "resourceSize": 472508
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2875,
+          "transferSize": 2873,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406230,
+          "transferSize": 406222,
           "resourceSize": 473064
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3853,
+          "transferSize": 3851,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1917,
+          "transferSize": 1912,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633171,
+          "transferSize": 633164,
           "resourceSize": 702715
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3048,
+          "transferSize": 3049,
           "resourceSize": 7883
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412581,
+          "transferSize": 412585,
           "resourceSize": 483197
         }
       },

--- a/.github/page_size_audit_results/v1.42.3.json
+++ b/.github/page_size_audit_results/v1.42.3.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:30.624Z"
+    "generatedAt": "2025-12-25T10:46:19.229Z"
   },
-  "timestamp": "2025-12-25T01:03:30.625Z",
+  "timestamp": "2025-12-25T10:46:19.229Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2836,
+          "transferSize": 2837,
           "resourceSize": 7581
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2796,
+          "transferSize": 2798,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407911,
+          "transferSize": 407919,
           "resourceSize": 476507
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5594,
+          "transferSize": 5595,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10178,
+          "transferSize": 10161,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199991,
+          "transferSize": 199975,
           "resourceSize": 288700
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406012,
+          "transferSize": 406011,
           "resourceSize": 472569
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2794,
+          "transferSize": 2796,
           "resourceSize": 7321
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406146,
+          "transferSize": 406148,
           "resourceSize": 472943
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406011,
+          "transferSize": 406007,
           "resourceSize": 472508
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2875,
+          "transferSize": 2876,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3855,
+          "transferSize": 3857,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1921,
+          "transferSize": 1943,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633177,
+          "transferSize": 633201,
           "resourceSize": 702715
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3053,
+          "transferSize": 3054,
           "resourceSize": 7883
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412571,
+          "transferSize": 412572,
           "resourceSize": 483168
         }
       },

--- a/.github/page_size_audit_results/v1.42.4.json
+++ b/.github/page_size_audit_results/v1.42.4.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.4",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:14.375Z"
+    "generatedAt": "2025-12-25T10:46:13.444Z"
   },
-  "timestamp": "2025-12-25T01:03:14.375Z",
+  "timestamp": "2025-12-25T10:46:13.444Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2830,
+          "transferSize": 2832,
           "resourceSize": 7581
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408266,
+          "transferSize": 408269,
           "resourceSize": 476838
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2791,
+          "transferSize": 2793,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5586,
+          "transferSize": 5590,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10176,
+          "transferSize": 10201,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 199981,
+          "transferSize": 200010,
           "resourceSize": 288700
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2657,
+          "transferSize": 2658,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406012,
+          "transferSize": 406007,
           "resourceSize": 472569
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2789,
+          "transferSize": 2791,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406146,
+          "transferSize": 406137,
           "resourceSize": 472943
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2656,
+          "transferSize": 2657,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406005,
+          "transferSize": 406014,
           "resourceSize": 472508
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2871,
+          "transferSize": 2872,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406227,
+          "transferSize": 406226,
           "resourceSize": 473064
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1937,
+          "transferSize": 1914,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633189,
+          "transferSize": 633166,
           "resourceSize": 702715
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3046,
+          "transferSize": 3050,
           "resourceSize": 7883
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1127,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 412566,
+          "transferSize": 412572,
           "resourceSize": 483168
         }
       },

--- a/.github/page_size_audit_results/v1.42.5.json
+++ b/.github/page_size_audit_results/v1.42.5.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.5",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:15.069Z"
+    "generatedAt": "2025-12-25T10:46:13.095Z"
   },
-  "timestamp": "2025-12-25T01:00:15.070Z",
+  "timestamp": "2025-12-25T10:46:13.095Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2846,
+          "transferSize": 2849,
           "resourceSize": 7683
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408481,
+          "transferSize": 408487,
           "resourceSize": 476970
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2794,
+          "transferSize": 2796,
           "resourceSize": 7567
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407916,
+          "transferSize": 407918,
           "resourceSize": 476509
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5586,
+          "transferSize": 5592,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10261,
+          "transferSize": 10285,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200068,
+          "transferSize": 200098,
           "resourceSize": 288702
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2658,
+          "transferSize": 2660,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406009,
+          "transferSize": 406014,
           "resourceSize": 472571
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2792,
+          "transferSize": 2794,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2657,
+          "transferSize": 2660,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406008,
+          "transferSize": 406012,
           "resourceSize": 472510
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2872,
+          "transferSize": 2875,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406223,
+          "transferSize": 406225,
           "resourceSize": 473066
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3851,
+          "transferSize": 3855,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1916,
+          "transferSize": 1943,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633170,
+          "transferSize": 633201,
           "resourceSize": 702717
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3063,
+          "transferSize": 3067,
           "resourceSize": 7985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1118,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413095,
+          "transferSize": 413104,
           "resourceSize": 483617
         }
       },

--- a/.github/page_size_audit_results/v1.42.6.json
+++ b/.github/page_size_audit_results/v1.42.6.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.6",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:12.465Z"
+    "generatedAt": "2025-12-25T10:46:18.833Z"
   },
-  "timestamp": "2025-12-25T01:03:12.465Z",
+  "timestamp": "2025-12-25T10:46:18.833Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2855,
+          "transferSize": 2857,
           "resourceSize": 7683
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 408542,
+          "transferSize": 408540,
           "resourceSize": 477020
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2802,
+          "transferSize": 2803,
           "resourceSize": 7567
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 407973,
+          "transferSize": 407971,
           "resourceSize": 476559
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5596,
+          "transferSize": 5595,
           "resourceSize": 24663
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 10185,
+          "transferSize": 10176,
           "resourceSize": 12954
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 200049,
+          "transferSize": 200039,
           "resourceSize": 288752
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2663,
+          "transferSize": 2667,
           "resourceSize": 6947
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406068,
+          "transferSize": 406069,
           "resourceSize": 472621
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2798,
+          "transferSize": 2800,
           "resourceSize": 7321
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406197,
+          "transferSize": 406205,
           "resourceSize": 472995
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2666,
+          "transferSize": 2665,
           "resourceSize": 6886
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 406071,
+          "transferSize": 406061,
           "resourceSize": 472560
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2877,
+          "transferSize": 2879,
           "resourceSize": 7441
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 406281,
+          "transferSize": 406279,
           "resourceSize": 473116
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3859,
+          "transferSize": 3858,
           "resourceSize": 11392
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1941,
+          "transferSize": 1911,
           "resourceSize": 1239
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 633251,
+          "transferSize": 633220,
           "resourceSize": 702767
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3072,
+          "transferSize": 3070,
           "resourceSize": 7985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1125,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 413158,
+          "transferSize": 413150,
           "resourceSize": 483667
         }
       },

--- a/.github/page_size_audit_results/v1.42.7.json
+++ b/.github/page_size_audit_results/v1.42.7.json
@@ -4,35 +4,35 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.42.7",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:12.984Z"
+    "generatedAt": "2025-12-25T10:46:13.260Z"
   },
-  "timestamp": "2025-12-25T01:03:12.984Z",
+  "timestamp": "2025-12-25T10:46:13.261Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2940,
-          "resourceSize": 7970
+          "transferSize": 2859,
+          "resourceSize": 7689
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 161802,
-          "resourceSize": 539781
+          "transferSize": 14697,
+          "resourceSize": 32476
         },
         "stylesheet": {
-          "transferSize": 10611,
-          "resourceSize": 52983
+          "transferSize": 9159,
+          "resourceSize": 51697
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 556505,
-          "resourceSize": 980890
+          "transferSize": 407874,
+          "resourceSize": 472018
         }
       },
       "themeResources": {
@@ -83,27 +83,27 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2882,
-          "resourceSize": 7854
+          "transferSize": 2804,
+          "resourceSize": 7573
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 161285,
-          "resourceSize": 539436
+          "transferSize": 14180,
+          "resourceSize": 32131
         },
         "stylesheet": {
-          "transferSize": 10611,
-          "resourceSize": 52983
+          "transferSize": 9159,
+          "resourceSize": 51697
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 555934,
-          "resourceSize": 980429
+          "transferSize": 407300,
+          "resourceSize": 471557
         }
       },
       "themeResources": {
@@ -154,36 +154,36 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5846,
-          "resourceSize": 25683
+          "transferSize": 5644,
+          "resourceSize": 24913
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 561285,
-          "resourceSize": 1691966
+          "transferSize": 18264,
+          "resourceSize": 38632
         },
         "stylesheet": {
-          "transferSize": 12179,
-          "resourceSize": 58843
+          "transferSize": 10727,
+          "resourceSize": 57557
         },
         "image": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 13055,
-          "resourceSize": 14252
+          "transferSize": 10161,
+          "resourceSize": 12954
         },
         "other": {
           "transferSize": 362,
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 748577,
-          "resourceSize": 1946699
+          "transferSize": 201008,
+          "resourceSize": 290011
         }
       },
       "themeResources": {
@@ -225,27 +225,27 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2750,
-          "resourceSize": 7234
+          "transferSize": 2667,
+          "resourceSize": 6953
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 160189,
-          "resourceSize": 536500
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 9916,
-          "resourceSize": 52453
+          "transferSize": 8464,
+          "resourceSize": 51167
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 554011,
-          "resourceSize": 976343
+          "transferSize": 405374,
+          "resourceSize": 467471
         }
       },
       "themeResources": {
@@ -296,36 +296,36 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2880,
-          "resourceSize": 7608
+          "transferSize": 2801,
+          "resourceSize": 7327
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 160189,
-          "resourceSize": 536500
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 9916,
-          "resourceSize": 52453
+          "transferSize": 8464,
+          "resourceSize": 51167
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 554147,
-          "resourceSize": 976718
+          "transferSize": 405504,
+          "resourceSize": 467845
         }
       },
       "themeResources": {
@@ -354,12 +354,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 363,
-          "resourceSize": 276
+          "transferSize": 362,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 401936,
-          "resourceSize": 460324
+          "transferSize": 401935,
+          "resourceSize": 460323
         }
       }
     },
@@ -367,20 +367,91 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2752,
-          "resourceSize": 7173
+          "transferSize": 2668,
+          "resourceSize": 6892
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 160189,
-          "resourceSize": 536500
+          "transferSize": 13084,
+          "resourceSize": 29195
         },
         "stylesheet": {
-          "transferSize": 9916,
-          "resourceSize": 52453
+          "transferSize": 8464,
+          "resourceSize": 51167
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 769,
+          "resourceSize": 195
+        },
+        "other": {
+          "transferSize": 362,
+          "resourceSize": 275
+        },
+        "total": {
+          "transferSize": 405372,
+          "resourceSize": 467410
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 155850,
+          "resourceSize": 155680
+        },
+        "script": {
+          "transferSize": 13084,
+          "resourceSize": 29195
+        },
+        "stylesheet": {
+          "transferSize": 8464,
+          "resourceSize": 51167
+        },
+        "image": {
+          "transferSize": 224175,
+          "resourceSize": 224006
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 362,
+          "resourceSize": 275
+        },
+        "total": {
+          "transferSize": 401935,
+          "resourceSize": 460323
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 2882,
+          "resourceSize": 7447
+        },
+        "font": {
+          "transferSize": 155850,
+          "resourceSize": 155680
+        },
+        "script": {
+          "transferSize": 13084,
+          "resourceSize": 29195
+        },
+        "stylesheet": {
+          "transferSize": 8464,
+          "resourceSize": 51167
         },
         "image": {
           "transferSize": 224175,
@@ -395,79 +466,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 554018,
-          "resourceSize": 976283
-        }
-      },
-      "themeResources": {
-        "document": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "font": {
-          "transferSize": 155850,
-          "resourceSize": 155680
-        },
-        "script": {
-          "transferSize": 13084,
-          "resourceSize": 29195
-        },
-        "stylesheet": {
-          "transferSize": 8464,
-          "resourceSize": 51167
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 0,
-          "resourceSize": 0
-        },
-        "other": {
-          "transferSize": 363,
-          "resourceSize": 276
-        },
-        "total": {
-          "transferSize": 401936,
-          "resourceSize": 460324
-        }
-      }
-    },
-    {
-      "url": "/categories/default",
-      "resources": {
-        "document": {
-          "transferSize": 2961,
-          "resourceSize": 7728
-        },
-        "font": {
-          "transferSize": 155850,
-          "resourceSize": 155680
-        },
-        "script": {
-          "transferSize": 160189,
-          "resourceSize": 536500
-        },
-        "stylesheet": {
-          "transferSize": 9916,
-          "resourceSize": 52453
-        },
-        "image": {
-          "transferSize": 224175,
-          "resourceSize": 224006
-        },
-        "fetch": {
-          "transferSize": 765,
-          "resourceSize": 195
-        },
-        "other": {
-          "transferSize": 363,
-          "resourceSize": 276
-        },
-        "total": {
-          "transferSize": 554219,
-          "resourceSize": 976838
+          "transferSize": 405591,
+          "resourceSize": 467966
         }
       },
       "themeResources": {
@@ -509,27 +509,27 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3933,
-          "resourceSize": 11679
+          "transferSize": 3857,
+          "resourceSize": 11398
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 159989,
-          "resourceSize": 536470
+          "transferSize": 12884,
+          "resourceSize": 29165
         },
         "stylesheet": {
-          "transferSize": 10761,
-          "resourceSize": 53133
+          "transferSize": 9309,
+          "resourceSize": 51847
         },
         "image": {
           "transferSize": 448350,
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 1912,
+          "transferSize": 1908,
           "resourceSize": 1239
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 781158,
-          "resourceSize": 1206489
+          "transferSize": 632521,
+          "resourceSize": 697617
         }
       },
       "themeResources": {
@@ -580,36 +580,36 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3317,
-          "resourceSize": 8874
+          "transferSize": 3091,
+          "resourceSize": 8090
         },
         "font": {
           "transferSize": 155850,
           "resourceSize": 155680
         },
         "script": {
-          "transferSize": 561802,
-          "resourceSize": 1692311
+          "transferSize": 18781,
+          "resourceSize": 38977
         },
         "stylesheet": {
-          "transferSize": 12179,
-          "resourceSize": 58843
+          "transferSize": 10727,
+          "resourceSize": 57557
         },
         "image": {
           "transferSize": 224175,
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 4000,
-          "resourceSize": 1493
+          "transferSize": 1122,
+          "resourceSize": 195
         },
         "other": {
           "transferSize": 363,
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 961686,
-          "resourceSize": 2141483
+          "transferSize": 414109,
+          "resourceSize": 484781
         }
       },
       "themeResources": {


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.12.2
- **End Version:** v1.42.7

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Audit workflow*