### PR TITLE
chore: update local action references

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -27,11 +27,11 @@ runs:
 
     - name: Setup pnpm (normal, when packageManager declares pnpm)
       if: ${{ steps.detect-pm.outputs.pm != '' && contains(steps.detect-pm.outputs.pm, 'pnpm') }}
-      uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # https://github.com/pnpm/action-setup/releases/tag/v6.0.3
+      uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # https://github.com/pnpm/action-setup/releases/tag/v6.0.5
 
     - name: Setup pnpm (fallback when packageManager missing)
       if: ${{ steps.detect-pm.outputs.pm == '' }}
-      uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # https://github.com/pnpm/action-setup/releases/tag/v6.0.3
+      uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # https://github.com/pnpm/action-setup/releases/tag/v6.0.5
       with:
         version: ${{ inputs.pnpm-version }}
 


### PR DESCRIPTION
This PR updates third-party GitHub Action references used by `.github/actions/**/action.yml`.

Generated automatically by the `update-local-action-uses` workflow because Dependabot does not update `uses:` entries inside local composite actions.