### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.8.1.json
+++ b/.github/page_size_audit_results/v1.8.1.json
@@ -1,27 +1,27 @@
 {
   "metadata": {
-    "haloVersion": "2.22.1",
+    "haloVersion": "2.22.3",
     "javaVersion": "21.0.9",
     "themeVersion": "v1.8.1",
     "lhciVersion": "0.15.1",
-    "generatedAt": "2025-12-25T13:08:58.675Z"
+    "generatedAt": "2025-12-27T18:19:16.810Z"
   },
-  "timestamp": "2025-12-25T13:08:58.675Z",
+  "timestamp": "2025-12-27T18:19:16.811Z",
   "results": [
     {
       "url": "/",
       "resources": {
         "document": {
-          "transferSize": 2709,
-          "resourceSize": 5704
+          "transferSize": 2648,
+          "resourceSize": 5554
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 157980,
-          "resourceSize": 471999
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -40,8 +40,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703437,
-          "resourceSize": 1411974
+          "transferSize": 690762,
+          "resourceSize": 1367254
         }
       },
       "themeResources": {
@@ -83,16 +83,16 @@
       "url": "/archives",
       "resources": {
         "document": {
-          "transferSize": 2575,
-          "resourceSize": 5388
+          "transferSize": 2515,
+          "resourceSize": 5238
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 157980,
-          "resourceSize": 471999
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -103,7 +103,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -111,8 +111,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703305,
-          "resourceSize": 1411658
+          "transferSize": 690629,
+          "resourceSize": 1366938
         }
       },
       "themeResources": {
@@ -154,16 +154,16 @@
       "url": "/archives/hello-halo",
       "resources": {
         "document": {
-          "transferSize": 5361,
-          "resourceSize": 17109
+          "transferSize": 5228,
+          "resourceSize": 16812
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 164051,
-          "resourceSize": 484395
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -174,7 +174,7 @@
           "resourceSize": 0
         },
         "fetch": {
-          "transferSize": 4971,
+          "transferSize": 4941,
           "resourceSize": 5685
         },
         "other": {
@@ -182,8 +182,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 491766,
-          "resourceSize": 1217259
+          "transferSize": 478989,
+          "resourceSize": 1172392
         }
       },
       "themeResources": {
@@ -225,16 +225,16 @@
       "url": "/tags",
       "resources": {
         "document": {
-          "transferSize": 2398,
-          "resourceSize": 4772
+          "transferSize": 2337,
+          "resourceSize": 4622
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 157980,
-          "resourceSize": 471999
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -245,7 +245,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 769,
           "resourceSize": 195
         },
         "other": {
@@ -253,8 +253,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703124,
-          "resourceSize": 1411042
+          "transferSize": 690452,
+          "resourceSize": 1366322
         }
       },
       "themeResources": {
@@ -296,16 +296,16 @@
       "url": "/tags/halo",
       "resources": {
         "document": {
-          "transferSize": 2563,
-          "resourceSize": 5198
+          "transferSize": 2503,
+          "resourceSize": 5048
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 157980,
-          "resourceSize": 471999
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -316,7 +316,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 772,
           "resourceSize": 195
         },
         "other": {
@@ -324,8 +324,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703293,
-          "resourceSize": 1411468
+          "transferSize": 690621,
+          "resourceSize": 1366748
         }
       },
       "themeResources": {
@@ -367,16 +367,16 @@
       "url": "/categories",
       "resources": {
         "document": {
-          "transferSize": 2415,
-          "resourceSize": 4754
+          "transferSize": 2351,
+          "resourceSize": 4604
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 157980,
-          "resourceSize": 471999
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -387,7 +387,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 771,
+          "transferSize": 765,
           "resourceSize": 195
         },
         "other": {
@@ -395,8 +395,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703146,
-          "resourceSize": 1411024
+          "transferSize": 690462,
+          "resourceSize": 1366304
         }
       },
       "themeResources": {
@@ -438,16 +438,16 @@
       "url": "/categories/default",
       "resources": {
         "document": {
-          "transferSize": 2624,
-          "resourceSize": 5308
+          "transferSize": 2561,
+          "resourceSize": 5158
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 157980,
-          "resourceSize": 471999
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -458,7 +458,7 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 770,
+          "transferSize": 768,
           "resourceSize": 195
         },
         "other": {
@@ -466,8 +466,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703354,
-          "resourceSize": 1411578
+          "transferSize": 690675,
+          "resourceSize": 1366858
         }
       },
       "themeResources": {
@@ -509,16 +509,16 @@
       "url": "/authors/admin",
       "resources": {
         "document": {
-          "transferSize": 3255,
-          "resourceSize": 7627
+          "transferSize": 3202,
+          "resourceSize": 7477
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 157980,
-          "resourceSize": 471999
+          "transferSize": 145366,
+          "resourceSize": 427429
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -529,7 +529,7 @@
           "resourceSize": 448012
         },
         "fetch": {
-          "transferSize": 766,
+          "transferSize": 771,
           "resourceSize": 195
         },
         "other": {
@@ -537,8 +537,8 @@
           "resourceSize": 275
         },
         "total": {
-          "transferSize": 703981,
-          "resourceSize": 1637903
+          "transferSize": 691319,
+          "resourceSize": 1593183
         }
       },
       "themeResources": {
@@ -580,16 +580,16 @@
       "url": "/about",
       "resources": {
         "document": {
-          "transferSize": 3327,
-          "resourceSize": 6851
+          "transferSize": 3206,
+          "resourceSize": 6554
         },
         "font": {
           "transferSize": 0,
           "resourceSize": 0
         },
         "script": {
-          "transferSize": 164051,
-          "resourceSize": 484395
+          "transferSize": 151437,
+          "resourceSize": 439825
         },
         "stylesheet": {
           "transferSize": 317021,
@@ -600,16 +600,16 @@
           "resourceSize": 224006
         },
         "fetch": {
-          "transferSize": 1132,
+          "transferSize": 1117,
           "resourceSize": 195
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 710491,
-          "resourceSize": 1425518
+          "transferSize": 697740,
+          "resourceSize": 1380650
         }
       },
       "themeResources": {
@@ -638,12 +638,12 @@
           "resourceSize": 0
         },
         "other": {
-          "transferSize": 785,
-          "resourceSize": 276
+          "transferSize": 784,
+          "resourceSize": 275
         },
         "total": {
-          "transferSize": 691407,
-          "resourceSize": 1372064
+          "transferSize": 691406,
+          "resourceSize": 1372063
         }
       }
     }


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.8.1
- **End Version:** v1.8.1

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Audit workflow*