### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.10.0.json
+++ b/.github/page_size_audit_results/v1.10.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:16.312Z"
+    "generatedAt": "2025-12-25T13:08:58.927Z"
   },
-  "timestamp": "2025-12-25T01:00:16.312Z",
+  "timestamp": "2025-12-25T13:08:58.927Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2700,
+          "transferSize": 2699,
           "resourceSize": 5945
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690819,
+          "transferSize": 690814,
           "resourceSize": 1367645
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2598,
+          "transferSize": 2599,
           "resourceSize": 5713
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690719,
+          "transferSize": 690718,
           "resourceSize": 1367413
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5304,
+          "transferSize": 5303,
           "resourceSize": 17502
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5025,
+          "transferSize": 4974,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479149,
+          "transferSize": 479097,
           "resourceSize": 1173082
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690533,
+          "transferSize": 690527,
           "resourceSize": 1366787
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2588,
+          "transferSize": 2586,
           "resourceSize": 5523
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690712,
+          "transferSize": 690704,
           "resourceSize": 1367223
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690548,
+          "transferSize": 690539,
           "resourceSize": 1366769
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2645,
+          "transferSize": 2644,
           "resourceSize": 5633
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 776,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690767,
+          "transferSize": 690762,
           "resourceSize": 1367333
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691369,
+          "transferSize": 691371,
           "resourceSize": 1593494
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697835,
+          "transferSize": 697834,
           "resourceSize": 1381081
         }
       },

--- a/.github/page_size_audit_results/v1.10.1.json
+++ b/.github/page_size_audit_results/v1.10.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:05:59.809Z"
+    "generatedAt": "2025-12-25T13:09:02.391Z"
   },
-  "timestamp": "2025-12-25T01:05:59.809Z",
+  "timestamp": "2025-12-25T13:09:02.391Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2732,
+          "transferSize": 2733,
           "resourceSize": 6013
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690847,
+          "transferSize": 690852,
           "resourceSize": 1367713
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2600,
+          "transferSize": 2602,
           "resourceSize": 5713
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 778,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690724,
+          "transferSize": 690723,
           "resourceSize": 1367413
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5304,
+          "transferSize": 5305,
           "resourceSize": 17502
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4968,
+          "transferSize": 4963,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479092,
+          "transferSize": 479088,
           "resourceSize": 1173082
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690527,
+          "transferSize": 690533,
           "resourceSize": 1366787
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2588,
+          "transferSize": 2590,
           "resourceSize": 5523
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690703,
+          "transferSize": 690711,
           "resourceSize": 1367223
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690546,
+          "transferSize": 690542,
           "resourceSize": 1366769
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2645,
+          "transferSize": 2647,
           "resourceSize": 5633
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690757,
+          "transferSize": 690768,
           "resourceSize": 1367333
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691410,
+          "transferSize": 691416,
           "resourceSize": 1593657
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1117,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697836,
+          "transferSize": 697832,
           "resourceSize": 1381081
         }
       },

--- a/.github/page_size_audit_results/v1.10.2.json
+++ b/.github/page_size_audit_results/v1.10.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.10.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:20.062Z"
+    "generatedAt": "2025-12-25T13:08:58.943Z"
   },
-  "timestamp": "2025-12-25T01:00:20.062Z",
+  "timestamp": "2025-12-25T13:08:58.943Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2730,
+          "transferSize": 2731,
           "resourceSize": 6013
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690847,
+          "transferSize": 690850,
           "resourceSize": 1367713
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690713,
+          "transferSize": 690718,
           "resourceSize": 1367413
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5307,
+          "transferSize": 5308,
           "resourceSize": 17514
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4966,
+          "transferSize": 4962,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479093,
+          "transferSize": 479090,
           "resourceSize": 1173094
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690533,
+          "transferSize": 690529,
           "resourceSize": 1366787
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690701,
+          "transferSize": 690707,
           "resourceSize": 1367223
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690542,
+          "transferSize": 690541,
           "resourceSize": 1366769
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690757,
+          "transferSize": 690758,
           "resourceSize": 1367333
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691409,
+          "transferSize": 691403,
           "resourceSize": 1593657
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1123,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697837,
+          "transferSize": 697839,
           "resourceSize": 1381081
         }
       },

