### PR TITLE
docs: Update Page Size Audit Results

### DIFF
--- a/.github/page_size_audit_results/v1.59.0.json
+++ b/.github/page_size_audit_results/v1.59.0.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.23.1",
+    "javaVersion": "21.0.10",
+    "themeVersion": "v1.59.0",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2026-03-20T20:57:03.658Z"
+  },
+  "timestamp": "2026-03-20T20:57:03.658Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 3300,
+          "resourceSize": 8627
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20623,
+          "resourceSize": 99555
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74173,
+          "resourceSize": 173179
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20623,
+          "resourceSize": 99555
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70873,
+          "resourceSize": 164552
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 3584,
+          "resourceSize": 9580
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 4045,
+          "resourceSize": 6109
+        },
+        "stylesheet": {
+          "transferSize": 21243,
+          "resourceSize": 99969
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 76103,
+          "resourceSize": 175994
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 4045,
+          "resourceSize": 6109
+        },
+        "stylesheet": {
+          "transferSize": 21243,
+          "resourceSize": 99969
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72519,
+          "resourceSize": 166414
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 6992,
+          "resourceSize": 47075
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 8256,
+          "resourceSize": 15224
+        },
+        "stylesheet": {
+          "transferSize": 22071,
+          "resourceSize": 108160
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 89235,
+          "resourceSize": 221255
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 6245,
+          "resourceSize": 13386
+        },
+        "stylesheet": {
+          "transferSize": 22071,
+          "resourceSize": 108160
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 79879,
+          "resourceSize": 172342
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 3063,
+          "resourceSize": 7900
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20155,
+          "resourceSize": 98774
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73468,
+          "resourceSize": 171671
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20155,
+          "resourceSize": 98774
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70405,
+          "resourceSize": 163771
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 3447,
+          "resourceSize": 9078
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 21180,
+          "resourceSize": 99707
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74877,
+          "resourceSize": 173782
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 21180,
+          "resourceSize": 99707
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71430,
+          "resourceSize": 164704
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 2995,
+          "resourceSize": 7651
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 19852,
+          "resourceSize": 98660
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73097,
+          "resourceSize": 171308
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 19852,
+          "resourceSize": 98660
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70102,
+          "resourceSize": 163657
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 3475,
+          "resourceSize": 9002
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20904,
+          "resourceSize": 99634
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74629,
+          "resourceSize": 173633
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20904,
+          "resourceSize": 99634
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71154,
+          "resourceSize": 164631
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3779,
+          "resourceSize": 10542
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 21894,
+          "resourceSize": 102888
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 75923,
+          "resourceSize": 178427
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 21894,
+          "resourceSize": 102888
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72144,
+          "resourceSize": 167885
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3444,
+          "resourceSize": 8644
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 5030,
+          "resourceSize": 6499
+        },
+        "stylesheet": {
+          "transferSize": 20666,
+          "resourceSize": 101211
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 81056,
+          "resourceSize": 180854
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 3019,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20666,
+          "resourceSize": 101211
+        },
+        "image": {
+          "transferSize": 13796,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 75248,
+          "resourceSize": 170372
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Size Audit Results Update

This PR adds/updates page size audit results for versions:
- **Start Version:** v1.59.0
- **End Version:** v1.59.0

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used for generating performance trend charts.

---
*Auto-generated by Page Audit workflow*