### PR TITLE
docs: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.58.2.json
+++ b/.github/page_size_audit_results/v1.58.2.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.23.1",
+    "javaVersion": "21.0.10",
+    "themeVersion": "v1.58.2",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2026-03-17T16:26:17.401Z"
+  },
+  "timestamp": "2026-03-17T16:26:17.401Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 3268,
+          "resourceSize": 8479
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18497,
+          "resourceSize": 93251
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71981,
+          "resourceSize": 166687
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18497,
+          "resourceSize": 93251
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 68713,
+          "resourceSize": 158208
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 3548,
+          "resourceSize": 9427
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3989,
+          "resourceSize": 6045
+        },
+        "stylesheet": {
+          "transferSize": 19117,
+          "resourceSize": 93665
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73885,
+          "resourceSize": 169473
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3989,
+          "resourceSize": 6045
+        },
+        "stylesheet": {
+          "transferSize": 19117,
+          "resourceSize": 93665
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70337,
+          "resourceSize": 160046
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 6296,
+          "resourceSize": 27619
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 7675,
+          "resourceSize": 14537
+        },
+        "stylesheet": {
+          "transferSize": 19945,
+          "resourceSize": 101856
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 85832,
+          "resourceSize": 194808
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 5664,
+          "resourceSize": 12699
+        },
+        "stylesheet": {
+          "transferSize": 19945,
+          "resourceSize": 101856
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 77172,
+          "resourceSize": 165351
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 3028,
+          "resourceSize": 7753
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18029,
+          "resourceSize": 92470
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71273,
+          "resourceSize": 165180
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18029,
+          "resourceSize": 92470
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 68245,
+          "resourceSize": 157427
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 3415,
+          "resourceSize": 8928
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 19054,
+          "resourceSize": 93403
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72685,
+          "resourceSize": 167288
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 19054,
+          "resourceSize": 93403
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 69270,
+          "resourceSize": 158360
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 2959,
+          "resourceSize": 7505
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 17726,
+          "resourceSize": 92356
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70901,
+          "resourceSize": 164818
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 17726,
+          "resourceSize": 92356
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 67942,
+          "resourceSize": 157313
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 3443,
+          "resourceSize": 8853
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18778,
+          "resourceSize": 93330
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72437,
+          "resourceSize": 167140
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18778,
+          "resourceSize": 93330
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 68994,
+          "resourceSize": 158287
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3748,
+          "resourceSize": 10392
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 19768,
+          "resourceSize": 96584
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73732,
+          "resourceSize": 171933
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 19768,
+          "resourceSize": 96584
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 69984,
+          "resourceSize": 161541
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3405,
+          "resourceSize": 8507
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 4996,
+          "resourceSize": 6459
+        },
+        "stylesheet": {
+          "transferSize": 18540,
+          "resourceSize": 94907
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 78857,
+          "resourceSize": 174373
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 2985,
+          "resourceSize": 4621
+        },
+        "stylesheet": {
+          "transferSize": 18540,
+          "resourceSize": 94907
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73088,
+          "resourceSize": 164028
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.58.2
- **End Version:** v1.58.2

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Audit workflow*