--- a/.github/page_size_audit_results/v1.11.0.json
+++ b/.github/page_size_audit_results/v1.11.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.11.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:18.481Z"
+    "generatedAt": "2025-12-25T13:08:54.856Z"
   },
-  "timestamp": "2025-12-25T01:00:18.481Z",
+  "timestamp": "2025-12-25T13:08:54.857Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2637,
+          "transferSize": 2634,
           "resourceSize": 5716
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690663,
+          "transferSize": 690659,
           "resourceSize": 1367123
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2601,
+          "transferSize": 2597,
           "resourceSize": 5713
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690627,
+          "transferSize": 690615,
           "resourceSize": 1367120
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4960,
+          "transferSize": 5020,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 478994,
+          "transferSize": 479054,
           "resourceSize": 1172801
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2413,
+          "transferSize": 2411,
           "resourceSize": 5087
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2590,
+          "transferSize": 2588,
           "resourceSize": 5523
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690613,
+          "transferSize": 690614,
           "resourceSize": 1366930
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2430,
+          "transferSize": 2426,
           "resourceSize": 5069
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690452,
+          "transferSize": 690451,
           "resourceSize": 1366476
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2647,
+          "transferSize": 2644,
           "resourceSize": 5633
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690671,
+          "transferSize": 690668,
           "resourceSize": 1367040
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3295,
+          "transferSize": 3293,
           "resourceSize": 7951
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691318,
+          "transferSize": 691317,
           "resourceSize": 1593364
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3299,
+          "transferSize": 3296,
           "resourceSize": 6985
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697746,
+          "transferSize": 697741,
           "resourceSize": 1380788
         }
       },

--- a/.github/page_size_audit_results/v1.12.0.json
+++ b/.github/page_size_audit_results/v1.12.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:11.702Z"
+    "generatedAt": "2025-12-25T13:09:00.099Z"
   },
-  "timestamp": "2025-12-25T01:03:11.702Z",
+  "timestamp": "2025-12-25T13:09:00.099Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690712,
+          "transferSize": 690715,
           "resourceSize": 1367305
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2609,
+          "transferSize": 2608,
           "resourceSize": 5754
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690680,
+          "transferSize": 690674,
           "resourceSize": 1367302
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5315,
+          "transferSize": 5314,
           "resourceSize": 17555
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4968,
+          "transferSize": 4963,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479055,
+          "transferSize": 479049,
           "resourceSize": 1172983
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2427,
+          "transferSize": 2424,
           "resourceSize": 5140
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690499,
+          "transferSize": 690487,
           "resourceSize": 1366688
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2598,
+          "transferSize": 2597,
           "resourceSize": 5564
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690665,
+          "transferSize": 690666,
           "resourceSize": 1367112
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2440,
+          "transferSize": 2438,
           "resourceSize": 5122
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690509,
+          "transferSize": 690507,
           "resourceSize": 1366670
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2656,
+          "transferSize": 2655,
           "resourceSize": 5674
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690724,
+          "transferSize": 690720,
           "resourceSize": 1367222
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3307,
+          "transferSize": 3304,
           "resourceSize": 7992
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691369,
+          "transferSize": 691377,
           "resourceSize": 1593546
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3309,
+          "transferSize": 3307,
           "resourceSize": 7042
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697798,
+          "transferSize": 697796,
           "resourceSize": 1380986
         }
       },

--- a/.github/page_size_audit_results/v1.12.1.json
+++ b/.github/page_size_audit_results/v1.12.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:32.941Z"
+    "generatedAt": "2025-12-25T13:09:03.467Z"
   },
-  "timestamp": "2025-12-25T01:03:32.941Z",
+  "timestamp": "2025-12-25T13:09:03.467Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691690,
+          "transferSize": 691687,
           "resourceSize": 1369939
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2614,
+          "transferSize": 2613,
           "resourceSize": 5938
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691653,
+          "transferSize": 691657,
           "resourceSize": 1369936
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5320,
+          "transferSize": 5321,
           "resourceSize": 17831
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4993,
+          "transferSize": 4969,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479785,
+          "transferSize": 479762,
           "resourceSize": 1174311
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2435,
+          "transferSize": 2433,
           "resourceSize": 5324
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691475,
+          "transferSize": 691472,
           "resourceSize": 1369322
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691645,
+          "transferSize": 691647,
           "resourceSize": 1369746
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2446,
+          "transferSize": 2444,
           "resourceSize": 5306
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691486,
+          "transferSize": 691489,
           "resourceSize": 1369304
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2660,
+          "transferSize": 2661,
           "resourceSize": 5858
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691701,
+          "transferSize": 691703,
           "resourceSize": 1369856
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3310,
+          "transferSize": 3307,
           "resourceSize": 8176
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692356,
+          "transferSize": 692350,
           "resourceSize": 1596180
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3314,
+          "transferSize": 3310,
           "resourceSize": 7226
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 698504,
+          "transferSize": 698499,
           "resourceSize": 1382222
         }
       },

