### PR TITLE
docs: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.58.1.json
+++ b/.github/page_size_audit_results/v1.58.1.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.22.10",
+    "javaVersion": "21.0.10",
+    "themeVersion": "v1.58.1",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2026-03-15T15:00:56.333Z"
+  },
+  "timestamp": "2026-03-15T15:00:56.333Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 3336,
+          "resourceSize": 8380
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18497,
+          "resourceSize": 93251
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72049,
+          "resourceSize": 166588
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18497,
+          "resourceSize": 93251
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 68713,
+          "resourceSize": 158208
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 3622,
+          "resourceSize": 9328
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3989,
+          "resourceSize": 6045
+        },
+        "stylesheet": {
+          "transferSize": 19117,
+          "resourceSize": 93665
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73959,
+          "resourceSize": 169374
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3989,
+          "resourceSize": 6045
+        },
+        "stylesheet": {
+          "transferSize": 19117,
+          "resourceSize": 93665
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70337,
+          "resourceSize": 160046
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 6394,
+          "resourceSize": 27605
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 7675,
+          "resourceSize": 14537
+        },
+        "stylesheet": {
+          "transferSize": 19945,
+          "resourceSize": 101856
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 85930,
+          "resourceSize": 194794
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 5664,
+          "resourceSize": 12699
+        },
+        "stylesheet": {
+          "transferSize": 19945,
+          "resourceSize": 101856
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 77172,
+          "resourceSize": 165351
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 3098,
+          "resourceSize": 7654
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18029,
+          "resourceSize": 92470
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71343,
+          "resourceSize": 165081
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18029,
+          "resourceSize": 92470
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 68245,
+          "resourceSize": 157427
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 3492,
+          "resourceSize": 8832
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 19054,
+          "resourceSize": 93403
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72762,
+          "resourceSize": 167192
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 19054,
+          "resourceSize": 93403
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 69270,
+          "resourceSize": 158360
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 3030,
+          "resourceSize": 7406
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 17726,
+          "resourceSize": 92356
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70972,
+          "resourceSize": 164719
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 17726,
+          "resourceSize": 92356
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 67942,
+          "resourceSize": 157313
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 3511,
+          "resourceSize": 8754
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18778,
+          "resourceSize": 93330
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72505,
+          "resourceSize": 167041
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18778,
+          "resourceSize": 93330
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 68994,
+          "resourceSize": 158287
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3812,
+          "resourceSize": 10293
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 19768,
+          "resourceSize": 96584
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73796,
+          "resourceSize": 171834
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 19768,
+          "resourceSize": 96584
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 69984,
+          "resourceSize": 161541
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3479,
+          "resourceSize": 8408
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 4996,
+          "resourceSize": 6459
+        },
+        "stylesheet": {
+          "transferSize": 18540,
+          "resourceSize": 94907
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 78931,
+          "resourceSize": 174274
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18540,
+          "resourceSize": 94907
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73088,
+          "resourceSize": 164028
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.58.1
- **End Version:** v1.58.1

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Audit workflow*