### PR TITLE
chore: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.58.0.json
+++ b/.github/page_size_audit_results/v1.58.0.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.22.10",
+    "javaVersion": "21.0.10",
+    "themeVersion": "v1.58.0",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2026-03-13T13:47:16.199Z"
+  },
+  "timestamp": "2026-03-13T13:47:16.200Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 3120,
+          "resourceSize": 7834
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 32308,
+          "resourceSize": 113693
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 84914,
+          "resourceSize": 186099
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 32308,
+          "resourceSize": 113693
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 81794,
+          "resourceSize": 178265
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 3430,
+          "resourceSize": 8599
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3274,
+          "resourceSize": 5660
+        },
+        "stylesheet": {
+          "transferSize": 32928,
+          "resourceSize": 114107
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 86863,
+          "resourceSize": 188702
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3274,
+          "resourceSize": 5660
+        },
+        "stylesheet": {
+          "transferSize": 32928,
+          "resourceSize": 114107
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 83433,
+          "resourceSize": 180103
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 6208,
+          "resourceSize": 27055
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 6932,
+          "resourceSize": 14127
+        },
+        "stylesheet": {
+          "transferSize": 33756,
+          "resourceSize": 122298
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 98812,
+          "resourceSize": 214276
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 4921,
+          "resourceSize": 12289
+        },
+        "stylesheet": {
+          "transferSize": 33756,
+          "resourceSize": 122298
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 90240,
+          "resourceSize": 185383
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 2901,
+          "resourceSize": 7108
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 31840,
+          "resourceSize": 112912
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 84227,
+          "resourceSize": 184592
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 31840,
+          "resourceSize": 112912
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 81326,
+          "resourceSize": 177484
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 3285,
+          "resourceSize": 8286
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 32865,
+          "resourceSize": 113845
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 85636,
+          "resourceSize": 186703
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 32865,
+          "resourceSize": 113845
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 82351,
+          "resourceSize": 178417
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 2831,
+          "resourceSize": 6860
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 31537,
+          "resourceSize": 112798
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 83854,
+          "resourceSize": 184230
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 31537,
+          "resourceSize": 112798
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 81023,
+          "resourceSize": 177370
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 3310,
+          "resourceSize": 8208
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 32589,
+          "resourceSize": 113772
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 85385,
+          "resourceSize": 186552
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 32589,
+          "resourceSize": 113772
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 82075,
+          "resourceSize": 178344
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3617,
+          "resourceSize": 9747
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 33579,
+          "resourceSize": 117026
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 86682,
+          "resourceSize": 191345
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 33579,
+          "resourceSize": 117026
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 83065,
+          "resourceSize": 181598
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3260,
+          "resourceSize": 7862
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 4266,
+          "resourceSize": 6074
+        },
+        "stylesheet": {
+          "transferSize": 32351,
+          "resourceSize": 115349
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 91793,
+          "resourceSize": 193785
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 2255,
+          "resourceSize": 4236
+        },
+        "stylesheet": {
+          "transferSize": 32351,
+          "resourceSize": 115349
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 86169,
+          "resourceSize": 184085
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.58.0
- **End Version:** v1.58.0

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Audit workflow*