--- a/.github/page_size_audit_results/v1.12.2.json
+++ b/.github/page_size_audit_results/v1.12.2.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.2",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T10:46:23.622Z"
+    "generatedAt": "2025-12-25T13:09:02.302Z"
   },
-  "timestamp": "2025-12-25T10:46:23.622Z",
+  "timestamp": "2025-12-25T13:09:02.302Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2708,
+          "transferSize": 2709,
           "resourceSize": 6131
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 777,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693357,
+          "transferSize": 693366,
           "resourceSize": 1373180
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2669,
+          "transferSize": 2670,
           "resourceSize": 6128
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693320,
+          "transferSize": 693317,
           "resourceSize": 1373177
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5382,
+          "transferSize": 5383,
           "resourceSize": 18021
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4962,
+          "transferSize": 5016,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481424,
+          "transferSize": 481479,
           "resourceSize": 1177552
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 764,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693132,
+          "transferSize": 693135,
           "resourceSize": 1372563
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693310,
+          "transferSize": 693306,
           "resourceSize": 1372987
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693143,
+          "transferSize": 693146,
           "resourceSize": 1372545
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2716,
+          "transferSize": 2717,
           "resourceSize": 6048
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693365,
+          "transferSize": 693367,
           "resourceSize": 1373097
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 777,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694035,
+          "transferSize": 694026,
           "resourceSize": 1599421
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700161,
+          "transferSize": 700165,
           "resourceSize": 1385464
         }
       },

--- a/.github/page_size_audit_results/v1.12.3.json
+++ b/.github/page_size_audit_results/v1.12.3.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.12.3",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T10:46:53.036Z"
+    "generatedAt": "2025-12-25T13:09:10.086Z"
   },
-  "timestamp": "2025-12-25T10:46:53.037Z",
+  "timestamp": "2025-12-25T13:09:10.087Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2714,
+          "transferSize": 2718,
           "resourceSize": 6137
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693368,
+          "transferSize": 693363,
           "resourceSize": 1373203
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2676,
+          "transferSize": 2680,
           "resourceSize": 6134
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693322,
+          "transferSize": 693331,
           "resourceSize": 1373200
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5387,
+          "transferSize": 5390,
           "resourceSize": 18027
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5029,
+          "transferSize": 4969,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481495,
+          "transferSize": 481438,
           "resourceSize": 1177575
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2503,
+          "transferSize": 2507,
           "resourceSize": 5520
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693151,
+          "transferSize": 693153,
           "resourceSize": 1372586
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2666,
+          "transferSize": 2669,
           "resourceSize": 5944
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693313,
+          "transferSize": 693322,
           "resourceSize": 1373010
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2512,
+          "transferSize": 2515,
           "resourceSize": 5502
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693162,
+          "transferSize": 693161,
           "resourceSize": 1372568
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2724,
+          "transferSize": 2727,
           "resourceSize": 6054
         },
         "font": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693370,
+          "transferSize": 693373,
           "resourceSize": 1373120
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3389,
+          "transferSize": 3392,
           "resourceSize": 8372
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694036,
+          "transferSize": 694042,
           "resourceSize": 1599444
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3371,
+          "transferSize": 3375,
           "resourceSize": 7422
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700168,
+          "transferSize": 700177,
           "resourceSize": 1385487
         }
       },

--- a/.github/page_size_audit_results/v1.13.0.json
+++ b/.github/page_size_audit_results/v1.13.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T10:46:12.395Z"
+    "generatedAt": "2025-12-25T13:08:56.967Z"
   },
