### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.50.2.json
+++ b/.github/page_size_audit_results/v1.50.2.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.22.4",
+    "javaVersion": "21.0.9",
+    "themeVersion": "v1.50.2",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2026-01-01T05:57:04.930Z"
+  },
+  "timestamp": "2026-01-01T05:57:04.931Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 2277,
+          "resourceSize": 6267
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 32413,
+          "resourceSize": 105936
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74824,
+          "resourceSize": 166147
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 32413,
+          "resourceSize": 105936
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72547,
+          "resourceSize": 159880
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 2339,
+          "resourceSize": 6666
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 4363,
+          "resourceSize": 4632
+        },
+        "stylesheet": {
+          "transferSize": 33156,
+          "resourceSize": 106350
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 77397,
+          "resourceSize": 168384
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 4363,
+          "resourceSize": 4632
+        },
+        "stylesheet": {
+          "transferSize": 33156,
+          "resourceSize": 106350
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 75058,
+          "resourceSize": 161718
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 4963,
+          "resourceSize": 23855
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 7999,
+          "resourceSize": 11735
+        },
+        "stylesheet": {
+          "transferSize": 33872,
+          "resourceSize": 111886
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 84726,
+          "resourceSize": 184508
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 5988,
+          "resourceSize": 9897
+        },
+        "stylesheet": {
+          "transferSize": 33872,
+          "resourceSize": 111886
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 77399,
+          "resourceSize": 158815
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 2110,
+          "resourceSize": 5625
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 31562,
+          "resourceSize": 105250
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73806,
+          "resourceSize": 164819
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 31562,
+          "resourceSize": 105250
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71696,
+          "resourceSize": 159194
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 2310,
+          "resourceSize": 6520
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 32893,
+          "resourceSize": 106088
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 75337,
+          "resourceSize": 166552
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 32893,
+          "resourceSize": 106088
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73027,
+          "resourceSize": 160032
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 2099,
+          "resourceSize": 5455
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 31283,
+          "resourceSize": 105136
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73516,
+          "resourceSize": 164535
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 31283,
+          "resourceSize": 105136
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71417,
+          "resourceSize": 159080
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 2384,
+          "resourceSize": 6517
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 32656,
+          "resourceSize": 106015
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 75174,
+          "resourceSize": 166476
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 32656,
+          "resourceSize": 106015
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72790,
+          "resourceSize": 159959
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 2627,
+          "resourceSize": 7977
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 34294,
+          "resourceSize": 108975
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 77055,
+          "resourceSize": 170896
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 34294,
+          "resourceSize": 108975
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74428,
+          "resourceSize": 162919
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 2477,
+          "resourceSize": 6391
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 4606,
+          "resourceSize": 5046
+        },
+        "stylesheet": {
+          "transferSize": 32285,
+          "resourceSize": 107461
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 77260,
+          "resourceSize": 169634
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 23666,
+          "resourceSize": 23328
+        },
+        "script": {
+          "transferSize": 2595,
+          "resourceSize": 3208
+        },
+        "stylesheet": {
+          "transferSize": 32285,
+          "resourceSize": 107461
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72419,
+          "resourceSize": 161405
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.50.2
- **End Version:** v1.50.2

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Audit workflow*