### PR TITLE
chore: update node and pnpm versions

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -8,7 +8,7 @@ inputs:
   pnpm-version:
     description: Fallback pnpm version when packageManager is missing
     required: false
-    default: "11.11.0"
+    default: "11.13.0"
 runs:
   using: composite
   steps:

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
   ],
   "engines": {
     "node": ">=24",
-    "pnpm": "^11.11.0"
+    "pnpm": "^11.13.0"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.13.0"
 }


### PR DESCRIPTION
This PR updates the repository toolchain versions tracked in:
- `package.json`
- `.github/actions/**/action.yml`
- workflows that bootstrap Node.js directly

Resolved by automation:
- Node.js major: `24`
- pnpm version: `11.13.0`