-  "timestamp": "2025-12-25T10:46:12.396Z",
+  "timestamp": "2025-12-25T13:08:56.968Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693364,
+          "transferSize": 693366,
           "resourceSize": 1373203
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693329,
+          "transferSize": 693324,
           "resourceSize": 1373200
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4976,
+          "transferSize": 4981,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481445,
+          "transferSize": 481450,
           "resourceSize": 1177575
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 764,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693158,
+          "transferSize": 693149,
           "resourceSize": 1372586
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693317,
+          "transferSize": 693316,
           "resourceSize": 1373010
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693165,
+          "transferSize": 693163,
           "resourceSize": 1372568
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693380,
+          "transferSize": 693377,
           "resourceSize": 1373120
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694045,
+          "transferSize": 694042,
           "resourceSize": 1599444
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1123,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700176,
+          "transferSize": 700175,
           "resourceSize": 1385487
         }
       },

--- a/.github/page_size_audit_results/v1.13.1.json
+++ b/.github/page_size_audit_results/v1.13.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.13.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T10:46:15.587Z"
+    "generatedAt": "2025-12-25T13:09:07.044Z"
   },
-  "timestamp": "2025-12-25T10:46:15.587Z",
+  "timestamp": "2025-12-25T13:09:07.045Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2726,
+          "transferSize": 2724,
           "resourceSize": 6155
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693435,
+          "transferSize": 693429,
           "resourceSize": 1373874
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2691,
+          "transferSize": 2687,
           "resourceSize": 6152
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693400,
+          "transferSize": 693397,
           "resourceSize": 1373871
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5056,
+          "transferSize": 5021,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481595,
+          "transferSize": 481560,
           "resourceSize": 1178246
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2516,
+          "transferSize": 2513,
           "resourceSize": 5538
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693228,
+          "transferSize": 693221,
           "resourceSize": 1373257
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2680,
+          "transferSize": 2677,
           "resourceSize": 5962
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693393,
+          "transferSize": 693392,
           "resourceSize": 1373681
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2525,
+          "transferSize": 2522,
           "resourceSize": 5520
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693239,
+          "transferSize": 693237,
           "resourceSize": 1373239
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2737,
+          "transferSize": 2735,
           "resourceSize": 6072
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693446,
+          "transferSize": 693441,
           "resourceSize": 1373791
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3396,
+          "transferSize": 3393,
           "resourceSize": 8390
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694106,
+          "transferSize": 694102,
           "resourceSize": 1600115
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3384,
+          "transferSize": 3380,
           "resourceSize": 7440
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1124,
+          "transferSize": 1122,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700246,
+          "transferSize": 700240,
           "resourceSize": 1386158
         }
       },

--- a/.github/page_size_audit_results/v1.14.0.json
+++ b/.github/page_size_audit_results/v1.14.0.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.14.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T10:46:35.521Z"
+    "generatedAt": "2025-12-25T13:09:15.841Z"
   },
-  "timestamp": "2025-12-25T10:46:35.522Z",
+  "timestamp": "2025-12-25T13:09:15.841Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693404,
+          "transferSize": 693407,
           "resourceSize": 1373802
         }
       },
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693371,
+          "transferSize": 693373,
           "resourceSize": 1373799
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5400,
+          "transferSize": 5399,
           "resourceSize": 18045
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4983,
+          "transferSize": 4961,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481523,
+          "transferSize": 481500,
           "resourceSize": 1178246
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693224,
+          "transferSize": 693226,
           "resourceSize": 1373257
         }
       },
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693357,
+          "transferSize": 693356,
           "resourceSize": 1373609
         }
       },
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693412,
+          "transferSize": 693419,
           "resourceSize": 1373719
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694074,
+          "transferSize": 694072,
           "resourceSize": 1600043
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700244,
+          "transferSize": 700243,
           "resourceSize": 1386158
         }
       },

--- a/.github/page_size_audit_results/v1.15.0.json
+++ b/.github/page_size_audit_results/v1.15.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T10:46:18.633Z"
+    "generatedAt": "2025-12-25T13:08:57.916Z"
   },
-  "timestamp": "2025-12-25T10:46:18.634Z",
+  "timestamp": "2025-12-25T13:08:57.917Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2709,
+          "transferSize": 2705,
           "resourceSize": 6101
         },
         "font": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693555,
