### PR TITLE
chore: update local action references

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -36,7 +36,7 @@ runs:
         version: ${{ inputs.pnpm-version }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # https://github.com/actions/setup-node/releases/tag/v6.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # https://github.com/actions/setup-node/releases/tag/v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: "pnpm"


### PR DESCRIPTION
This PR updates third-party GitHub Action references used by `.github/actions/**/action.yml`.

Generated automatically by the `update-local-action-uses` workflow because Dependabot does not update `uses:` entries inside local composite actions.