### PR TITLE
chore: Downgrade package.json version to 1.66.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.66.11",
+  "version": "1.66.10",
   "private": true,
   "keywords": [
     "halo",


### PR DESCRIPTION
因为 GitHub Actions 故障，导致发布流程未触发，因此降级