+          "transferSize": 693551,
           "resourceSize": 1374456
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2674,
+          "transferSize": 2670,
           "resourceSize": 6098
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5584,
+          "transferSize": 5579,
           "resourceSize": 18349
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4969,
+          "transferSize": 4982,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 481825,
+          "transferSize": 481833,
           "resourceSize": 1179186
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2530,
+          "transferSize": 2527,
           "resourceSize": 5556
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693373,
+          "transferSize": 693368,
           "resourceSize": 1373911
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2663,
+          "transferSize": 2660,
           "resourceSize": 5908
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693502,
+          "transferSize": 693505,
           "resourceSize": 1374263
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2541,
+          "transferSize": 2538,
           "resourceSize": 5538
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2719,
+          "transferSize": 2715,
           "resourceSize": 6018
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693566,
+          "transferSize": 693556,
           "resourceSize": 1374373
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3375,
+          "transferSize": 3373,
           "resourceSize": 8336
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 694218,
+          "transferSize": 694212,
           "resourceSize": 1600697
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3395,
+          "transferSize": 3394,
           "resourceSize": 7458
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1125,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 700387,
+          "transferSize": 700389,
           "resourceSize": 1386812
         }
       },

--- a/.github/page_size_audit_results/v1.15.1.json
+++ b/.github/page_size_audit_results/v1.15.1.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.15.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T10:46:11.331Z"
+    "generatedAt": "2025-12-25T13:09:01.920Z"
   },
-  "timestamp": "2025-12-25T10:46:11.332Z",
+  "timestamp": "2025-12-25T13:09:01.921Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2061,
+          "transferSize": 2058,
           "resourceSize": 4959
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692437,
+          "transferSize": 692429,
           "resourceSize": 1372340
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2028,
+          "transferSize": 2025,
           "resourceSize": 4956
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692395,
+          "transferSize": 692399,
           "resourceSize": 1372337
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5032,
+          "transferSize": 5031,
           "resourceSize": 17245
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4978,
+          "transferSize": 4976,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480812,
+          "transferSize": 480809,
           "resourceSize": 1177108
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1897,
+          "transferSize": 1895,
           "resourceSize": 4414
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692271,
+          "transferSize": 692267,
           "resourceSize": 1371795
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2031,
+          "transferSize": 2026,
           "resourceSize": 4766
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692406,
+          "transferSize": 692402,
           "resourceSize": 1372147
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1912,
+          "transferSize": 1909,
           "resourceSize": 4396
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692284,
+          "transferSize": 692283,
           "resourceSize": 1371777
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2104,
+          "transferSize": 2101,
           "resourceSize": 4876
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692475,
+          "transferSize": 692470,
           "resourceSize": 1372257
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2754,
+          "transferSize": 2750,
           "resourceSize": 7194
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 775,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693124,
+          "transferSize": 693127,
           "resourceSize": 1598581
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2795,
+          "transferSize": 2789,
           "resourceSize": 6298
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1121,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699316,
+          "transferSize": 699313,
           "resourceSize": 1384678
         }
       },

--- a/.github/page_size_audit_results/v1.16.0.json
+++ b/.github/page_size_audit_results/v1.16.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T10:46:21.747Z"
+    "generatedAt": "2025-12-25T13:09:00.317Z"
   },
-  "timestamp": "2025-12-25T10:46:21.747Z",
+  "timestamp": "2025-12-25T13:09:00.318Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2059,
+          "transferSize": 2063,
           "resourceSize": 4969
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692528,
+          "transferSize": 692531,
           "resourceSize": 1372886
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2026,
+          "transferSize": 2029,
           "resourceSize": 4966
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 776,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692496,
+          "transferSize": 692505,
           "resourceSize": 1372883
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5032,
+          "transferSize": 5034,
           "resourceSize": 17255
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5054,
+          "transferSize": 5025,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480986,
+          "transferSize": 480959,
           "resourceSize": 1177654
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 1897,
+          "transferSize": 1900,
           "resourceSize": 4424
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 767,
           "resourceSize": 195
         },
         "other": {
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2029,
+          "transferSize": 2031,
           "resourceSize": 4776
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 780,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692509,
+          "transferSize": 692500,
           "resourceSize": 1372693
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 1911,
+          "transferSize": 1913,
           "resourceSize": 4406
         },
         "font": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692380,
