### PR TITLE
docs: Update Page Resource Size Diff Results

### DIFF
--- a/.github/page_size_audit_results/v1.63.3.json
+++ b/.github/page_size_audit_results/v1.63.3.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.23.1",
+    "javaVersion": "21.0.10",
+    "themeVersion": "v1.63.3",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2026-04-11T05:36:06.220Z"
+  },
+  "timestamp": "2026-04-11T05:36:06.221Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 3507,
+          "resourceSize": 9452
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20552,
+          "resourceSize": 96254
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74390,
+          "resourceSize": 170703
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20552,
+          "resourceSize": 96254
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70883,
+          "resourceSize": 161251
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 3796,
+          "resourceSize": 10409
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 4047,
+          "resourceSize": 6109
+        },
+        "stylesheet": {
+          "transferSize": 21172,
+          "resourceSize": 96668
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 76323,
+          "resourceSize": 173522
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 4047,
+          "resourceSize": 6109
+        },
+        "stylesheet": {
+          "transferSize": 21172,
+          "resourceSize": 96668
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72527,
+          "resourceSize": 163113
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 7322,
+          "resourceSize": 51235
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 8784,
+          "resourceSize": 15964
+        },
+        "stylesheet": {
+          "transferSize": 22150,
+          "resourceSize": 106562
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 90249,
+          "resourceSize": 224557
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 6773,
+          "resourceSize": 14126
+        },
+        "stylesheet": {
+          "transferSize": 22150,
+          "resourceSize": 106562
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 80563,
+          "resourceSize": 171484
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 3275,
+          "resourceSize": 8703
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20041,
+          "resourceSize": 95319
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73647,
+          "resourceSize": 169019
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20041,
+          "resourceSize": 95319
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70372,
+          "resourceSize": 160316
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 3669,
+          "resourceSize": 9907
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 21109,
+          "resourceSize": 96406
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 75109,
+          "resourceSize": 171310
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 21109,
+          "resourceSize": 96406
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71440,
+          "resourceSize": 161403
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 3209,
+          "resourceSize": 8454
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 19738,
+          "resourceSize": 95205
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73278,
+          "resourceSize": 168656
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 19738,
+          "resourceSize": 95205
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70069,
+          "resourceSize": 160202
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 3696,
+          "resourceSize": 9831
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20833,
+          "resourceSize": 96333
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74860,
+          "resourceSize": 171161
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20833,
+          "resourceSize": 96333
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71164,
+          "resourceSize": 161330
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3971,
+          "resourceSize": 11383
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 22016,
+          "resourceSize": 101444
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 76318,
+          "resourceSize": 177824
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3023,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 22016,
+          "resourceSize": 101444
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72347,
+          "resourceSize": 166441
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3796,
+          "resourceSize": 9833
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 5915,
+          "resourceSize": 7367
+        },
+        "stylesheet": {
+          "transferSize": 20745,
+          "resourceSize": 99613
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 82449,
+          "resourceSize": 181313
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 3904,
+          "resourceSize": 5529
+        },
+        "stylesheet": {
+          "transferSize": 20745,
+          "resourceSize": 99613
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 76289,
+          "resourceSize": 169642
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Resource Size Diff Results Update

This PR adds or updates page resource size diff results for versions:
- **Start Version:** v1.63.3
- **End Version:** v1.63.3

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used to generate page resource size trend charts.

---
*Auto-generated by the Generate Page Size Audit JSON workflow*