### PR TITLE
docs: Update Page Resource Size Diff Results

### DIFF
--- a/.github/page_size_audit_results/v1.63.4.json
+++ b/.github/page_size_audit_results/v1.63.4.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.23.1",
+    "javaVersion": "21.0.10",
+    "themeVersion": "v1.63.4",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2026-04-12T16:38:31.016Z"
+  },
+  "timestamp": "2026-04-12T16:38:31.017Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 3501,
+          "resourceSize": 9452
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20639,
+          "resourceSize": 96254
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74465,
+          "resourceSize": 170703
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20639,
+          "resourceSize": 96254
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70964,
+          "resourceSize": 161251
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 3795,
+          "resourceSize": 10409
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 4039,
+          "resourceSize": 6109
+        },
+        "stylesheet": {
+          "transferSize": 21259,
+          "resourceSize": 96668
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 76401,
+          "resourceSize": 173522
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 4039,
+          "resourceSize": 6109
+        },
+        "stylesheet": {
+          "transferSize": 21259,
+          "resourceSize": 96668
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72606,
+          "resourceSize": 163113
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 7320,
+          "resourceSize": 51235
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 8779,
+          "resourceSize": 15964
+        },
+        "stylesheet": {
+          "transferSize": 22237,
+          "resourceSize": 106562
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 90329,
+          "resourceSize": 224557
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 6768,
+          "resourceSize": 14126
+        },
+        "stylesheet": {
+          "transferSize": 22237,
+          "resourceSize": 106562
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 80645,
+          "resourceSize": 171484
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 3271,
+          "resourceSize": 8703
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20128,
+          "resourceSize": 95319
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73724,
+          "resourceSize": 169019
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20128,
+          "resourceSize": 95319
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70453,
+          "resourceSize": 160316
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 3665,
+          "resourceSize": 9907
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 21196,
+          "resourceSize": 96406
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 75186,
+          "resourceSize": 171310
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 21196,
+          "resourceSize": 96406
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71521,
+          "resourceSize": 161403
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 3203,
+          "resourceSize": 8454
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 19825,
+          "resourceSize": 95205
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73353,
+          "resourceSize": 168656
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 19825,
+          "resourceSize": 95205
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70150,
+          "resourceSize": 160202
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 3691,
+          "resourceSize": 9831
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20920,
+          "resourceSize": 96333
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74936,
+          "resourceSize": 171161
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20920,
+          "resourceSize": 96333
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71245,
+          "resourceSize": 161330
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3966,
+          "resourceSize": 11383
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 22103,
+          "resourceSize": 101444
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 76394,
+          "resourceSize": 177824
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3017,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 22103,
+          "resourceSize": 101444
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72428,
+          "resourceSize": 166441
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3788,
+          "resourceSize": 9833
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 5908,
+          "resourceSize": 7367
+        },
+        "stylesheet": {
+          "transferSize": 20832,
+          "resourceSize": 99613
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 82521,
+          "resourceSize": 181313
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 3897,
+          "resourceSize": 5529
+        },
+        "stylesheet": {
+          "transferSize": 20832,
+          "resourceSize": 99613
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 76369,
+          "resourceSize": 169642
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Resource Size Diff Results Update

This PR adds or updates page resource size diff results for versions:
- **Start Version:** v1.63.4
- **End Version:** v1.63.4

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used to generate page resource size trend charts.

---
*Auto-generated by the Generate Page Size Audit JSON workflow*