+          "transferSize": 692382,
           "resourceSize": 1372323
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2103,
+          "transferSize": 2106,
           "resourceSize": 4886
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692570,
+          "transferSize": 692574,
           "resourceSize": 1372803
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 2753,
+          "transferSize": 2756,
           "resourceSize": 7204
         },
         "font": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693223,
+          "transferSize": 693226,
           "resourceSize": 1599127
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 2792,
+          "transferSize": 2798,
           "resourceSize": 6308
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699411,
+          "transferSize": 699417,
           "resourceSize": 1385224
         }
       },

--- a/.github/page_size_audit_results/v1.16.1.json
+++ b/.github/page_size_audit_results/v1.16.1.json
@@ -4,9 +4,9 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.16.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T10:46:20.997Z"
+    "generatedAt": "2025-12-25T13:08:57.469Z"
   },
-  "timestamp": "2025-12-25T10:46:20.997Z",
+  "timestamp": "2025-12-25T13:08:57.469Z",
   "results": [
     {
       "url": "/",
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 780,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692543,
+          "transferSize": 692535,
           "resourceSize": 1372886
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2028,
+          "transferSize": 2029,
           "resourceSize": 4966
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692498,
+          "transferSize": 692499,
           "resourceSize": 1372883
         }
       },
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 5018,
+          "transferSize": 5029,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 480952,
+          "transferSize": 480963,
           "resourceSize": 1177654
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692374,
+          "transferSize": 692369,
           "resourceSize": 1372341
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2031,
+          "transferSize": 2030,
           "resourceSize": 4776
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 692497,
+          "transferSize": 692501,
           "resourceSize": 1372693
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2106,
+          "transferSize": 2105,
           "resourceSize": 4886
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 693223,
+          "transferSize": 693225,
           "resourceSize": 1599127
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1122,
+          "transferSize": 1119,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 276
         },
         "total": {
-          "transferSize": 699417,
+          "transferSize": 699414,
           "resourceSize": 1385224
         }
       },

--- a/.github/page_size_audit_results/v1.7.0.json
+++ b/.github/page_size_audit_results/v1.7.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.7.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:11.421Z"
+    "generatedAt": "2025-12-25T13:08:57.014Z"
   },
-  "timestamp": "2025-12-25T01:00:11.422Z",
+  "timestamp": "2025-12-25T13:08:57.014Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2646,
+          "transferSize": 2645,
           "resourceSize": 5549
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690759,
+          "transferSize": 690761,
           "resourceSize": 1367249
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2513,
+          "transferSize": 2512,
           "resourceSize": 5233
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690633,
+          "transferSize": 690627,
           "resourceSize": 1366933
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5229,
+          "transferSize": 5231,
           "resourceSize": 16807
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4985,
+          "transferSize": 4993,
           "resourceSize": 5685
         },
         "other": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479034,
+          "transferSize": 479044,
           "resourceSize": 1172387
         }
       },
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2334,
+          "transferSize": 2332,
           "resourceSize": 4617
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690454,
+          "transferSize": 690451,
           "resourceSize": 1366317
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2501,
+          "transferSize": 2500,
           "resourceSize": 5043
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690619,
+          "transferSize": 690614,
           "resourceSize": 1366743
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2348,
+          "transferSize": 2345,
           "resourceSize": 4599
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690466,
+          "transferSize": 690459,
           "resourceSize": 1366299
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2559,
+          "transferSize": 2558,
           "resourceSize": 5153
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690678,
+          "transferSize": 690672,
           "resourceSize": 1366853
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3200,
+          "transferSize": 3196,
           "resourceSize": 7472
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691320,
+          "transferSize": 691313,
           "resourceSize": 1593178
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3204,
+          "transferSize": 3201,
           "resourceSize": 6549
         },
         "font": {
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1129,
+          "transferSize": 1120,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697750,
+          "transferSize": 697738,
           "resourceSize": 1380645
         }
       },

--- a/.github/page_size_audit_results/v1.8.0.json
+++ b/.github/page_size_audit_results/v1.8.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:03:15.759Z"
+    "generatedAt": "2025-12-25T13:08:54.996Z"
   },
