### PR TITLE
docs: Update Page Resource Size Diff Results

### DIFF
--- a/.github/page_size_audit_results/v1.64.0.json
+++ b/.github/page_size_audit_results/v1.64.0.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "haloVersion": "2.23.1",
+    "javaVersion": "21.0.10",
+    "themeVersion": "v1.64.0",
+    "lhciVersion": "0.15.1",
+    "generatedAt": "2026-04-20T19:41:21.339Z"
+  },
+  "timestamp": "2026-04-20T19:41:21.339Z",
+  "results": [
+    {
+      "url": "/",
+      "resources": {
+        "document": {
+          "transferSize": 3501,
+          "resourceSize": 9452
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20427,
+          "resourceSize": 96254
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74258,
+          "resourceSize": 170703
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20427,
+          "resourceSize": 96254
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70757,
+          "resourceSize": 161251
+        }
+      }
+    },
+    {
+      "url": "/archives",
+      "resources": {
+        "document": {
+          "transferSize": 3794,
+          "resourceSize": 10409
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 4029,
+          "resourceSize": 6109
+        },
+        "stylesheet": {
+          "transferSize": 21047,
+          "resourceSize": 96668
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 76178,
+          "resourceSize": 173522
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 4029,
+          "resourceSize": 6109
+        },
+        "stylesheet": {
+          "transferSize": 21047,
+          "resourceSize": 96668
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72384,
+          "resourceSize": 163113
+        }
+      }
+    },
+    {
+      "url": "/archives/hello-halo",
+      "resources": {
+        "document": {
+          "transferSize": 7316,
+          "resourceSize": 51235
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 8765,
+          "resourceSize": 15964
+        },
+        "stylesheet": {
+          "transferSize": 22025,
+          "resourceSize": 106562
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 90099,
+          "resourceSize": 224557
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 6754,
+          "resourceSize": 14126
+        },
+        "stylesheet": {
+          "transferSize": 22025,
+          "resourceSize": 106562
+        },
+        "image": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 80419,
+          "resourceSize": 171484
+        }
+      }
+    },
+    {
+      "url": "/tags",
+      "resources": {
+        "document": {
+          "transferSize": 3273,
+          "resourceSize": 8703
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 19916,
+          "resourceSize": 95319
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73519,
+          "resourceSize": 169019
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 19916,
+          "resourceSize": 95319
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 70246,
+          "resourceSize": 160316
+        }
+      }
+    },
+    {
+      "url": "/tags/halo",
+      "resources": {
+        "document": {
+          "transferSize": 3662,
+          "resourceSize": 9907
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20984,
+          "resourceSize": 96406
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74976,
+          "resourceSize": 171310
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20984,
+          "resourceSize": 96406
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71314,
+          "resourceSize": 161403
+        }
+      }
+    },
+    {
+      "url": "/categories",
+      "resources": {
+        "document": {
+          "transferSize": 3205,
+          "resourceSize": 8454
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 19613,
+          "resourceSize": 95205
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 73148,
+          "resourceSize": 168656
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 19613,
+          "resourceSize": 95205
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 69943,
+          "resourceSize": 160202
+        }
+      }
+    },
+    {
+      "url": "/categories/default",
+      "resources": {
+        "document": {
+          "transferSize": 3690,
+          "resourceSize": 9831
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20708,
+          "resourceSize": 96333
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 74728,
+          "resourceSize": 171161
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 20708,
+          "resourceSize": 96333
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 71038,
+          "resourceSize": 161330
+        }
+      }
+    },
+    {
+      "url": "/authors/admin",
+      "resources": {
+        "document": {
+          "transferSize": 3967,
+          "resourceSize": 11383
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 21891,
+          "resourceSize": 101444
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 76188,
+          "resourceSize": 177824
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 33435,
+          "resourceSize": 32928
+        },
+        "script": {
+          "transferSize": 3022,
+          "resourceSize": 4661
+        },
+        "stylesheet": {
+          "transferSize": 21891,
+          "resourceSize": 101444
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 72221,
+          "resourceSize": 166441
+        }
+      }
+    },
+    {
+      "url": "/about",
+      "resources": {
+        "document": {
+          "transferSize": 3791,
+          "resourceSize": 9833
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 5901,
+          "resourceSize": 7367
+        },
+        "stylesheet": {
+          "transferSize": 20620,
+          "resourceSize": 99613
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 353,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 82305,
+          "resourceSize": 181313
+        }
+      },
+      "themeResources": {
+        "document": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "font": {
+          "transferSize": 37767,
+          "resourceSize": 37092
+        },
+        "script": {
+          "transferSize": 3890,
+          "resourceSize": 5529
+        },
+        "stylesheet": {
+          "transferSize": 20620,
+          "resourceSize": 99613
+        },
+        "image": {
+          "transferSize": 13873,
+          "resourceSize": 13704
+        },
+        "fetch": {
+          "transferSize": 0,
+          "resourceSize": 0
+        },
+        "other": {
+          "transferSize": 0,
+          "resourceSize": 13704
+        },
+        "total": {
+          "transferSize": 76150,
+          "resourceSize": 169642
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Page Resource Size Diff Results Update

This PR adds or updates page resource size diff results for versions:
- **Start Version:** v1.64.0
- **End Version:** v1.64.0

The following JSON data files have been updated in `.github/page_size_audit_results/`:
- Multiple version result files

These files will be used to generate page resource size trend charts.

---
*Auto-generated by the Generate Page Size Audit JSON workflow*