-  "timestamp": "2025-12-25T01:03:15.759Z",
+  "timestamp": "2025-12-25T13:08:54.997Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2645,
+          "transferSize": 2648,
           "resourceSize": 5554
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690759,
+          "transferSize": 690764,
           "resourceSize": 1367254
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2512,
+          "transferSize": 2515,
           "resourceSize": 5238
         },
         "font": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690627,
+          "transferSize": 690630,
           "resourceSize": 1366938
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5226,
+          "transferSize": 5227,
           "resourceSize": 16812
         },
         "font": {
@@ -182,7 +182,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479009,
+          "transferSize": 479010,
           "resourceSize": 1172392
         }
       },
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 778,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690450,
+          "transferSize": 690461,
           "resourceSize": 1366322
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2502,
+          "transferSize": 2504,
           "resourceSize": 5048
         },
         "font": {
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690613,
+          "transferSize": 690619,
           "resourceSize": 1366748
         }
       },
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 767,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690463,
+          "transferSize": 690464,
           "resourceSize": 1366304
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2559,
+          "transferSize": 2562,
           "resourceSize": 5158
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 780,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690670,
+          "transferSize": 690688,
           "resourceSize": 1366858
         }
       },
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691316,
+          "transferSize": 691312,
           "resourceSize": 1593183
         }
       },
@@ -600,7 +600,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1120,
+          "transferSize": 1124,
           "resourceSize": 195
         },
         "other": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697742,
+          "transferSize": 697746,
           "resourceSize": 1380650
         }
       },

--- a/.github/page_size_audit_results/v1.8.1.json
+++ b/.github/page_size_audit_results/v1.8.1.json
@@ -4,24 +4,24 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:22.447Z"
+    "generatedAt": "2025-12-25T13:08:58.675Z"
   },
-  "timestamp": "2025-12-25T01:00:22.447Z",
+  "timestamp": "2025-12-25T13:08:58.675Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2646,
-          "resourceSize": 5554
+          "transferSize": 2709,
+          "resourceSize": 5704
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 157980,
+          "resourceSize": 471999
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690761,
-          "resourceSize": 1367254
+          "transferSize": 703437,
+          "resourceSize": 1411974
         }
       },
       "themeResources": {
@@ -83,16 +83,16 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2513,
-          "resourceSize": 5238
+          "transferSize": 2575,
+          "resourceSize": 5388
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 157980,
+          "resourceSize": 471999
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690629,
-          "resourceSize": 1366938
+          "transferSize": 703305,
+          "resourceSize": 1411658
         }
       },
       "themeResources": {
@@ -154,16 +154,16 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5227,
-          "resourceSize": 16812
+          "transferSize": 5361,
+          "resourceSize": 17109
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 151437,
-          "resourceSize": 439825
+          "transferSize": 164051,
+          "resourceSize": 484395
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4977,
+          "transferSize": 4971,
           "resourceSize": 5685
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 479024,
-          "resourceSize": 1172392
+          "transferSize": 491766,
+          "resourceSize": 1217259
         }
       },
       "themeResources": {
@@ -225,16 +225,16 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2336,
-          "resourceSize": 4622
+          "transferSize": 2398,
+          "resourceSize": 4772
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 157980,
+          "resourceSize": 471999
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 774,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690456,
-          "resourceSize": 1366322
+          "transferSize": 703124,
+          "resourceSize": 1411042
         }
       },
       "themeResources": {
@@ -296,16 +296,16 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2502,
-          "resourceSize": 5048
+          "transferSize": 2563,
+          "resourceSize": 5198
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 157980,
+          "resourceSize": 471999
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 773,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690621,
-          "resourceSize": 1366748
+          "transferSize": 703293,
+          "resourceSize": 1411468
         }
       },
       "themeResources": {
@@ -367,16 +367,16 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2349,
-          "resourceSize": 4604
+          "transferSize": 2415,
+          "resourceSize": 4754
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 157980,
+          "resourceSize": 471999
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 772,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690467,
-          "resourceSize": 1366304
+          "transferSize": 703146,
+          "resourceSize": 1411024
         }
       },
       "themeResources": {
@@ -438,16 +438,16 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2560,
-          "resourceSize": 5158
+          "transferSize": 2624,
+          "resourceSize": 5308
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 157980,
+          "resourceSize": 471999
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690677,
-          "resourceSize": 1366858
+          "transferSize": 703354,
+          "resourceSize": 1411578
         }
       },
       "themeResources": {
@@ -509,16 +509,16 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3199,
-          "resourceSize": 7477
+          "transferSize": 3255,
+          "resourceSize": 7627
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 145366,
-          "resourceSize": 427429
+          "transferSize": 157980,
+          "resourceSize": 471999
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 766,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691316,
-          "resourceSize": 1593183
+          "transferSize": 703981,
+          "resourceSize": 1637903
         }
       },
       "themeResources": {
@@ -580,16 +580,16 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3204,
-          "resourceSize": 6554
+          "transferSize": 3327,
+          "resourceSize": 6851
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 151437,
-          "resourceSize": 439825
+          "transferSize": 164051,
+          "resourceSize": 484395
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -600,16 +600,16 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1118,
+          "transferSize": 1132,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 784,
-          "resourceSize": 275
+          "transferSize": 785,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 697739,
-          "resourceSize": 1380650
+          "transferSize": 710491,
+          "resourceSize": 1425518
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 784,
-          "resourceSize": 275
+          "transferSize": 785,
+          "resourceSize": 276
         },
         "total": {
-          "transferSize": 691406,
-          "resourceSize": 1372063
+          "transferSize": 691407,
+          "resourceSize": 1372064
         }
       }
     }

--- a/.github/page_size_audit_results/v1.9.0.json
+++ b/.github/page_size_audit_results/v1.9.0.json
@@ -4,15 +4,15 @@
     "javaVersion": "21.0.9",
     "themeVersion": "v1.9.0",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T01:00:22.085Z"
+    "generatedAt": "2025-12-25T13:08:59.482Z"
   },
-  "timestamp": "2025-12-25T01:00:22.085Z",
+  "timestamp": "2025-12-25T13:08:59.482Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2653,
+          "transferSize": 2655,
           "resourceSize": 5593
         },
         "font": {
@@ -32,7 +32,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 768,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -40,7 +40,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690767,
+          "transferSize": 690771,
           "resourceSize": 1367293
         }
       },
@@ -83,7 +83,7 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2520,
+          "transferSize": 2522,
           "resourceSize": 5277
         },
         "font": {
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 770,
           "resourceSize": 195
         },
         "other": {
@@ -111,7 +111,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690631,
+          "transferSize": 690638,
           "resourceSize": 1366977
         }
       },
@@ -154,7 +154,7 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5239,
+          "transferSize": 5241,
           "resourceSize": 16851
         },
         "font": {
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4970,
+          "transferSize": 4968,
           "resourceSize": 5685
         },
         "other": {
@@ -225,7 +225,7 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2343,
+          "transferSize": 2345,
           "resourceSize": 4661
         },
         "font": {
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 765,
+          "transferSize": 774,
           "resourceSize": 195
         },
         "other": {
@@ -253,7 +253,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690454,
+          "transferSize": 690465,
           "resourceSize": 1366361
         }
       },
@@ -296,7 +296,7 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2511,
+          "transferSize": 2512,
           "resourceSize": 5087
         },
         "font": {
@@ -324,7 +324,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690624,
+          "transferSize": 690625,
           "resourceSize": 1366787
         }
       },
@@ -367,7 +367,7 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2355,
+          "transferSize": 2358,
           "resourceSize": 4643
         },
         "font": {
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -395,7 +395,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690471,
+          "transferSize": 690473,
           "resourceSize": 1366343
         }
       },
@@ -438,7 +438,7 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2567,
+          "transferSize": 2569,
           "resourceSize": 5197
         },
         "font": {
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 775,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -466,7 +466,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 690688,
+          "transferSize": 690684,
           "resourceSize": 1366897
         }
       },
@@ -509,7 +509,7 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3206,
+          "transferSize": 3207,
           "resourceSize": 7516
         },
         "font": {
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 769,
+          "transferSize": 773,
           "resourceSize": 195
         },
         "other": {
@@ -537,7 +537,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 691321,
+          "transferSize": 691326,
           "resourceSize": 1593222
         }
       },
@@ -580,7 +580,7 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3212,
+          "transferSize": 3211,
           "resourceSize": 6593
         },
         "font": {
@@ -608,7 +608,7 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 697746,
+          "transferSize": 697745,
           "resourceSize": 1380689
         }
       },


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.7.0
- **End Version:** v1.16.1

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Audit workflow*